### PR TITLE
Fix @zappar/msdf-generator module resolution in Denali notebook

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -236,11 +236,14 @@ export default defineConfig(async ({ command }) => {
           join(SRC_DIR, "index.html"),
           ...notebookPaths,
         ],
-        external: ['@zappar/msdf-generator'],
       },
     },
     root: "src",
     base: "/",
+    optimizeDeps: {
+      // Exclude msdf-generator from pre-bundling to preserve worker structure
+      exclude: ['@zappar/msdf-generator'],
+    },
     server: {
       host: true,
       hmr: {


### PR DESCRIPTION
The package was listed in package.json but not installed, and was incorrectly marked as external in rollup config which prevents bundling and leaves a bare module specifier the browser cannot resolve. Remove the external marking and add optimizeDeps.exclude to preserve the worker/WASM structure during dev.

https://claude.ai/code/session_011VHc4WyGrKg7vx9Vb4ANMW