### PR TITLE
Per-pixel sun angle from time in the terrain relief pass

### DIFF
--- a/src/notebooks/line-sweep-terrain-lighting/index.html
+++ b/src/notebooks/line-sweep-terrain-lighting/index.html
@@ -1936,6 +1936,7 @@
     import { expandable } from "./lib/expandable.js";
     import SunCalc from "npm:suncalc";
     import { createSunCalendar } from "./sun-calendar.js";
+    import { solarTimeQuantities } from "./solar-time.js";
   </script>
   <script id="71" type="module">
     const tileViewerControlsDiv = html`<div class="tile-viewer-controls"></div>`;
@@ -1978,6 +1979,10 @@
       value: 0.3,
       step: 0.01,
     });
+    const sunModeEl = Inputs.radio(
+      new Map([["fixed angle", "fixed"], ["from time", "time"]]),
+      { label: "sun mode", value: "fixed" },
+    );
     let _viewerRef = null;
     const tileViewerRef = { set: (v) => { _viewerRef = v; } };
     const sunCalendarEl = createSunCalendar(SunCalc, {
@@ -1992,6 +1997,7 @@
     tileViewerControlsDiv.appendChild(shadowSamplesEl);
     tileViewerControlsDiv.appendChild(aoFalloffEl);
     tileViewerControlsDiv.appendChild(zoomExagEl);
+    tileViewerControlsDiv.appendChild(sunModeEl);
     tileViewerControlsDiv.appendChild(sunCalendarEl);
     display(tileViewerControlsDiv);
     const tileViewerControls = {
@@ -2003,6 +2009,8 @@
       shadowSamplesEl,
       aoFalloffEl,
       zoomExagEl,
+      sunModeEl,
+      sunCalendarEl,
     };
   </script>
   <script id="72" type="module">
@@ -2096,7 +2104,36 @@
       // uniform-buffer write. `needsRender` inside the viewer makes
       // the render loop a no-op when there's nothing to update.
       const c = tileViewerControls;
+      // In time mode the sun handle visualises the center-of-view sun
+      // position (which also feeds the shadow sweep) but is not
+      // user-editable — the calendar is authoritative.
+      const syncSunHandleStyle = () => {
+        const useTime = c.sunModeEl.value === "time";
+        sunWrapper.style.pointerEvents = useTime ? "none" : "auto";
+        sunWrapper.style.opacity = useTime ? "0.55" : "1";
+      };
+      c.sunModeEl.addEventListener("input", syncSunHandleStyle);
+      syncSunHandleStyle();
       const tickLighting = () => {
+        const useTime = c.sunModeEl.value === "time";
+        // In time mode the calendar drives az/alt: push the current
+        // calendar value into the mutable each frame so the shadow
+        // sweep (and the handle visual) track the CPU-computed sun
+        // direction at the view centre as the view pans or the
+        // time slider moves.
+        let solar = null;
+        if (useTime) {
+          const utcDate = c.sunCalendarEl.getUtcDate();
+          if (utcDate) {
+            solar = solarTimeQuantities(utcDate.getTime());
+            const [lat, lng] = viewer.getCenter();
+            const pos = SunCalc.getPosition(utcDate, lat, lng);
+            const altDeg = (pos.altitude * 180) / Math.PI;
+            const scAzDeg = (pos.azimuth * 180) / Math.PI;
+            const azDeg = (((270 - scAzDeg) % 360) + 360) % 360;
+            tileViewerSunDirAccessor.set({ az: azDeg, alt: altDeg });
+          }
+        }
         const sd = tileViewerSunDirAccessor.get();
         const azRad = (sd.az * Math.PI) / 180;
         // Clamp to the horizon for shading/shadow math — a negative
@@ -2117,7 +2154,7 @@
         const isDebug = c.bakeModeEl.value === "debug";
         const lsaoFalloff = c.aoFalloffEl.value === "e^(−sin α)" ? "exp" : "cos2";
         const reliefBeta = Number(c.zoomExagEl.value);
-        viewer.setLighting({
+        const lightingUpdate = {
           sunX,
           sunY,
           sunZ,
@@ -2133,7 +2170,10 @@
           bakeMode: isDebug ? "cpu" : c.bakeModeEl.value,
           lsaoFalloff,
           reliefBeta,
-        });
+          useTime,
+        };
+        if (solar) lightingUpdate.solar = solar;
+        viewer.setLighting(lightingUpdate);
         requestAnimationFrame(tickLighting);
       };
       requestAnimationFrame(tickLighting);

--- a/src/notebooks/line-sweep-terrain-lighting/solar-time.js
+++ b/src/notebooks/line-sweep-terrain-lighting/solar-time.js
@@ -1,0 +1,59 @@
+// CPU-side decomposition of suncalc's sun-position computation.
+//
+// Everything in here depends only on time (not location), so we can do
+// it once per frame in JS doubles and hand the shader three small
+// scalars. The GPU then computes the location-dependent tail — hour
+// angle → altitude/azimuth — per pixel. That keeps double-precision
+// work (in particular the 360.9856235·d accumulation of sidereal time)
+// on the CPU where we have 53-bit mantissas instead of 23.
+//
+// Formulas track the public-domain suncalc source. Per-pixel the
+// shader should compute (with phi = latitude, lam = longitude, both in
+// radians):
+//
+//   H        = gmstMinusRA + lam
+//   sinAlt   = sin(phi)*sinDec + cos(phi)*cosDec*cos(H)
+//   azSunc   = atan2(sin(H), cos(H)*sin(phi) - (sinDec/cosDec)*cos(phi))
+//
+// where azSunc follows suncalc's convention (0 = south, clockwise).
+// Convert to the notebook's convention (0 = east, counter-clockwise)
+// via `azNotebook = 3π/2 − azSunc`.
+
+const RAD = Math.PI / 180;
+const J1970 = 2440588;
+const J2000 = 2451545;
+const OBLIQUITY = 23.4397 * RAD;
+const SIN_OBLIQUITY = Math.sin(OBLIQUITY);
+const COS_OBLIQUITY = Math.cos(OBLIQUITY);
+const PERIHELION = 102.9372 * RAD;
+const TWO_PI = 2 * Math.PI;
+
+function toDays(utcMs) {
+  return utcMs / 86400000 - 0.5 + J1970 - J2000;
+}
+
+// Reduce x to [-π, π). Done in doubles so that the large
+// 360.9856235·d sidereal accumulation loses no meaningful precision
+// before we cast to f32.
+function wrapPi(x) {
+  return x - Math.floor((x + Math.PI) / TWO_PI) * TWO_PI;
+}
+
+export function solarTimeQuantities(utcMs) {
+  const d = toDays(utcMs);
+  const M = (357.5291 + 0.98560028 * d) * RAD;
+  const C =
+    (1.9148 * Math.sin(M) +
+      0.02 * Math.sin(2 * M) +
+      0.0003 * Math.sin(3 * M)) *
+    RAD;
+  const L = M + C + PERIHELION + Math.PI;
+  const sinL = Math.sin(L);
+  const cosL = Math.cos(L);
+  const sinDec = SIN_OBLIQUITY * sinL;
+  const cosDec = Math.sqrt(Math.max(0, 1 - sinDec * sinDec));
+  const RA = Math.atan2(sinL * COS_OBLIQUITY, cosL);
+  const GMST = (280.16 + 360.9856235 * d) * RAD;
+  const gmstMinusRA = wrapPi(GMST - RA);
+  return { sinDec, cosDec, gmstMinusRA };
+}

--- a/src/notebooks/line-sweep-terrain-lighting/sun-calendar.js
+++ b/src/notebooks/line-sweep-terrain-lighting/sun-calendar.js
@@ -195,5 +195,10 @@ export function createSunCalendar(SunCalc, { getLocation, onChange }) {
   // Show initial time but don't fire onChange
   updateDisplay();
 
+  // Expose the currently selected UTC instant. The notebook's
+  // time-driven lighting mode reads this every frame to compute solar
+  // quantities without re-routing through the onChange callback.
+  container.getUtcDate = getSelectedDate;
+
   return container;
 }

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -252,12 +252,11 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   // Shadow-vs-altitude blend. In fixed mode, fade to "fully
   // shadowed" as the handle approaches the horizon — a grace note
   // so the view doesn't snap to black at dip. In time mode, fade
-  // to "no shadow" per-pixel as the local sun crosses the horizon:
-  // sun-cast shadows don't exist at night, and the bake ran with
-  // clamped center altitude anyway so those values are meaningless
-  // for tiles on the far side of the terminator.
+  // to "no shadow" per-pixel on the twilight smoothstep, matching
+  // the range used for nightMask and the relief fade so all three
+  // effects ramp together through the terminator.
   let fixedHS = mix(1.0, shadow, saturate(g.sunDir.z / 0.035));
-  let timeHS = mix(0.0, shadow, saturate(sunPP.z / 0.035));
+  let timeHS = mix(0.0, shadow, twilight);
   let horizonShadow = mix(fixedHS, timeHS, useTime);
   let shadowMask = 1.0 - shadowStrength * horizonShadow;
 
@@ -297,7 +296,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   let scaledSlope = min(slopeAngle * reliefStr * 2.0, 1.5);
   let aspectAlign = select(0.0, dot(nxy, sunDir.xy) / (slopeMag * sunHL), slopeMag > 0.001 && sunHL > 0.001);
   let shadeDir = 0.5 + 0.5 * aspectAlign;
-  let reliefFade = mix(1.0, saturate(sunPP.z / 0.035), useTime);
+  let reliefFade = mix(1.0, twilight, useTime);
   let reliefDark = sin(scaledSlope) * (1.0 - shadeDir) * reliefFade;
   let reliefSrgb = pow(1.0 - reliefDark * 0.85, 2.5) * shadowMask;
 

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -335,7 +335,7 @@ export function createTileViewer(opts) {
   container.style.touchAction = "none";
   container.style.cursor = "grab";
   container.style.userSelect = "none";
-  container.style.background = container.style.background || "#151515";
+  container.style.background = container.style.background || "#ffffff";
 
   const canvas = document.createElement("canvas");
   canvas.style.position = "absolute";
@@ -1345,7 +1345,7 @@ export function createTileViewer(opts) {
       colorAttachments: [
         {
           view: gpuCtx.getCurrentTexture().createView(),
-          clearValue: { r: 0.08, g: 0.08, b: 0.08, a: 1 },
+          clearValue: { r: 1, g: 1, b: 1, a: 1 },
           loadOp: "clear",
           storeOp: "store",
         },

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -249,14 +249,16 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 
   let aoContrast = g.params.z;
   let shadowStrength = g.params.w;
-  // Fade shadow to fully shadowed as the center sun approaches the
-  // horizon — this is a fixed-mode grace note so the view doesn't
-  // snap to black when the handle dips below horizontal. In time
-  // mode the per-pixel terminator handles darkening correctly, and
-  // a center-driven fade would dim tiles far from the center for no
-  // good reason, so we short-circuit it to 1.0 there.
-  let horizonFade = mix(saturate(g.sunDir.z / 0.035), 1.0, useTime);
-  let horizonShadow = mix(1.0, shadow, horizonFade);
+  // Shadow-vs-altitude blend. In fixed mode, fade to "fully
+  // shadowed" as the handle approaches the horizon — a grace note
+  // so the view doesn't snap to black at dip. In time mode, fade
+  // to "no shadow" per-pixel as the local sun crosses the horizon:
+  // sun-cast shadows don't exist at night, and the bake ran with
+  // clamped center altitude anyway so those values are meaningless
+  // for tiles on the far side of the terminator.
+  let fixedHS = mix(1.0, shadow, saturate(g.sunDir.z / 0.035));
+  let timeHS = mix(0.0, shadow, saturate(sunPP.z / 0.035));
+  let horizonShadow = mix(fixedHS, timeHS, useTime);
   let shadowMask = 1.0 - shadowStrength * horizonShadow;
 
   // AO tonemap in sRGB space — matching the LSAO section's atan

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -286,6 +286,10 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   let lambertian = diffuse * shadowMask;
 
   // Relief shading adapted from maplibre's standard hillshade.
+  // In time mode, reliefDark fades to zero per-pixel as the local
+  // sun crosses the horizon, so the aspect cross-hatch disappears
+  // on the night side and only LSAO (via aoFactor) textures the
+  // terrain there.
   let slopeMag = length(nxy);
   let sunHL = length(sunDir.xy);
   let zFactor = 0.625 * sqrt(sunHL);
@@ -293,7 +297,8 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   let scaledSlope = min(slopeAngle * reliefStr * 2.0, 1.5);
   let aspectAlign = select(0.0, dot(nxy, sunDir.xy) / (slopeMag * sunHL), slopeMag > 0.001 && sunHL > 0.001);
   let shadeDir = 0.5 + 0.5 * aspectAlign;
-  let reliefDark = sin(scaledSlope) * (1.0 - shadeDir);
+  let reliefFade = mix(1.0, saturate(sunPP.z / 0.035), useTime);
+  let reliefDark = sin(scaledSlope) * (1.0 - shadeDir) * reliefFade;
   let reliefSrgb = pow(1.0 - reliefDark * 0.85, 2.5) * shadowMask;
 
   // Debug mode: show the raw bake texture, darkened by shadow.

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -137,12 +137,14 @@ struct Global {
   viewportPx: vec4<f32>,   // xy = viewport size, z = shadingMode (0=lambertian,1=relief), w = reliefStrength
   sunDir: vec4<f32>,       // xyz = world-space sun direction, w = aoBoost (zoom-dependent)
   params: vec4<f32>,       // x=kAmbient, y=kDirect, z=aoStrength, w=shadowStrength
+  solar: vec4<f32>,        // x=sinDec, y=cosDec, z=gmstMinusRA (rad), w=useTime (0 or 1)
 };
 
 @group(0) @binding(0) var<uniform> g: Global;
 
 struct TileData {
   originSize: vec4<f32>,   // xy = tile top-left in screen px, zw = tile size in screen px
+  tileZXY: vec4<f32>,      // x=z (integer), y=tileX, z=tileY, w unused
 };
 
 @group(1) @binding(0) var<uniform> t: TileData;
@@ -182,6 +184,47 @@ fn linearToSrgb(x: f32) -> f32 {
   return 1.055 * pow(c, 1.0 / 2.4) - 0.055;
 }
 
+// Invert web-mercator: (uv in tile, plus integer tile z/x/y) → lat/lng
+// in radians. Uses WGSL's built-in sinh; the Gudermannian form
+// atan(sinh(x)) gives the standard mercator-to-latitude map.
+const PI_F: f32 = 3.14159265358979323846;
+const TWO_PI_F: f32 = 6.28318530717958647693;
+const THREE_HALF_PI_F: f32 = 4.71238898038468985769;
+
+fn pixelToLatLngRad(uv: vec2<f32>, tileZ: f32, tileX: f32, tileY: f32) -> vec2<f32> {
+  let n = exp2(tileZ);
+  let lngRad = ((tileX + uv.x) / n) * TWO_PI_F - PI_F;
+  let nMerc = PI_F * (1.0 - 2.0 * (tileY + uv.y) / n);
+  let latRad = atan(sinh(nMerc));
+  return vec2<f32>(latRad, lngRad);
+}
+
+// World-frame sun direction derived from the time-only quantities in
+// g.solar and the per-pixel (lat, lng). Returns (x, y, z) in the same
+// convention as g.sunDir — 0 = east (+x), +y = north, +z = up — so
+// the caller can drop it into the existing shading code unchanged.
+// Returned vector has unit length even when the sun is below the
+// horizon (altitude < 0); callers gate with the terminator fade.
+fn perPixelSunDir(uv: vec2<f32>) -> vec3<f32> {
+  let ll = pixelToLatLngRad(uv, t.tileZXY.x, t.tileZXY.y, t.tileZXY.z);
+  let phi = ll.x;
+  let lam = ll.y;
+  let sinPhi = sin(phi);
+  let cosPhi = cos(phi);
+  let H = g.solar.z + lam;
+  let sinH = sin(H);
+  let cosH = cos(H);
+  let sinDec = g.solar.x;
+  let cosDec = max(g.solar.y, 1e-6);
+  let sinAlt = sinPhi * sinDec + cosPhi * cosDec * cosH;
+  let cosAlt = sqrt(max(0.0, 1.0 - sinAlt * sinAlt));
+  // suncalc convention: 0 = south, clockwise.
+  let azS = atan2(sinH, cosH * sinPhi - (sinDec / cosDec) * cosPhi);
+  // Rotate to notebook convention: 0 = east, counter-clockwise.
+  let azN = THREE_HALF_PI_F - azS;
+  return vec3<f32>(cosAlt * cos(azN), cosAlt * sin(azN), sinAlt);
+}
+
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   let s = textureSample(tileTex, tileSampler, in.uv);
@@ -191,9 +234,22 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   let ao = s.b;
   let shadow = s.a;
 
+  // Pick between the uniform (handle-driven) sun direction and a
+  // per-pixel direction derived from time + lat/lng. In time mode we
+  // also multiply the whole composite by a civil-twilight smoothstep
+  // so the terminator sweeps darkness across relief shading too —
+  // otherwise aspect shading would keep drawing ridges into the night.
+  let useTime = g.solar.w;
+  let sunPP = perPixelSunDir(in.uv);
+  let sunDir = mix(g.sunDir.xyz, sunPP, useTime);
+  let twilight = smoothstep(-0.105, 0.035, sunPP.z); // ≈ (−6°, +2°)
+  let nightMask = mix(1.0, twilight, useTime);
+
   let aoContrast = g.params.z;
   let shadowStrength = g.params.w;
-  // Fade shadow to fully shadowed as sun approaches horizon.
+  // Fade shadow to fully shadowed as sun approaches horizon. In fixed
+  // mode the sweep sun altitude drives this directly; in time mode
+  // the sweep still uses g.sunDir (center-of-view), so reuse that.
   let horizonShadow = mix(1.0, shadow, saturate(g.sunDir.z / 0.035));
   let shadowMask = 1.0 - shadowStrength * horizonShadow;
 
@@ -218,16 +274,16 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   let lambNxy = nxy * lambExag;
   let lambLen = length(vec3<f32>(lambNxy, nz));
   let lambN = vec3<f32>(lambNxy, nz) / lambLen;
-  let diffuse = max(0.0, dot(lambN, g.sunDir.xyz));
+  let diffuse = max(0.0, dot(lambN, sunDir));
   let lambertian = diffuse * shadowMask;
 
   // Relief shading adapted from maplibre's standard hillshade.
   let slopeMag = length(nxy);
-  let sunHL = length(g.sunDir.xy);
+  let sunHL = length(sunDir.xy);
   let zFactor = 0.625 * sqrt(sunHL);
   let slopeAngle = atan(zFactor * slopeMag / max(nz, 0.001));
   let scaledSlope = min(slopeAngle * reliefStr * 2.0, 1.5);
-  let aspectAlign = select(0.0, dot(nxy, g.sunDir.xy) / (slopeMag * sunHL), slopeMag > 0.001 && sunHL > 0.001);
+  let aspectAlign = select(0.0, dot(nxy, sunDir.xy) / (slopeMag * sunHL), slopeMag > 0.001 && sunHL > 0.001);
   let shadeDir = 0.5 + 0.5 * aspectAlign;
   let reliefDark = sin(scaledSlope) * (1.0 - shadeDir);
   let reliefSrgb = pow(1.0 - reliefDark * 0.85, 2.5) * shadowMask;
@@ -240,8 +296,11 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 
   // Composite in sRGB: convert base shading to sRGB, then multiply
   // by aoFactor in perceptual space. No linearToSrgb at the end.
+  // nightMask is 1 outside time mode; inside time mode it's a civil-
+  // twilight smoothstep on the per-pixel altitude, so the terminator
+  // darkens both lambertian and relief together.
   let baseSrgb = mix(linearToSrgb(lambertian), reliefSrgb, reliefMode);
-  let v = clamp(baseSrgb * aoFactor, 0.0, 1.0);
+  let v = clamp(baseSrgb * aoFactor * nightMask, 0.0, 1.0);
   return vec4<f32>(v, v, v, 1.0);
 }
 `;
@@ -412,9 +471,10 @@ export function createTileViewer(opts) {
     addressModeV: "clamp-to-edge",
   });
 
-  // Global uniform buffer (48 bytes: three vec4s).
+  // Global uniform buffer (64 bytes: four vec4s — viewport, sunDir,
+  // params, solar).
   const globalBuffer = device.createBuffer({
-    size: 48,
+    size: 64,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     label: "tile-viewer global uniforms",
   });
@@ -422,7 +482,7 @@ export function createTileViewer(opts) {
     layout: globalBindGroupLayout,
     entries: [{ binding: 0, resource: { buffer: globalBuffer } }],
   });
-  const globalData = new Float32Array(12);
+  const globalData = new Float32Array(16);
 
   // ------------------------------------------------------------------
   // GPU tile-bake resources.
@@ -531,6 +591,14 @@ export function createTileViewer(opts) {
     // visually too strong — subjective preference sits around 0.3
     // (half the theoretical compensation).
     reliefBeta: 0.3,
+    // Per-pixel sun-position mode (time-driven). When useTime is
+    // truthy and solar is set, the composite shader derives sunDir
+    // per fragment from the tile's geographic coordinates plus the
+    // CPU-precomputed (sinDec, cosDec, gmstMinusRA) in `solar`. The
+    // shadow sweep still consumes the scalar sunX/Y/Z above — those
+    // represent the sun direction at the view centre.
+    useTime: false,
+    solar: { sinDec: 0, cosDec: 1, gmstMinusRA: 0 },
   };
 
   // Inverse-normal CDF (Peter Acklam's rational approximation). Used
@@ -569,9 +637,12 @@ export function createTileViewer(opts) {
       this.y = y;
       this.ready = false;
       this.destroyed = false;
-      this.tileData = new Float32Array(4);
+      this.tileData = new Float32Array(8);
+      this.tileData[4] = z;
+      this.tileData[5] = x;
+      this.tileData[6] = y;
       this.uniformBuffer = device.createBuffer({
-        size: 16,
+        size: 32,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
         label: `tile ${z}/${x}/${y} uniforms`,
       });
@@ -1183,9 +1254,10 @@ export function createTileViewer(opts) {
     needsRender = false;
 
     // Global uniform packing:
-    //   f32[0..1]  = viewportPx.xy
-    //   f32[4..6]  = sunDir.xyz
-    //   f32[8..11] = params (kAmbient, kDirect, aoStrength, shadowStrength)
+    //   f32[0..3]   = viewportPx (w,h,shadingMode,reliefStrength)
+    //   f32[4..7]   = sunDir.xyz, aoBoost
+    //   f32[8..11]  = params (kAmbient, kDirect, aoStrength, shadowStrength)
+    //   f32[12..15] = solar (sinDec, cosDec, gmstMinusRA, useTime)
     globalData[0] = viewportW;
     globalData[1] = viewportH;
     globalData[2] = lighting.shadingMode;
@@ -1201,6 +1273,10 @@ export function createTileViewer(opts) {
     globalData[9] = lighting.kDirect;
     globalData[10] = lighting.aoStrength;
     globalData[11] = lighting.shadowStrength;
+    globalData[12] = lighting.solar.sinDec;
+    globalData[13] = lighting.solar.cosDec;
+    globalData[14] = lighting.solar.gmstMinusRA;
+    globalData[15] = lighting.useTime ? 1 : 0;
     device.queue.writeBuffer(globalBuffer, 0, globalData);
 
     // Per-tile uniform updates — screen-space origin is a small f32

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -239,18 +239,24 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
   // also multiply the whole composite by a civil-twilight smoothstep
   // so the terminator sweeps darkness across relief shading too —
   // otherwise aspect shading would keep drawing ridges into the night.
+  // The smoothstep is floored at 0.25 so the night side stays visible
+  // (just dimmed) rather than going fully black.
   let useTime = g.solar.w;
   let sunPP = perPixelSunDir(in.uv);
   let sunDir = mix(g.sunDir.xyz, sunPP, useTime);
   let twilight = smoothstep(-0.105, 0.035, sunPP.z); // ≈ (−6°, +2°)
-  let nightMask = mix(1.0, twilight, useTime);
+  let nightMask = mix(1.0, 0.25 + 0.75 * twilight, useTime);
 
   let aoContrast = g.params.z;
   let shadowStrength = g.params.w;
-  // Fade shadow to fully shadowed as sun approaches horizon. In fixed
-  // mode the sweep sun altitude drives this directly; in time mode
-  // the sweep still uses g.sunDir (center-of-view), so reuse that.
-  let horizonShadow = mix(1.0, shadow, saturate(g.sunDir.z / 0.035));
+  // Fade shadow to fully shadowed as the center sun approaches the
+  // horizon — this is a fixed-mode grace note so the view doesn't
+  // snap to black when the handle dips below horizontal. In time
+  // mode the per-pixel terminator handles darkening correctly, and
+  // a center-driven fade would dim tiles far from the center for no
+  // good reason, so we short-circuit it to 1.0 there.
+  let horizonFade = mix(saturate(g.sunDir.z / 0.035), 1.0, useTime);
+  let horizonShadow = mix(1.0, shadow, horizonFade);
   let shadowMask = 1.0 - shadowStrength * horizonShadow;
 
   // AO tonemap in sRGB space — matching the LSAO section's atan

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -435,7 +435,7 @@ export function createTileViewer(opts) {
     entries: [
       {
         binding: 0,
-        visibility: GPUShaderStage.VERTEX,
+        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
         buffer: { type: "uniform" },
       },
       {


### PR DESCRIPTION
Adds a time-driven lighting mode that computes the sun direction per
fragment from the tile's geographic coordinates. Time-only suncalc
quantities (sinDec, cosDec, GMST−RA) are precomputed on the CPU in
doubles — critical for the 360.9856235·d sidereal accumulation — and
uploaded as a vec4. The composite shader derives per-pixel lat/lng
from tile (z, x, y) + uv and finishes the altitude/azimuth calc,
giving a true solar terminator that sweeps across relief and
lambertian shading together. The sweep/shadow/LSAO bakes are
unchanged; they still consume the scalar sun direction at the view
centre, which is visually indistinguishable at the scales where the
terminator matters.