### PR TITLE
Set container element id to match hash fragment identifier

### DIFF
--- a/src/lib/expandable.js
+++ b/src/lib/expandable.js
@@ -104,6 +104,7 @@ export function expandable(content, {
 
   const container = document.createElement('div');
   container.className = 'expandable-container';
+  container.id = hashId;
 
   const contentWrapper = document.createElement('div');
   contentWrapper.className = 'expandable-content';


### PR DESCRIPTION
The expandable container's DOM id now matches the hash fragment, so #foo corresponds to an element with id="foo" as HTML intends.

https://claude.ai/code/session_0119pZWQTU7joCFzSJ3rC2SE