### PR TITLE
Fix localhost link to denali notebook

### DIFF
--- a/src/notebooks/line-sweep-terrain-lighting/index.html
+++ b/src/notebooks/line-sweep-terrain-lighting/index.html
@@ -8,7 +8,7 @@
 
     The goal of this notebook to compute terrain lighting using web map terrain tiles as input and produce corresponding raster light maps as output. For terrain data, we'll be using the excellent and open [Mapterhorn](https://mapterhorn.com/) tileset. We'll start with a simple horizon visibility algorithm and extend it to cover self-shadowing and ambient occlusion. It's definitely not novel, but the devil is in the details.
 
-    Although I don't [work in mapping anymore](https://www.mapbox.com), I'll always have have a soft spot for experimental map rendering techniques. Previously I've built a live [solar terminator map](https://rreusser.github.io/notebooks/night-and-day/) and a [kinda janky 3D map renderer](http://localhost:5173/notebooks/denali/). Inspired by some good posts on the topic, I've also dabbled in heightfield shadowing. This article finally pulls the latter work together into something functional.
+    Although I don't [work in mapping anymore](https://www.mapbox.com), I'll always have have a soft spot for experimental map rendering techniques. Previously I've built a live [solar terminator map](https://rreusser.github.io/notebooks/night-and-day/) and a [kinda janky 3D map renderer](https://rreusser.github.io/notebooks/denali/). Inspired by some good posts on the topic, I've also dabbled in heightfield shadowing. This article finally pulls the latter work together into something functional.
 
     ## Inspiration
     


### PR DESCRIPTION
The link in the second paragraph pointed to a local dev server URL
instead of the published notebook.