### PR TITLE
Add hash fragment support to expandable figures

### DIFF
--- a/docs/implementation-guide/02-figures-and-layout.md
+++ b/docs/implementation-guide/02-figures-and-layout.md
@@ -43,6 +43,22 @@ The `width` and `height` options set the collapsed (inline) size. `onResize` is 
 | `wide` | boolean | Break out of the article column when collapsed (for wider figures) |
 | `maxWidth` | number | Maximum width for wide layout (default 1200) |
 | `aspectRatio` | number | Aspect ratio to maintain in wide layout |
+| `id` | string | Hash fragment identifier (e.g. `'my-figure'` → `#my-figure`). Auto-generated as `fig-1`, `fig-2`, etc. if omitted. |
+
+## Hash fragments for deep-linking
+
+When a figure is expanded, `expandable()` sets the URL hash to `#<id>`. When the page is loaded with that hash, the figure starts expanded automatically. When collapsed, the hash is cleared. This lets users share links that open directly to an expanded figure.
+
+```javascript
+display(expandable(figure, {
+  width: 640,
+  height: 480,
+  id: 'phase-portrait',  // URL becomes …#phase-portrait when expanded
+  onResize(el, w, h) { ... }
+}));
+```
+
+If no `id` is provided, a serial counter assigns `fig-1`, `fig-2`, etc. in DOM order. Prefer explicit IDs for figures you expect readers to share links to, since auto-generated IDs are fragile if figures are reordered.
 
 ## Controls panel
 

--- a/src/lib/expandable.js
+++ b/src/lib/expandable.js
@@ -30,6 +30,7 @@
  * @param {number} [options.maxWidth=1200] - Max width for wide layout
  * @param {number} [options.aspectRatio] - Override aspect ratio for wide layout
  * @param {Array} [options.buttons] - Extra buttons: { icon, title, onClick }
+ * @param {string} [options.id] - Hash fragment identifier (e.g. 'my-figure' → #my-figure). Auto-generated as fig-1, fig-2, etc. if omitted.
  * @returns {HTMLElement} The expandable container element
  */
 const svgIcon = (d, {viewBox = '0 0 16 16', strokeWidth = 1.5} = {}) =>
@@ -55,6 +56,8 @@ export const ICON_ARCBALL = svgIcon(
   '<circle cx="8" cy="8" r="6"/><path d="M4 5.5 Q8 8.5 12 5.5"/><path d="M4 10.5 Q8 7.5 12 10.5"/><path d="M5.5 4 Q8.5 8 5.5 12"/><path d="M10.5 4 Q7.5 8 10.5 12"/>'
 , {strokeWidth: 1.25});
 
+let _expandableCounter = 0;
+
 export function expandable(content, {
   width, height,
   toggleOffset = [8, 8],
@@ -66,9 +69,15 @@ export function expandable(content, {
   wide = false,
   maxWidth = 1200,
   aspectRatio,
-  buttons = []
+  buttons = [],
+  id
 }) {
-  let expanded = state?.expanded ?? false;
+  const hashId = id || `fig-${++_expandableCounter}`;
+  const hashFragment = `#${hashId}`;
+
+  // Check if this expandable should start expanded based on the URL hash
+  const hashExpanded = window.location.hash === hashFragment;
+  let expanded = hashExpanded || state?.expanded || false;
   let currentWidth = 0;
   let currentHeight = 0;
   let controlsPanelExpanded = false;
@@ -377,6 +386,7 @@ export function expandable(content, {
   function expand() {
     expanded = true;
     if (state) state.expanded = true;
+    history.replaceState(null, '', hashFragment);
     container.classList.add('expandable-expanded');
     toggleBtn.innerHTML = ICON_CLOSE;
     toggleBtn.title = 'Collapse';
@@ -431,6 +441,9 @@ export function expandable(content, {
   function collapse() {
     expanded = false;
     if (state) state.expanded = false;
+    if (window.location.hash === hashFragment) {
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
     container.classList.remove('expandable-expanded');
     toggleBtn.innerHTML = ICON_EXPAND;
     toggleBtn.title = 'Expand';
@@ -507,6 +520,9 @@ export function expandable(content, {
       if (overlay.parentNode) overlay.remove();
       restoreControls();
       if (floatingPanel?.parentNode) floatingPanel.remove();
+      if (window.location.hash === hashFragment) {
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+      }
       domObserver.disconnect();
     }
   });
@@ -516,7 +532,7 @@ export function expandable(content, {
     get: () => ({ width: currentWidth, height: currentHeight, expanded })
   });
 
-  if (state?.expanded) requestAnimationFrame(() => expand());
+  if (expanded) requestAnimationFrame(() => expand());
 
   return container;
 }

--- a/src/notebooks/3d-reaction-diffusion/index.html
+++ b/src/notebooks/3d-reaction-diffusion/index.html
@@ -220,6 +220,7 @@
     const canvasContainer = html`<div id="rd-container" style="width: 100%; height: 100%;">${canvas}</div>`;
 
     const container = expandable(canvasContainer, {
+      id: 'reaction-diffusion',
       width: defaultWidth,
       height: defaultHeight,
       onResize: handleResize,

--- a/src/notebooks/3d-reaction-diffusion/index.html
+++ b/src/notebooks/3d-reaction-diffusion/index.html
@@ -220,7 +220,7 @@
     const canvasContainer = html`<div id="rd-container" style="width: 100%; height: 100%;">${canvas}</div>`;
 
     const container = expandable(canvasContainer, {
-      id: 'reaction-diffusion',
+      id: 'reaction-diffusion-sim',
       width: defaultWidth,
       height: defaultHeight,
       onResize: handleResize,

--- a/src/notebooks/adaptive-contouring-in-fragment-shaders/index.html
+++ b/src/notebooks/adaptive-contouring-in-fragment-shaders/index.html
@@ -1021,7 +1021,7 @@
     </figure>`;
 
     display(expandable(shadedFigure, {
-      id: 'contour-shading',
+      id: 'contour-plot',
       width: largeCanvas.width,
       height: largeCanvas.height,
       toggleOffset: [-6, -23],

--- a/src/notebooks/adaptive-contouring-in-fragment-shaders/index.html
+++ b/src/notebooks/adaptive-contouring-in-fragment-shaders/index.html
@@ -1021,6 +1021,7 @@
     </figure>`;
 
     display(expandable(shadedFigure, {
+      id: 'contour-shading',
       width: largeCanvas.width,
       height: largeCanvas.height,
       toggleOffset: [-6, -23],

--- a/src/notebooks/boys-surface/index.html
+++ b/src/notebooks/boys-surface/index.html
@@ -156,6 +156,7 @@ camera.triggerRepaint();
 
 let expandableContainer;
 expandableContainer = expandable(container, {
+  id: 'boys-surface',
   width: 640,
   height: 480,
   controls: controlsContainer,

--- a/src/notebooks/boys-surface/index.html
+++ b/src/notebooks/boys-surface/index.html
@@ -156,7 +156,7 @@ camera.triggerRepaint();
 
 let expandableContainer;
 expandableContainer = expandable(container, {
-  id: 'boys-surface',
+  id: 'surface-viewer',
   width: 640,
   height: 480,
   controls: controlsContainer,

--- a/src/notebooks/chaotic-magnetic-pendulum-webgpu/index.html
+++ b/src/notebooks/chaotic-magnetic-pendulum-webgpu/index.html
@@ -13,6 +13,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'magnetic-pendulum',
       width: Math.min(width, 640),
       height: Math.min(640, width),
       controls: '.magnetic-pendulum-controls',

--- a/src/notebooks/chaotic-magnetic-pendulum-webgpu/index.html
+++ b/src/notebooks/chaotic-magnetic-pendulum-webgpu/index.html
@@ -13,7 +13,7 @@
     </figure>`;
 
     display(expandable(figure, {
-      id: 'magnetic-pendulum',
+      id: 'attractor-basin',
       width: Math.min(width, 640),
       height: Math.min(640, width),
       controls: '.magnetic-pendulum-controls',

--- a/src/notebooks/chaotic-magnetic-pendulum/index.html
+++ b/src/notebooks/chaotic-magnetic-pendulum/index.html
@@ -13,6 +13,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'magnetic-pendulum',
       width: Math.min(width, 640),
       height: Math.min(640, width),
       controls: '.magnetic-pendulum-controls',

--- a/src/notebooks/chaotic-magnetic-pendulum/index.html
+++ b/src/notebooks/chaotic-magnetic-pendulum/index.html
@@ -13,7 +13,7 @@
     </figure>`;
 
     display(expandable(figure, {
-      id: 'magnetic-pendulum',
+      id: 'attractor-basin',
       width: Math.min(width, 640),
       height: Math.min(640, width),
       controls: '.magnetic-pendulum-controls',

--- a/src/notebooks/charmin-nanotubes-and-toiletpaperfullerenes/index.html
+++ b/src/notebooks/charmin-nanotubes-and-toiletpaperfullerenes/index.html
@@ -728,6 +728,7 @@ const figureHeight = Math.round(figureWidth * 576 / 640);
 let expandableContainer: HTMLElement | null = null;
 
 const expandableElement = expandable(figure, {
+  id: 'toiletpaperfullerene',
   width: figureWidth,
   height: figureHeight,
   padding: [0, 0],

--- a/src/notebooks/charmin-nanotubes-and-toiletpaperfullerenes/index.html
+++ b/src/notebooks/charmin-nanotubes-and-toiletpaperfullerenes/index.html
@@ -728,7 +728,7 @@ const figureHeight = Math.round(figureWidth * 576 / 640);
 let expandableContainer: HTMLElement | null = null;
 
 const expandableElement = expandable(figure, {
-  id: 'toiletpaperfullerene',
+  id: 'molecular-editor',
   width: figureWidth,
   height: figureHeight,
   padding: [0, 0],

--- a/src/notebooks/denali/index.html
+++ b/src/notebooks/denali/index.html
@@ -206,7 +206,7 @@
     });
 
     display(expandable(container, {
-      id: 'denali',
+      id: 'terrain-viewer',
       wide: true,
       width: 640,
       height: 600,

--- a/src/notebooks/denali/index.html
+++ b/src/notebooks/denali/index.html
@@ -206,6 +206,7 @@
     });
 
     display(expandable(container, {
+      id: 'denali',
       wide: true,
       width: 640,
       height: 600,

--- a/src/notebooks/double-pendulum-map/index.html
+++ b/src/notebooks/double-pendulum-map/index.html
@@ -43,6 +43,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'pendulum-map',
       width: Math.min(width, 640),
       height: Math.min(width, 640),
       toggleOffset: [-25, -42],

--- a/src/notebooks/double-pendulum-map/index.html
+++ b/src/notebooks/double-pendulum-map/index.html
@@ -43,7 +43,7 @@
     </figure>`;
 
     display(expandable(figure, {
-      id: 'pendulum-map',
+      id: 'phase-space-plot',
       width: Math.min(width, 640),
       height: Math.min(width, 640),
       toggleOffset: [-25, -42],

--- a/src/notebooks/hess-smith-panel-solver/index.html
+++ b/src/notebooks/hess-smith-panel-solver/index.html
@@ -13,6 +13,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'panel-solver',
       width: Math.min(width, 800),
       height: Math.min(500, width * 0.625),
       controls: '.panel-solver-controls',

--- a/src/notebooks/hess-smith-panel-solver/index.html
+++ b/src/notebooks/hess-smith-panel-solver/index.html
@@ -13,7 +13,7 @@
     </figure>`;
 
     display(expandable(figure, {
-      id: 'panel-solver',
+      id: 'flow-viewer',
       width: Math.min(width, 800),
       height: Math.min(500, width * 0.625),
       controls: '.panel-solver-controls',

--- a/src/notebooks/kerr-geodesics/index.html
+++ b/src/notebooks/kerr-geodesics/index.html
@@ -343,6 +343,7 @@ container.appendChild(canvas);
 
 let expandableContainer: ReturnType<typeof expandable>;
 expandableContainer = expandable(container, {
+  id: 'geodesics',
   width: 640,
   height: 480,
   wide: true,
@@ -629,6 +630,7 @@ rtContainer.appendChild(rtCanvas);
 
 let rtExpandable: ReturnType<typeof expandable>;
 rtExpandable = expandable(rtContainer, {
+  id: 'ray-tracer',
   width: 640,
   height: 480,
   wide: true,

--- a/src/notebooks/kerr-geodesics/index.html
+++ b/src/notebooks/kerr-geodesics/index.html
@@ -343,7 +343,7 @@ container.appendChild(canvas);
 
 let expandableContainer: ReturnType<typeof expandable>;
 expandableContainer = expandable(container, {
-  id: 'geodesics',
+  id: 'geodesic-viewer',
   width: 640,
   height: 480,
   wide: true,

--- a/src/notebooks/lawsons-klein-bottle/index.html
+++ b/src/notebooks/lawsons-klein-bottle/index.html
@@ -112,7 +112,7 @@ const figureHeight = Math.round(Math.max(500, figureWidth * 1.0));
 
 let expandableContainer;
 expandableContainer = expandable(figure, {
-  id: 'klein-bottle',
+  id: 'surface-viewer',
   wide: true,
   width: figureWidth,
   height: figureHeight,

--- a/src/notebooks/lawsons-klein-bottle/index.html
+++ b/src/notebooks/lawsons-klein-bottle/index.html
@@ -112,6 +112,7 @@ const figureHeight = Math.round(Math.max(500, figureWidth * 1.0));
 
 let expandableContainer;
 expandableContainer = expandable(figure, {
+  id: 'klein-bottle',
   wide: true,
   width: figureWidth,
   height: figureHeight,

--- a/src/notebooks/multiscale-turing-patterns/index.html
+++ b/src/notebooks/multiscale-turing-patterns/index.html
@@ -169,7 +169,7 @@
     const figure = html`<figure style="margin: 0;">${stack.element}</figure>`;
 
     display(expandable(figure, {
-      id: 'turing-patterns',
+      id: 'pattern-sim',
       width: Math.min(width, 640),
       height: Math.min(width, 640),
       toggleOffset: [-15, -16],

--- a/src/notebooks/multiscale-turing-patterns/index.html
+++ b/src/notebooks/multiscale-turing-patterns/index.html
@@ -169,6 +169,7 @@
     const figure = html`<figure style="margin: 0;">${stack.element}</figure>`;
 
     display(expandable(figure, {
+      id: 'turing-patterns',
       width: Math.min(width, 640),
       height: Math.min(width, 640),
       toggleOffset: [-15, -16],

--- a/src/notebooks/night-and-day/index.html
+++ b/src/notebooks/night-and-day/index.html
@@ -68,7 +68,7 @@ The astronomical calculations are based on Vladimir Agafonkin's [SunCalc](https:
     const expandableState = { expanded: false, resizeMap: null };
 
     const container = expandable(wrapper, {
-      id: 'night-and-day',
+      id: 'terminator-map',
       width: Math.min(width, 900),
       height: 600,
       controls: '.controls-panel',

--- a/src/notebooks/night-and-day/index.html
+++ b/src/notebooks/night-and-day/index.html
@@ -68,6 +68,7 @@ The astronomical calculations are based on Vladimir Agafonkin's [SunCalc](https:
     const expandableState = { expanded: false, resizeMap: null };
 
     const container = expandable(wrapper, {
+      id: 'night-and-day',
       width: Math.min(width, 900),
       height: 600,
       controls: '.controls-panel',

--- a/src/notebooks/particle-mesh-gravity/index.html
+++ b/src/notebooks/particle-mesh-gravity/index.html
@@ -369,6 +369,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'gravity-sim',
       width: initialWidth,
       height: initialHeight,
       wide: true,

--- a/src/notebooks/periodic-planar-three-body-orbits/index.html
+++ b/src/notebooks/periodic-planar-three-body-orbits/index.html
@@ -335,6 +335,7 @@
   </script>
   <script id="107" type="text/x-typescript">
     display(expandable(stack.element, {
+      id: 'orbit-viewer',
       width: Math.min(width, 640),
       height: Math.min(480, width * 0.7),
       controls: ['.orbit-selector', '.orbit-metadata', '.plot-controls'],
@@ -890,6 +891,7 @@
     projFigure.appendChild(projCaption);
 
     display(expandable(projFigure, {
+      id: 'stereographic-projection',
       width: Math.min(width, 640),
       height: Math.min(400, Math.floor(width * 0.625)),
       onResize(el, w, h) {

--- a/src/notebooks/plot-with-zoom/index.html
+++ b/src/notebooks/plot-with-zoom/index.html
@@ -48,6 +48,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'zoomable-plot',
       width: Math.min(width, 640),
       height: Math.min(480, width),
       toggleOffset: [-15, -33],

--- a/src/notebooks/point-cloud-point-opacity/index.html
+++ b/src/notebooks/point-cloud-point-opacity/index.html
@@ -156,7 +156,7 @@
     </figure>`;
 
     display(expandable(figure, {
-      id: 'point-opacity',
+      id: 'point-cloud-plot',
       width: Math.min(width, 640),
       height: Math.min(480, width),
       toggleOffset: [-6, -33],

--- a/src/notebooks/point-cloud-point-opacity/index.html
+++ b/src/notebooks/point-cloud-point-opacity/index.html
@@ -156,6 +156,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'point-opacity',
       width: Math.min(width, 640),
       height: Math.min(480, width),
       toggleOffset: [-6, -33],

--- a/src/notebooks/simulating-the-2d-kuramoto-sivashinsky-equation-in-webgpu/index.html
+++ b/src/notebooks/simulating-the-2d-kuramoto-sivashinsky-equation-in-webgpu/index.html
@@ -126,7 +126,7 @@
     const figure = html`<figure style="margin: 0;">${stack.element}</figure>`;
 
     display(expandable(figure, {
-      id: 'kuramoto-sivashinsky',
+      id: 'pde-sim',
       width: Math.min(width, 640),
       height: Math.min(width, 640),
       toggleOffset: [-15, -16],

--- a/src/notebooks/simulating-the-2d-kuramoto-sivashinsky-equation-in-webgpu/index.html
+++ b/src/notebooks/simulating-the-2d-kuramoto-sivashinsky-equation-in-webgpu/index.html
@@ -126,6 +126,7 @@
     const figure = html`<figure style="margin: 0;">${stack.element}</figure>`;
 
     display(expandable(figure, {
+      id: 'kuramoto-sivashinsky',
       width: Math.min(width, 640),
       height: Math.min(width, 640),
       toggleOffset: [-15, -16],

--- a/src/notebooks/strange-attractors-in-webgpu/index.html
+++ b/src/notebooks/strange-attractors-in-webgpu/index.html
@@ -89,7 +89,7 @@ camera; canvas; figure; stack; renderState; canvasWidth; canvasHeight; device; c
 
 let expandableContainer;
 expandableContainer = expandable(figure, {
-  id: 'strange-attractor',
+  id: 'attractor-viewer',
   width: canvasWidth,
   height: canvasHeight,
   controls: '.attractor-controls',

--- a/src/notebooks/strange-attractors-in-webgpu/index.html
+++ b/src/notebooks/strange-attractors-in-webgpu/index.html
@@ -89,6 +89,7 @@ camera; canvas; figure; stack; renderState; canvasWidth; canvasHeight; device; c
 
 let expandableContainer;
 expandableContainer = expandable(figure, {
+  id: 'strange-attractor',
   width: canvasWidth,
   height: canvasHeight,
   controls: '.attractor-controls',

--- a/src/notebooks/transparency-for-3d-surfaces/index.html
+++ b/src/notebooks/transparency-for-3d-surfaces/index.html
@@ -266,6 +266,7 @@ const figureWidth = Math.min(width, 640);
 const figureHeight = Math.round(Math.max(500, figureWidth * 0.7));
 
 display(expandable(figure, {
+  id: 'transparency',
   wide: true,
   width: figureWidth,
   height: figureHeight,

--- a/src/notebooks/transparency-for-3d-surfaces/index.html
+++ b/src/notebooks/transparency-for-3d-surfaces/index.html
@@ -266,7 +266,7 @@ const figureWidth = Math.min(width, 640);
 const figureHeight = Math.round(Math.max(500, figureWidth * 0.7));
 
 display(expandable(figure, {
-  id: 'transparency',
+  id: 'surface-viewer',
   wide: true,
   width: figureWidth,
   height: figureHeight,

--- a/src/notebooks/visualizing-sloan-digital-sky-survey-data/index.html
+++ b/src/notebooks/visualizing-sloan-digital-sky-survey-data/index.html
@@ -211,6 +211,7 @@ const figure = html`<figure style="margin: 0; max-width: none;" id="sdss-figure"
 </figure>`;
 
 display(expandable(figure, {
+  id: 'sky-survey',
   width: initialWidth,
   height: initialHeight,
   wide: true,

--- a/src/notebooks/visualizing-sloan-digital-sky-survey-data/index.html
+++ b/src/notebooks/visualizing-sloan-digital-sky-survey-data/index.html
@@ -211,7 +211,7 @@ const figure = html`<figure style="margin: 0; max-width: none;" id="sdss-figure"
 </figure>`;
 
 display(expandable(figure, {
-  id: 'sky-survey',
+  id: 'star-cloud-viewer',
   width: initialWidth,
   height: initialHeight,
   wide: true,

--- a/src/notebooks/webgpu-lines/index.html
+++ b/src/notebooks/webgpu-lines/index.html
@@ -84,7 +84,7 @@
     </figure>`;
 
     display(expandable(figure, {
-      id: 'webgpu-lines',
+      id: 'line-editor',
       width: canvasWidth,
       height: canvasHeight,
       controls: '.lines-controls',

--- a/src/notebooks/webgpu-lines/index.html
+++ b/src/notebooks/webgpu-lines/index.html
@@ -84,6 +84,7 @@
     </figure>`;
 
     display(expandable(figure, {
+      id: 'webgpu-lines',
       width: canvasWidth,
       height: canvasHeight,
       controls: '.lines-controls',


### PR DESCRIPTION
When expanded, sets URL hash to #<id> (e.g. #phase-portrait). Loading a page with that hash auto-expands the matching figure. Collapsing clears the hash. Supports explicit id option or auto-generated fig-1, fig-2, etc.

https://claude.ai/code/session_0119pZWQTU7joCFzSJ3rC2SE