### PR TITLE
Add infinite-zoom Spectre tiling notebook

### DIFF
--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -138,6 +138,11 @@ export function createInfiniteRenderer({
     centerY: 0,
     // physical pixels per world unit. 60 ≈ a unit-edge spectre ~60 px tall.
     pixelScale: 60,
+    // Premultiplied (rgb*a, a). Callers can mutate this so any uncovered
+    // pixels (sub-pixel gaps between cells, viewport regions outside the
+    // root cluster) blend with a colour close to the average tile colour
+    // instead of a jarring opaque black/dark grey.
+    clearValue: { r: 0, g: 0, b: 0, a: 0 },
     _frameRequested: false,
     onViewChange,
 
@@ -225,7 +230,7 @@ export function createInfiniteRenderer({
         colorAttachments: [{
           view: this.msTexture.createView(),
           resolveTarget: context.getCurrentTexture().createView(),
-          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          clearValue: this.clearValue,
           loadOp: 'clear',
           storeOp: 'discard',
         }],

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -250,6 +250,24 @@ export function createInfiniteRenderer({
       device.queue.submit([encoder.finish()]);
     },
 
+    // Snapshot/restore the view state. Useful for reproducing a specific
+    // zoom + pan from the runtime — call getView() to capture, then
+    // setView({centerX, centerY, pixelScale}) later to restore.
+    getView() {
+      return {
+        centerX: this.centerX,
+        centerY: this.centerY,
+        pixelScale: this.pixelScale,
+      };
+    },
+    setView(state) {
+      if (state.centerX != null) this.centerX = state.centerX;
+      if (state.centerY != null) this.centerY = state.centerY;
+      if (state.pixelScale != null) this.pixelScale = state.pixelScale;
+      this.onViewChange?.(this);
+      this.requestFrame();
+    },
+
     panBy(dxCss, dyCss) {
       const rect = canvas.getBoundingClientRect();
       const dpr = this.pixelWidth / Math.max(1, rect.width);

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -389,7 +389,7 @@ export function createInfiniteRenderer({
     // contrast curve, with the result clamped to [0, 1]. Defaults are
     // identity (no visible change vs. the pre-HDR pipeline aside from
     // float16 → 8-bit requantization at the canvas write).
-    tonemap: { contrast: 1.0, saturation: 1.0, midpoint: 0.5, brightness: 0.0,
+    tonemap: { contrast: 1.3, saturation: 1.05, midpoint: 0.5, brightness: 0.01,
                biasR: 0.0, biasG: 0.0, biasB: 0.0 },
     // Per-leaf outline. Drawn after the fill pass with line-strip
     // topology, fading linearly from `fadeOutPx` to `fadeInPx` so

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -6,7 +6,62 @@
 import { createVertexBuffer, createIndexBuffer, createUniformBuffer } from './lib/webgpu-canvas.js';
 
 const SAMPLE_COUNT = 4;
+// Wide-gamut intermediate so a contrast/saturation curve can stretch the
+// muted, multi-level-blended output without 8-bit banding. The actual
+// shader inputs and outputs stay inside [0, 1]; the float16 buffer is
+// purely about precision while the post pass remaps values.
+const HDR_FORMAT = 'rgba16float';
 export const INSTANCE_STRIDE = 16;
+
+const outlineShaderCode = /* wgsl */`
+struct View { scale: vec2f, offset: vec2f };
+struct OutlineU { alpha: f32, _pad0: f32, _pad1: f32, _pad2: f32 };
+@group(0) @binding(0) var<uniform> view: View;
+@group(0) @binding(1) var<uniform> ou: OutlineU;
+
+struct VsIn {
+  @location(0) pos: vec2f,
+  @location(1) iWorld: vec2f,
+  @location(2) iCosSin: vec2f,
+  @location(3) iColMir: vec4f,
+};
+struct VsOut {
+  @builtin(position) pos: vec4f,
+  @location(0) alpha: f32,
+};
+
+@vertex fn vs(in: VsIn) -> VsOut {
+  // Decode mirror flag (high bit of byte 15) and the 7-bit per-leaf
+  // alpha (low 7 bits). Multiply the uniform outline alpha by the
+  // leaf's own alpha so an outline fades together with its leaf
+  // during the parent's fade-in: in the substitution chain, Γ
+  // (mystic tile) aggregates earliest because its bounding ball is
+  // smallest, so its leaves' alpha drops while other leaves are
+  // still at 1. Tying outline alpha to leaf alpha keeps the
+  // outline's fade in lockstep with the fill — no flash-off, and
+  // no "aggregate visible through outline" at mid fade.
+  let v255 = in.iColMir.w * 255.0;
+  let isMirror = v255 >= 128.0;
+  let mirror = select(1.0, -1.0, isMirror);
+  let alpha7 = v255 - select(0.0, 128.0, isMirror);
+  let leafAlpha = alpha7 / 127.0;
+  let m = vec2f(in.pos.x, in.pos.y * mirror);
+  let cs = in.iCosSin;
+  let r = vec2f(cs.x * m.x - cs.y * m.y, cs.y * m.x + cs.x * m.y);
+  let world = r + in.iWorld;
+  var out: VsOut;
+  out.pos = vec4f(world * view.scale + view.offset, 0.0, 1.0);
+  out.alpha = ou.alpha * leafAlpha;
+  return out;
+}
+@fragment fn fs(in: VsOut) -> @location(0) vec4f {
+  // Black outline. Premultiplied — rgb is (0,0,0) and a = ou.alpha,
+  // so the fill colour is multiplied by (1 - alpha) and we add 0,
+  // giving a darkened cell outline that respects the existing
+  // tonemap pipeline.
+  return vec4f(0.0, 0.0, 0.0, in.alpha);
+}
+`;
 
 const fillShaderCode = /* wgsl */`
 struct View { scale: vec2f, offset: vec2f };
@@ -44,10 +99,77 @@ struct VsOut {
   return out;
 }
 @fragment fn fs(in: VsOut) -> @location(0) vec4f {
-  // Premultiplied alpha — the canvas is in 'premultiplied' alphaMode and
-  // the pipeline blend is set up to do "src + (1 - src.a) * dst" so that
-  // a fading-in level draws on top of the level it's replacing.
+  // Premultiplied alpha — the HDR intermediate uses the same blend as
+  // the canvas did before ("src + (1 - src.a) * dst") so a fading-in
+  // level draws on top of the level it's replacing.
   return vec4f(in.color * in.alpha, in.alpha);
+}
+`;
+
+// Fullscreen-triangle post pass: samples the HDR intermediate, applies
+// saturation and contrast around `midpoint`, clamps to [0, 1], and writes
+// premultiplied output to the canvas (or a capture target). With both
+// knobs at 1 this is a near-identity pass aside from the float16 → 8-bit
+// requantization, so the default look matches the pre-HDR pipeline.
+const tonemapShaderCode = /* wgsl */`
+struct TM {
+  contrast: f32,
+  saturation: f32,
+  midpoint: f32,
+  brightness: f32,
+  // Per-channel additive bias on top of the scalar brightness. The
+  // video exporter uses this for loop-seamless rendering: it
+  // measures the per-channel average colour of the first and last
+  // frames and ramps biasRgb across the trajectory so both endpoints
+  // converge to the same average colour (not just the same luma).
+  // Default is vec3(0); the live UI ignores it.
+  biasRgb: vec3f,
+  _pad: f32,
+};
+@group(0) @binding(0) var srcTex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> tm: TM;
+
+@vertex fn vs(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var p = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(p[vi], 0.0, 1.0);
+}
+
+@fragment fn fs(@builtin(position) pos: vec4f) -> @location(0) vec4f {
+  let s = textureLoad(srcTex, vec2i(pos.xy), 0);
+  // Unpremultiply so the curve operates on the actual scene colour
+  // rather than a coverage-attenuated value. Tiny epsilon avoids /0.
+  let a = max(s.a, 1e-4);
+  let rgb = s.rgb / a;
+  // Rec. 709 luma — close enough for a perceptual saturation pull.
+  let luma = dot(rgb, vec3f(0.2126, 0.7152, 0.0722));
+  let satted = mix(vec3f(luma), rgb, tm.saturation);
+  let contrasted = (satted - vec3f(tm.midpoint)) * tm.contrast + vec3f(tm.midpoint);
+  let brightened = contrasted + vec3f(tm.brightness) + tm.biasRgb;
+  let finalRgb = clamp(brightened, vec3f(0.0), vec3f(1.0));
+  return vec4f(finalRgb * s.a, s.a);
+}
+`;
+
+// Additive-blend accumulator pass: samples the HDR resolve target,
+// multiplies by `weight`, and adds into a separate HDR accumulator
+// (target blend = "src + dst"). Used for video-export temporal
+// supersampling so that sub-frames are averaged in linear HDR space
+// *before* the tonemap curve runs once on the final mean — preserving
+// pleasant highlight streaks that the per-sub-frame tonemap path
+// would otherwise clip and then dilute via post-tonemap averaging.
+const accumulateShaderCode = /* wgsl */`
+struct W { weight: f32, _pad0: f32, _pad1: f32, _pad2: f32 };
+@group(0) @binding(0) var srcTex: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: W;
+
+@vertex fn vs(@builtin(vertex_index) vi: u32) -> @builtin(position) vec4f {
+  var p = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+  return vec4f(p[vi], 0.0, 1.0);
+}
+
+@fragment fn fs(@builtin(position) pos: vec4f) -> @location(0) vec4f {
+  let s = textureLoad(srcTex, vec2i(pos.xy), 0);
+  return s * u.weight;
 }
 `;
 
@@ -72,6 +194,14 @@ export function createInfiniteRenderer({
   const meshVertexBuffer = createVertexBuffer(device, 'spectre-verts', meshVertexData);
   const meshIndexBuffer  = createIndexBuffer(device, 'spectre-fill-indices', meshFillIndices);
   const indexCount = meshFillIndices.length;
+  // Leaf bound radius (max distance from local origin to any spectre
+  // vertex). Used to convert the live pixelScale into a per-leaf
+  // on-screen size so outline alpha can fade as leaves shrink.
+  let leafBoundRadius = 0;
+  for (let i = 0; i < meshVertexData.length; i += 2) {
+    const r = Math.hypot(meshVertexData[i], meshVertexData[i + 1]);
+    if (r > leafBoundRadius) leafBoundRadius = r;
+  }
   // Spectre tile mesh, exposed so callers can construct a draw group
   // for the per-leaf instances using the same renderer-owned buffers.
   const defaultMesh = {
@@ -80,6 +210,19 @@ export function createInfiniteRenderer({
     indexCount,
     indexFormat: 'uint16',
   };
+
+  // Spectre outline indices: 14-vertex closed line strip (0..13, 0).
+  // Reuses meshVertexBuffer; runs after the fill pass with line-strip
+  // topology to draw a 1-px boundary around every leaf instance.
+  // Buffer is padded to 16 entries so total byte length (32) is a
+  // multiple of 4 — required by WebGPU's writeBuffer. drawIndexed
+  // only consumes the first 15 entries, so the trailing pad value
+  // never reaches the rasteriser.
+  const _outlineIndexData = new Uint16Array(16);
+  for (let i = 0; i < 14; i++) _outlineIndexData[i] = i;
+  _outlineIndexData[14] = 0;
+  _outlineIndexData[15] = 0;
+  const outlineIndexBuffer = createIndexBuffer(device, 'spectre-outline-indices', _outlineIndexData);
   const viewUniformBuffer = createUniformBuffer(device, 'view-uniforms', 16);
 
   const vertexLayouts = [
@@ -107,7 +250,7 @@ export function createInfiniteRenderer({
     fragment: {
       module: fillShader, entryPoint: 'fs',
       targets: [{
-        format: canvasFormat,
+        format: HDR_FORMAT,
         blend: {
           // Premultiplied "src over dst": src is already (rgb*a, a) from
           // the fragment shader, so we add it directly and attenuate dst
@@ -125,6 +268,93 @@ export function createInfiniteRenderer({
     entries: [{ binding: 0, resource: { buffer: viewUniformBuffer } }],
   });
 
+  // Outline pipeline: same vertex layout as fill, line-strip topology,
+  // its own fragment shader that ignores the per-instance colour and
+  // emits a uniform-alpha black premultiplied output. Drawn after the
+  // fill pass so it sits ON TOP of cell colour but UNDER the tonemap.
+  const outlineShader = device.createShaderModule({ label: 'spectre-outline', code: outlineShaderCode });
+  const outlineUniformBuffer = createUniformBuffer(device, 'outline-uniforms', 16);
+  const outlinePipeline = device.createRenderPipeline({
+    label: 'spectre-outline-pipeline',
+    layout: 'auto',
+    vertex:   { module: outlineShader, entryPoint: 'vs', buffers: vertexLayouts },
+    fragment: {
+      module: outlineShader, entryPoint: 'fs',
+      targets: [{
+        format: HDR_FORMAT,
+        blend: {
+          color: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+          alpha: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+        },
+      }],
+    },
+    primitive: { topology: 'line-strip', stripIndexFormat: 'uint16' },
+    multisample: { count: SAMPLE_COUNT },
+  });
+  const outlineBindGroup = device.createBindGroup({
+    layout: outlinePipeline.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: { buffer: viewUniformBuffer } },
+      { binding: 1, resource: { buffer: outlineUniformBuffer } },
+    ],
+  });
+
+  const tonemapShader = device.createShaderModule({ label: 'spectre-tonemap', code: tonemapShaderCode });
+  const tonemapPipeline = device.createRenderPipeline({
+    label: 'spectre-tonemap-pipeline',
+    layout: 'auto',
+    vertex:   { module: tonemapShader, entryPoint: 'vs' },
+    fragment: { module: tonemapShader, entryPoint: 'fs', targets: [{ format: canvasFormat }] },
+    primitive: { topology: 'triangle-list' },
+  });
+  // 32 bytes: contrast/saturation/midpoint/brightness (4 × f32 = 16),
+  // then biasRgb at offset 16 (vec3 has 16-byte alignment in std140;
+  // vec3 + 1 pad f32 = 16 bytes). Total 32.
+  const tonemapUniformBuffer = createUniformBuffer(device, 'tonemap-uniforms', 32);
+  function makePostBindGroup(hdrTexture) {
+    return device.createBindGroup({
+      label: 'spectre-tonemap-bg',
+      layout: tonemapPipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: hdrTexture.createView() },
+        { binding: 1, resource: { buffer: tonemapUniformBuffer } },
+      ],
+    });
+  }
+
+  const accumulateShader = device.createShaderModule({
+    label: 'spectre-accumulate', code: accumulateShaderCode,
+  });
+  const accumulatePipeline = device.createRenderPipeline({
+    label: 'spectre-accumulate-pipeline',
+    layout: 'auto',
+    vertex:   { module: accumulateShader, entryPoint: 'vs' },
+    fragment: {
+      module: accumulateShader, entryPoint: 'fs',
+      targets: [{
+        format: HDR_FORMAT,
+        // Additive: weight*src + dst. The accumulator must be cleared
+        // to zero before each output frame's sub-frame loop.
+        blend: {
+          color: { srcFactor: 'one', dstFactor: 'one', operation: 'add' },
+          alpha: { srcFactor: 'one', dstFactor: 'one', operation: 'add' },
+        },
+      }],
+    },
+    primitive: { topology: 'triangle-list' },
+  });
+  const accumulateUniformBuffer = createUniformBuffer(device, 'accumulate-uniforms', 16);
+  function makeAccumulateBindGroup(srcTex) {
+    return device.createBindGroup({
+      label: 'spectre-accumulate-bg',
+      layout: accumulatePipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: srcTex.createView() },
+        { binding: 1, resource: { buffer: accumulateUniformBuffer } },
+      ],
+    });
+  }
+
   const state = {
     canvas,
     defaultMesh,
@@ -135,17 +365,41 @@ export function createInfiniteRenderer({
     // setDrawList (or the legacy setInstances → leaves-only path).
     drawGroups: [],
     msTexture: null,
+    hdrTexture: null,
+    _postBindGroup: null,
     pixelWidth: 0,
     pixelHeight: 0,
     centerX: 0,
     centerY: 0,
     // physical pixels per world unit. 60 ≈ a unit-edge spectre ~60 px tall.
     pixelScale: 60,
+    // World coords baked into the instance buffer are stored as
+    // (world − instanceCenterX/Y). Normally instanceCenterX/Y track
+    // centerX/Y so the offset uniform is zero; the freeze toggle
+    // pins them to the freeze-time view center, then pan/zoom shifts
+    // the offset uniform instead of re-walking the tree.
+    instanceCenterX: 0,
+    instanceCenterY: 0,
     // Premultiplied (rgb*a, a). Callers can mutate this so any uncovered
     // pixels (sub-pixel gaps between cells, viewport regions outside the
     // root cluster) blend with a colour close to the average tile colour
     // instead of a jarring opaque black/dark grey.
     clearValue: { r: 0, g: 0, b: 0, a: 0 },
+    // Tonemap stretches the post-blend colours through a saturation +
+    // contrast curve, with the result clamped to [0, 1]. Defaults are
+    // identity (no visible change vs. the pre-HDR pipeline aside from
+    // float16 → 8-bit requantization at the canvas write).
+    tonemap: { contrast: 1.0, saturation: 1.0, midpoint: 0.5, brightness: 0.0,
+               biasR: 0.0, biasG: 0.0, biasB: 0.0 },
+    // Per-leaf outline. Drawn after the fill pass with line-strip
+    // topology, fading linearly from `fadeOutPx` to `fadeInPx` so
+    // outlines disappear when leaves are smaller than ~`fadeOutPx`
+    // pixels across (no visible noise) and reach full strength at
+    // ~`fadeInPx`. `enabled = false` (or opacity = 0) skips the
+    // draw entirely. Defaults skew toward EARLY disable: line-strip
+    // line-list draw is per-leaf, so culling the outline below
+    // `fadeOutPx` saves real time at low zooms.
+    outline: { enabled: true, opacity: 0.5, fadeOutPx: 16, fadeInPx: 120 },
     _frameRequested: false,
     _rafId: null,
     _capture: null,
@@ -164,13 +418,21 @@ export function createInfiniteRenderer({
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
       });
       this.msTexture?.destroy();
+      this.hdrTexture?.destroy();
       this.msTexture = device.createTexture({
-        label: 'spectre-msaa',
+        label: 'spectre-hdr-msaa',
         size: [px, py],
         sampleCount: SAMPLE_COUNT,
-        format: canvasFormat,
+        format: HDR_FORMAT,
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
       });
+      this.hdrTexture = device.createTexture({
+        label: 'spectre-hdr-resolve',
+        size: [px, py],
+        format: HDR_FORMAT,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      });
+      this._postBindGroup = makePostBindGroup(this.hdrTexture);
       this.onViewChange?.(this);
       this.requestFrame();
     },
@@ -224,42 +486,91 @@ export function createInfiniteRenderer({
     },
 
     draw() {
-      if (!this.instanceBuffer || !this.pixelWidth || !this.msTexture) return;
-      this._renderTo(context.getCurrentTexture());
+      if (!this.instanceBuffer || !this.pixelWidth || !this.msTexture || !this.hdrTexture) return;
+      this._renderTo(
+        context.getCurrentTexture(),
+        this.msTexture, this.hdrTexture, this._postBindGroup,
+      );
     },
 
-    _renderTo(target, extraEncode) {
+    _renderTo(target, msHdr, hdrResolve, postBindGroup, extraEncode) {
       const sx = 2 * this.pixelScale / this.pixelWidth;
       const sy = 2 * this.pixelScale / this.pixelHeight;
-      // Instance positions are already view-relative (the walker subtracts
-      // centerX/Y in Float64 before truncating to Float32), so the shader
-      // just needs the scale — no large `-center * scale` term that would
-      // cancel large numbers and chew through Float32 precision.
+      // Instance positions are stored as (world − instanceCenter); the
+      // shader projects them as (iWorld + (instanceCenter − center)) *
+      // scale = (world − center) * scale. Normally instanceCenter ==
+      // center and the offset is zero (no large-number cancellation);
+      // when the structure is frozen the offset diverges from zero
+      // and absorbs all subsequent pan/zoom without a re-walk.
+      const ox = (this.instanceCenterX - this.centerX) * sx;
+      const oy = (this.instanceCenterY - this.centerY) * sy;
       device.queue.writeBuffer(viewUniformBuffer, 0, new Float32Array([
-        sx, sy, 0, 0,
+        sx, sy, ox, oy,
+      ]));
+      const tm = this.tonemap;
+      device.queue.writeBuffer(tonemapUniformBuffer, 0, new Float32Array([
+        tm.contrast, tm.saturation, tm.midpoint, tm.brightness,
+        tm.biasR ?? 0, tm.biasG ?? 0, tm.biasB ?? 0, 0,
       ]));
       const encoder = device.createCommandEncoder();
-      const pass = encoder.beginRenderPass({
+      // Pass 1: scene → HDR MSAA, resolved to single-sample HDR.
+      const fillPass = encoder.beginRenderPass({
         colorAttachments: [{
-          view: this.msTexture.createView(),
-          resolveTarget: target.createView(),
+          view: msHdr.createView(),
+          resolveTarget: hdrResolve.createView(),
           clearValue: this.clearValue,
           loadOp: 'clear',
           storeOp: 'discard',
         }],
       });
       if (this.drawGroups.length > 0) {
-        pass.setPipeline(fillPipeline);
-        pass.setBindGroup(0, fillBindGroup);
-        pass.setVertexBuffer(1, this.instanceBuffer);
+        fillPass.setPipeline(fillPipeline);
+        fillPass.setBindGroup(0, fillBindGroup);
+        fillPass.setVertexBuffer(1, this.instanceBuffer);
         for (const g of this.drawGroups) {
           if (g.instanceCount === 0) continue;
-          pass.setVertexBuffer(0, g.mesh.vertexBuffer);
-          pass.setIndexBuffer(g.mesh.indexBuffer, g.mesh.indexFormat);
-          pass.drawIndexed(g.mesh.indexCount, g.instanceCount, 0, 0, g.instanceOffset);
+          fillPass.setVertexBuffer(0, g.mesh.vertexBuffer);
+          fillPass.setIndexBuffer(g.mesh.indexBuffer, g.mesh.indexFormat);
+          fillPass.drawIndexed(g.mesh.indexCount, g.instanceCount, 0, 0, g.instanceOffset);
+        }
+        // Pass 1b: outline strokes around each leaf instance. Same
+        // pass (writes into the HDR resolve target so the tonemap
+        // applies) but a different pipeline (line-strip + outline
+        // shader) and only the leaf groups (those whose mesh is the
+        // default spectre fill mesh).
+        const o = this.outline;
+        if (o && o.enabled) {
+          const leafSizePx = leafBoundRadius * 2 * this.pixelScale;
+          const t = (leafSizePx - o.fadeOutPx) / Math.max(1e-6, o.fadeInPx - o.fadeOutPx);
+          const fade = t <= 0 ? 0 : t >= 1 ? 1 : t * t * (3 - 2 * t);
+          const alpha = fade * o.opacity;
+          if (alpha > 0) {
+            device.queue.writeBuffer(outlineUniformBuffer, 0, new Float32Array([alpha, 0, 0, 0]));
+            fillPass.setPipeline(outlinePipeline);
+            fillPass.setBindGroup(0, outlineBindGroup);
+            fillPass.setVertexBuffer(0, meshVertexBuffer);
+            fillPass.setIndexBuffer(outlineIndexBuffer, 'uint16');
+            for (const g of this.drawGroups) {
+              if (g.instanceCount === 0 || g.mesh !== defaultMesh) continue;
+              fillPass.drawIndexed(15, g.instanceCount, 0, 0, g.instanceOffset);
+            }
+          }
         }
       }
-      pass.end();
+      fillPass.end();
+      // Pass 2: tonemap HDR → canvas (or capture target).
+      const postPass = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: target.createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        }],
+      });
+      postPass.setPipeline(tonemapPipeline);
+      postPass.setBindGroup(0, postBindGroup);
+      postPass.draw(3, 1, 0, 0);
+      postPass.end();
       if (extraEncode) extraEncode(encoder);
       device.queue.submit([encoder.finish()]);
     },
@@ -267,19 +578,30 @@ export function createInfiniteRenderer({
     // Offline-capture API. Use to render at a fixed pixel size (e.g.,
     // 1280×720 for video export) without disturbing the live canvas.
     //
-    //   beginCapture(w, h) — override the renderer's pixel dims and
-    //     allocate dedicated MSAA + COPY_SRC targets at (w, h). The
+    //   beginCapture(w, h, opts?) — override the renderer's pixel dims
+    //     and allocate dedicated MSAA + tonemap targets at (w, h). The
     //     walker (invoked via setView → onViewChange) sees the new dims
     //     because it reads pixelWidth/pixelHeight off the renderer state.
-    //   captureFrame()    — render the current draw list to the capture
-    //     target and copy pixels back as RGBA Uint8Array.
+    //     opts.accumulator: when true, also allocate an HDR accumulator
+    //     for temporal supersampling (see clearAccumulator /
+    //     accumulateSubFrame / captureAccumulated below).
+    //   captureFrame()    — render the current draw list, tonemap to the
+    //     capture target, copy pixels back as RGBA Uint8Array. Single
+    //     sub-frame; the tonemap runs on the raw scene HDR.
+    //   clearAccumulator()       — zero the HDR accumulator. Call once
+    //     per output frame.
+    //   accumulateSubFrame(w)    — render the current draw list into the
+    //     HDR resolve target, then additively blend (weight × resolve)
+    //     into the accumulator. No tonemap, no readback.
+    //   captureAccumulated()     — tonemap the accumulator to the
+    //     capture target and read pixels back as RGBA Uint8Array.
     //   endCapture()      — destroy the temp targets, restore live dims,
     //     redraw the live canvas.
     //
     // While a capture session is active, requestFrame is a no-op and any
     // already-pending rAF is cancelled, so a stray draw doesn't try to
     // render at mismatched dims onto the live canvas.
-    beginCapture(w, h) {
+    beginCapture(w, h, opts) {
       if (this._capture) throw new Error('capture already in progress');
       if (this._rafId != null) {
         cancelAnimationFrame(this._rafId);
@@ -288,13 +610,17 @@ export function createInfiniteRenderer({
       const savedFrameRequested = this._frameRequested;
       this._frameRequested = true;
       const savedPxW = this.pixelWidth, savedPxH = this.pixelHeight;
-      const savedMs = this.msTexture;
       this.pixelWidth = w;
       this.pixelHeight = h;
-      const ms = device.createTexture({
-        label: 'spectre-capture-ms',
-        size: [w, h], sampleCount: SAMPLE_COUNT, format: canvasFormat,
+      const msHdr = device.createTexture({
+        label: 'spectre-capture-hdr-ms',
+        size: [w, h], sampleCount: SAMPLE_COUNT, format: HDR_FORMAT,
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+      const hdrResolve = device.createTexture({
+        label: 'spectre-capture-hdr-resolve',
+        size: [w, h], format: HDR_FORMAT,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
       });
       const target = device.createTexture({
         label: 'spectre-capture-target',
@@ -307,18 +633,184 @@ export function createInfiniteRenderer({
         size: bytesPerRow * h,
         usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
       });
-      this.msTexture = ms;
+      const postBindGroup = makePostBindGroup(hdrResolve);
+      let accumulator = null;
+      let accumulateBindGroup = null;
+      let postBindGroupAcc = null;
+      if (opts && opts.accumulator) {
+        accumulator = device.createTexture({
+          label: 'spectre-capture-accumulator',
+          size: [w, h], format: HDR_FORMAT,
+          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+        });
+        accumulateBindGroup = makeAccumulateBindGroup(hdrResolve);
+        postBindGroupAcc = makePostBindGroup(accumulator);
+      }
       this._capture = {
-        w, h, ms, target, readback, bytesPerRow,
-        savedPxW, savedPxH, savedMs, savedFrameRequested,
+        w, h, msHdr, hdrResolve, target, readback, bytesPerRow, postBindGroup,
+        accumulator, accumulateBindGroup, postBindGroupAcc,
+        savedPxW, savedPxH, savedFrameRequested,
       };
+    },
+
+    // Zero the HDR accumulator. Call once per output frame, before the
+    // sub-frame loop.
+    clearAccumulator() {
+      if (!this._capture || !this._capture.accumulator) {
+        throw new Error('accumulator not enabled — pass { accumulator: true } to beginCapture');
+      }
+      const encoder = device.createCommandEncoder();
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: this._capture.accumulator.createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        }],
+      });
+      pass.end();
+      device.queue.submit([encoder.finish()]);
+    },
+
+    // Render one sub-frame of the current draw list into the HDR resolve
+    // target, then additively blend (weight × resolve) into the
+    // accumulator. The fill pass uses clearValue so a single sub-frame
+    // contribution accounts for the renderer's clear colour as well.
+    accumulateSubFrame(weight) {
+      if (!this._capture || !this._capture.accumulator) {
+        throw new Error('accumulator not enabled — pass { accumulator: true } to beginCapture');
+      }
+      if (!this.instanceBuffer) return;
+      const c = this._capture;
+      const sx = 2 * this.pixelScale / this.pixelWidth;
+      const sy = 2 * this.pixelScale / this.pixelHeight;
+      const ox = (this.instanceCenterX - this.centerX) * sx;
+      const oy = (this.instanceCenterY - this.centerY) * sy;
+      device.queue.writeBuffer(viewUniformBuffer, 0, new Float32Array([sx, sy, ox, oy]));
+      device.queue.writeBuffer(accumulateUniformBuffer, 0, new Float32Array([weight, 0, 0, 0]));
+      const encoder = device.createCommandEncoder();
+      // Pass 1: scene → HDR ms → HDR resolve.
+      const fillPass = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: c.msHdr.createView(),
+          resolveTarget: c.hdrResolve.createView(),
+          clearValue: this.clearValue,
+          loadOp: 'clear',
+          storeOp: 'discard',
+        }],
+      });
+      if (this.drawGroups.length > 0) {
+        fillPass.setPipeline(fillPipeline);
+        fillPass.setBindGroup(0, fillBindGroup);
+        fillPass.setVertexBuffer(1, this.instanceBuffer);
+        for (const g of this.drawGroups) {
+          if (g.instanceCount === 0) continue;
+          fillPass.setVertexBuffer(0, g.mesh.vertexBuffer);
+          fillPass.setIndexBuffer(g.mesh.indexBuffer, g.mesh.indexFormat);
+          fillPass.drawIndexed(g.mesh.indexCount, g.instanceCount, 0, 0, g.instanceOffset);
+        }
+        // Outline pass for video-export sub-frames (mirrors the live
+        // _renderTo path; same fade math so the live preview and the
+        // exported frames look the same).
+        const o = this.outline;
+        if (o && o.enabled) {
+          const leafSizePx = leafBoundRadius * 2 * this.pixelScale;
+          const t = (leafSizePx - o.fadeOutPx) / Math.max(1e-6, o.fadeInPx - o.fadeOutPx);
+          const fade = t <= 0 ? 0 : t >= 1 ? 1 : t * t * (3 - 2 * t);
+          const alpha = fade * o.opacity;
+          if (alpha > 0) {
+            device.queue.writeBuffer(outlineUniformBuffer, 0, new Float32Array([alpha, 0, 0, 0]));
+            fillPass.setPipeline(outlinePipeline);
+            fillPass.setBindGroup(0, outlineBindGroup);
+            fillPass.setVertexBuffer(0, meshVertexBuffer);
+            fillPass.setIndexBuffer(outlineIndexBuffer, 'uint16');
+            for (const g of this.drawGroups) {
+              if (g.instanceCount === 0 || g.mesh !== defaultMesh) continue;
+              fillPass.drawIndexed(15, g.instanceCount, 0, 0, g.instanceOffset);
+            }
+          }
+        }
+      }
+      fillPass.end();
+      // Pass 2: weight × hdrResolve → accumulator (additive blend).
+      const accPass = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: c.accumulator.createView(),
+          loadOp: 'load',
+          storeOp: 'store',
+        }],
+      });
+      accPass.setPipeline(accumulatePipeline);
+      accPass.setBindGroup(0, c.accumulateBindGroup);
+      accPass.draw(3, 1, 0, 0);
+      accPass.end();
+      device.queue.submit([encoder.finish()]);
+    },
+
+    // Tonemap the accumulator to the canvas-format capture target and
+    // read pixels back as RGBA. Mirrors captureFrame() except it sources
+    // the accumulator instead of running the fill pass first.
+    async captureAccumulated() {
+      if (!this._capture || !this._capture.accumulator) {
+        throw new Error('accumulator not enabled — pass { accumulator: true } to beginCapture');
+      }
+      const c = this._capture;
+      const tm = this.tonemap;
+      device.queue.writeBuffer(tonemapUniformBuffer, 0, new Float32Array([
+        tm.contrast, tm.saturation, tm.midpoint, tm.brightness,
+        tm.biasR ?? 0, tm.biasG ?? 0, tm.biasB ?? 0, 0,
+      ]));
+      const encoder = device.createCommandEncoder();
+      const postPass = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: c.target.createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        }],
+      });
+      postPass.setPipeline(tonemapPipeline);
+      postPass.setBindGroup(0, c.postBindGroupAcc);
+      postPass.draw(3, 1, 0, 0);
+      postPass.end();
+      encoder.copyTextureToBuffer(
+        { texture: c.target },
+        { buffer: c.readback, bytesPerRow: c.bytesPerRow, rowsPerImage: c.h },
+        [c.w, c.h, 1],
+      );
+      device.queue.submit([encoder.finish()]);
+      await c.readback.mapAsync(GPUMapMode.READ);
+      const padded = new Uint8Array(c.readback.getMappedRange());
+      const out = new Uint8Array(c.w * c.h * 4);
+      const isBgra = canvasFormat === 'bgra8unorm';
+      for (let y = 0; y < c.h; y++) {
+        const srcRow = y * c.bytesPerRow;
+        const dstRow = y * c.w * 4;
+        for (let x = 0; x < c.w; x++) {
+          const s = srcRow + x * 4;
+          const d = dstRow + x * 4;
+          if (isBgra) {
+            out[d + 0] = padded[s + 2];
+            out[d + 1] = padded[s + 1];
+            out[d + 2] = padded[s + 0];
+            out[d + 3] = padded[s + 3];
+          } else {
+            out[d + 0] = padded[s + 0];
+            out[d + 1] = padded[s + 1];
+            out[d + 2] = padded[s + 2];
+            out[d + 3] = padded[s + 3];
+          }
+        }
+      }
+      c.readback.unmap();
+      return out;
     },
 
     async captureFrame() {
       if (!this._capture) throw new Error('beginCapture not called');
       if (!this.instanceBuffer) return new Uint8Array(0);
-      const { w, h, target, readback, bytesPerRow } = this._capture;
-      this._renderTo(target, (encoder) => {
+      const { w, h, msHdr, hdrResolve, target, readback, bytesPerRow, postBindGroup } = this._capture;
+      this._renderTo(target, msHdr, hdrResolve, postBindGroup, (encoder) => {
         encoder.copyTextureToBuffer(
           { texture: target },
           { buffer: readback, bytesPerRow, rowsPerImage: h },
@@ -357,8 +849,9 @@ export function createInfiniteRenderer({
       const c = this._capture;
       c.target.destroy();
       c.readback.destroy();
-      c.ms.destroy();
-      this.msTexture = c.savedMs;
+      c.msHdr.destroy();
+      c.hdrResolve.destroy();
+      c.accumulator?.destroy();
       this.pixelWidth = c.savedPxW;
       this.pixelHeight = c.savedPxH;
       this._frameRequested = c.savedFrameRequested;
@@ -481,6 +974,7 @@ export function createInfiniteRenderer({
 
   invalidation.then(() => {
     state.msTexture?.destroy();
+    state.hdrTexture?.destroy();
     state.instanceBuffer?.destroy();
   });
 

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -64,7 +64,10 @@ export function createInfiniteRenderer({
   canvas.style.cursor = 'grab';
 
   const context = canvas.getContext('webgpu');
-  context.configure({ device, format: canvasFormat, alphaMode: 'premultiplied' });
+  context.configure({
+    device, format: canvasFormat, alphaMode: 'premultiplied',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
 
   const meshVertexBuffer = createVertexBuffer(device, 'spectre-verts', meshVertexData);
   const meshIndexBuffer  = createIndexBuffer(device, 'spectre-fill-indices', meshFillIndices);
@@ -144,6 +147,8 @@ export function createInfiniteRenderer({
     // instead of a jarring opaque black/dark grey.
     clearValue: { r: 0, g: 0, b: 0, a: 0 },
     _frameRequested: false,
+    _rafId: null,
+    _capture: null,
     onViewChange,
 
     resize(w, h) {
@@ -154,7 +159,10 @@ export function createInfiniteRenderer({
       this.pixelHeight = py;
       canvas.width = px;
       canvas.height = py;
-      context.configure({ device, format: canvasFormat, alphaMode: 'premultiplied' });
+      context.configure({
+        device, format: canvasFormat, alphaMode: 'premultiplied',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      });
       this.msTexture?.destroy();
       this.msTexture = device.createTexture({
         label: 'spectre-msaa',
@@ -208,14 +216,19 @@ export function createInfiniteRenderer({
     requestFrame() {
       if (this._frameRequested) return;
       this._frameRequested = true;
-      requestAnimationFrame(() => {
+      this._rafId = requestAnimationFrame(() => {
         this._frameRequested = false;
+        this._rafId = null;
         this.draw();
       });
     },
 
     draw() {
       if (!this.instanceBuffer || !this.pixelWidth || !this.msTexture) return;
+      this._renderTo(context.getCurrentTexture());
+    },
+
+    _renderTo(target, extraEncode) {
       const sx = 2 * this.pixelScale / this.pixelWidth;
       const sy = 2 * this.pixelScale / this.pixelHeight;
       // Instance positions are already view-relative (the walker subtracts
@@ -229,7 +242,7 @@ export function createInfiniteRenderer({
       const pass = encoder.beginRenderPass({
         colorAttachments: [{
           view: this.msTexture.createView(),
-          resolveTarget: context.getCurrentTexture().createView(),
+          resolveTarget: target.createView(),
           clearValue: this.clearValue,
           loadOp: 'clear',
           storeOp: 'discard',
@@ -247,7 +260,114 @@ export function createInfiniteRenderer({
         }
       }
       pass.end();
+      if (extraEncode) extraEncode(encoder);
       device.queue.submit([encoder.finish()]);
+    },
+
+    // Offline-capture API. Use to render at a fixed pixel size (e.g.,
+    // 1280×720 for video export) without disturbing the live canvas.
+    //
+    //   beginCapture(w, h) — override the renderer's pixel dims and
+    //     allocate dedicated MSAA + COPY_SRC targets at (w, h). The
+    //     walker (invoked via setView → onViewChange) sees the new dims
+    //     because it reads pixelWidth/pixelHeight off the renderer state.
+    //   captureFrame()    — render the current draw list to the capture
+    //     target and copy pixels back as RGBA Uint8Array.
+    //   endCapture()      — destroy the temp targets, restore live dims,
+    //     redraw the live canvas.
+    //
+    // While a capture session is active, requestFrame is a no-op and any
+    // already-pending rAF is cancelled, so a stray draw doesn't try to
+    // render at mismatched dims onto the live canvas.
+    beginCapture(w, h) {
+      if (this._capture) throw new Error('capture already in progress');
+      if (this._rafId != null) {
+        cancelAnimationFrame(this._rafId);
+        this._rafId = null;
+      }
+      const savedFrameRequested = this._frameRequested;
+      this._frameRequested = true;
+      const savedPxW = this.pixelWidth, savedPxH = this.pixelHeight;
+      const savedMs = this.msTexture;
+      this.pixelWidth = w;
+      this.pixelHeight = h;
+      const ms = device.createTexture({
+        label: 'spectre-capture-ms',
+        size: [w, h], sampleCount: SAMPLE_COUNT, format: canvasFormat,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+      const target = device.createTexture({
+        label: 'spectre-capture-target',
+        size: [w, h], format: canvasFormat,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      });
+      const bytesPerRow = Math.ceil(w * 4 / 256) * 256;
+      const readback = device.createBuffer({
+        label: 'spectre-capture-readback',
+        size: bytesPerRow * h,
+        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+      });
+      this.msTexture = ms;
+      this._capture = {
+        w, h, ms, target, readback, bytesPerRow,
+        savedPxW, savedPxH, savedMs, savedFrameRequested,
+      };
+    },
+
+    async captureFrame() {
+      if (!this._capture) throw new Error('beginCapture not called');
+      if (!this.instanceBuffer) return new Uint8Array(0);
+      const { w, h, target, readback, bytesPerRow } = this._capture;
+      this._renderTo(target, (encoder) => {
+        encoder.copyTextureToBuffer(
+          { texture: target },
+          { buffer: readback, bytesPerRow, rowsPerImage: h },
+          [w, h, 1],
+        );
+      });
+      await readback.mapAsync(GPUMapMode.READ);
+      const padded = new Uint8Array(readback.getMappedRange());
+      const out = new Uint8Array(w * h * 4);
+      const isBgra = canvasFormat === 'bgra8unorm';
+      for (let y = 0; y < h; y++) {
+        const srcRow = y * bytesPerRow;
+        const dstRow = y * w * 4;
+        for (let x = 0; x < w; x++) {
+          const s = srcRow + x * 4;
+          const d = dstRow + x * 4;
+          if (isBgra) {
+            out[d + 0] = padded[s + 2];
+            out[d + 1] = padded[s + 1];
+            out[d + 2] = padded[s + 0];
+            out[d + 3] = padded[s + 3];
+          } else {
+            out[d + 0] = padded[s + 0];
+            out[d + 1] = padded[s + 1];
+            out[d + 2] = padded[s + 2];
+            out[d + 3] = padded[s + 3];
+          }
+        }
+      }
+      readback.unmap();
+      return out;
+    },
+
+    endCapture() {
+      if (!this._capture) return;
+      const c = this._capture;
+      c.target.destroy();
+      c.readback.destroy();
+      c.ms.destroy();
+      this.msTexture = c.savedMs;
+      this.pixelWidth = c.savedPxW;
+      this.pixelHeight = c.savedPxH;
+      this._frameRequested = c.savedFrameRequested;
+      this._capture = null;
+      // Walker output reflects the capture dims; trigger a fresh
+      // repack at live dims and redraw the live canvas.
+      this.onViewChange?.(this);
+      this._frameRequested = false;
+      this.requestFrame();
     },
 
     // Snapshot/restore the view state. Useful for reproducing a specific

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -189,8 +189,12 @@ export function createInfiniteRenderer({
       if (!this.instanceBuffer || !this.pixelWidth || !this.msTexture) return;
       const sx = 2 * this.pixelScale / this.pixelWidth;
       const sy = 2 * this.pixelScale / this.pixelHeight;
+      // Instance positions are already view-relative (the walker subtracts
+      // centerX/Y in Float64 before truncating to Float32), so the shader
+      // just needs the scale — no large `-center * scale` term that would
+      // cancel large numbers and chew through Float32 precision.
       device.queue.writeBuffer(viewUniformBuffer, 0, new Float32Array([
-        sx, sy, -this.centerX * sx, -this.centerY * sy,
+        sx, sy, 0, 0,
       ]));
       const encoder = device.createCommandEncoder();
       const pass = encoder.beginRenderPass({

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -21,10 +21,18 @@ struct VsIn {
 struct VsOut {
   @builtin(position) pos: vec4f,
   @location(0) color: vec3f,
+  @location(1) alpha: f32,
 };
 
+// The fourth instance byte packs (mirror_bit << 7) | alpha7. Decode:
+// byte values 0..127 are non-mirrored (mirror = +1), 128..255 are
+// mirrored (mirror = -1); the low 7 bits are alpha in [0, 127].
 @vertex fn vs(in: VsIn) -> VsOut {
-  let mirror = 1.0 - 2.0 * in.iColMir.w;
+  let v255 = in.iColMir.w * 255.0;
+  let isMirror = v255 >= 128.0;
+  let mirror = select(1.0, -1.0, isMirror);
+  let alpha7 = v255 - select(0.0, 128.0, isMirror);
+  let alpha = alpha7 / 127.0;
   let m = vec2f(in.pos.x, in.pos.y * mirror);
   let cs = in.iCosSin;
   let r = vec2f(cs.x * m.x - cs.y * m.y, cs.y * m.x + cs.x * m.y);
@@ -32,10 +40,14 @@ struct VsOut {
   var out: VsOut;
   out.pos = vec4f(world * view.scale + view.offset, 0.0, 1.0);
   out.color = in.iColMir.rgb;
+  out.alpha = alpha;
   return out;
 }
 @fragment fn fs(in: VsOut) -> @location(0) vec4f {
-  return vec4f(in.color, 1.0);
+  // Premultiplied alpha — the canvas is in 'premultiplied' alphaMode and
+  // the pipeline blend is set up to do "src + (1 - src.a) * dst" so that
+  // a fading-in level draws on top of the level it's replacing.
+  return vec4f(in.color * in.alpha, in.alpha);
 }
 `;
 
@@ -89,7 +101,19 @@ export function createInfiniteRenderer({
     label: 'spectre-fill-pipeline',
     layout: 'auto',
     vertex:   { module: fillShader, entryPoint: 'vs', buffers: vertexLayouts },
-    fragment: { module: fillShader, entryPoint: 'fs', targets: [{ format: canvasFormat }] },
+    fragment: {
+      module: fillShader, entryPoint: 'fs',
+      targets: [{
+        format: canvasFormat,
+        blend: {
+          // Premultiplied "src over dst": src is already (rgb*a, a) from
+          // the fragment shader, so we add it directly and attenuate dst
+          // by (1 - src.a).
+          color: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+          alpha: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+        },
+      }],
+    },
     primitive: { topology: 'triangle-list' },
     multisample: { count: SAMPLE_COUNT },
   });

--- a/src/notebooks/aperiodic-monotile/infinite-renderer.js
+++ b/src/notebooks/aperiodic-monotile/infinite-renderer.js
@@ -1,0 +1,317 @@
+// Minimal WebGPU renderer for the infinite-zoom Spectre notebook. Owns the
+// canvas, one fill pipeline, the view uniform, and the pan/zoom event
+// handlers. The notebook calls state.setInstances(...) followed by
+// state.requestFrame() to put a fresh batch of tiles on screen.
+
+import { createVertexBuffer, createIndexBuffer, createUniformBuffer } from './lib/webgpu-canvas.js';
+
+const SAMPLE_COUNT = 4;
+export const INSTANCE_STRIDE = 16;
+
+const fillShaderCode = /* wgsl */`
+struct View { scale: vec2f, offset: vec2f };
+@group(0) @binding(0) var<uniform> view: View;
+
+struct VsIn {
+  @location(0) pos: vec2f,
+  @location(1) iWorld: vec2f,
+  @location(2) iCosSin: vec2f,
+  @location(3) iColMir: vec4f,
+};
+struct VsOut {
+  @builtin(position) pos: vec4f,
+  @location(0) color: vec3f,
+};
+
+@vertex fn vs(in: VsIn) -> VsOut {
+  let mirror = 1.0 - 2.0 * in.iColMir.w;
+  let m = vec2f(in.pos.x, in.pos.y * mirror);
+  let cs = in.iCosSin;
+  let r = vec2f(cs.x * m.x - cs.y * m.y, cs.y * m.x + cs.x * m.y);
+  let world = r + in.iWorld;
+  var out: VsOut;
+  out.pos = vec4f(world * view.scale + view.offset, 0.0, 1.0);
+  out.color = in.iColMir.rgb;
+  return out;
+}
+@fragment fn fs(in: VsOut) -> @location(0) vec4f {
+  return vec4f(in.color, 1.0);
+}
+`;
+
+export function createInfiniteRenderer({
+  device, canvasFormat, invalidation,
+  meshVertexData, meshFillIndices,
+  onViewChange,
+}) {
+  const canvas = document.createElement('canvas');
+  canvas.style.display = 'block';
+  canvas.style.width = '100%';
+  canvas.style.height = '100%';
+  canvas.style.touchAction = 'none';
+  canvas.style.cursor = 'grab';
+
+  const context = canvas.getContext('webgpu');
+  context.configure({ device, format: canvasFormat, alphaMode: 'premultiplied' });
+
+  const meshVertexBuffer = createVertexBuffer(device, 'spectre-verts', meshVertexData);
+  const meshIndexBuffer  = createIndexBuffer(device, 'spectre-fill-indices', meshFillIndices);
+  const indexCount = meshFillIndices.length;
+  // Spectre tile mesh, exposed so callers can construct a draw group
+  // for the per-leaf instances using the same renderer-owned buffers.
+  const defaultMesh = {
+    vertexBuffer: meshVertexBuffer,
+    indexBuffer: meshIndexBuffer,
+    indexCount,
+    indexFormat: 'uint16',
+  };
+  const viewUniformBuffer = createUniformBuffer(device, 'view-uniforms', 16);
+
+  const vertexLayouts = [
+    {
+      arrayStride: 8,
+      stepMode: 'vertex',
+      attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x2' }],
+    },
+    {
+      arrayStride: INSTANCE_STRIDE,
+      stepMode: 'instance',
+      attributes: [
+        { shaderLocation: 1, offset: 0,  format: 'float32x2' },
+        { shaderLocation: 2, offset: 8,  format: 'snorm16x2' },
+        { shaderLocation: 3, offset: 12, format: 'unorm8x4'  },
+      ],
+    },
+  ];
+
+  const fillShader = device.createShaderModule({ label: 'spectre-fill', code: fillShaderCode });
+  const fillPipeline = device.createRenderPipeline({
+    label: 'spectre-fill-pipeline',
+    layout: 'auto',
+    vertex:   { module: fillShader, entryPoint: 'vs', buffers: vertexLayouts },
+    fragment: { module: fillShader, entryPoint: 'fs', targets: [{ format: canvasFormat }] },
+    primitive: { topology: 'triangle-list' },
+    multisample: { count: SAMPLE_COUNT },
+  });
+  const fillBindGroup = device.createBindGroup({
+    layout: fillPipeline.getBindGroupLayout(0),
+    entries: [{ binding: 0, resource: { buffer: viewUniformBuffer } }],
+  });
+
+  const state = {
+    canvas,
+    defaultMesh,
+    instanceBuffer: null,
+    instanceCapacity: 0,
+    // List of { mesh, instanceOffset, instanceCount } describing how the
+    // shared instance buffer is partitioned across draws. Populated by
+    // setDrawList (or the legacy setInstances → leaves-only path).
+    drawGroups: [],
+    msTexture: null,
+    pixelWidth: 0,
+    pixelHeight: 0,
+    centerX: 0,
+    centerY: 0,
+    // physical pixels per world unit. 60 ≈ a unit-edge spectre ~60 px tall.
+    pixelScale: 60,
+    _frameRequested: false,
+    onViewChange,
+
+    resize(w, h) {
+      const px = Math.max(1, Math.floor(w * devicePixelRatio));
+      const py = Math.max(1, Math.floor(h * devicePixelRatio));
+      if (px === this.pixelWidth && py === this.pixelHeight) return;
+      this.pixelWidth = px;
+      this.pixelHeight = py;
+      canvas.width = px;
+      canvas.height = py;
+      context.configure({ device, format: canvasFormat, alphaMode: 'premultiplied' });
+      this.msTexture?.destroy();
+      this.msTexture = device.createTexture({
+        label: 'spectre-msaa',
+        size: [px, py],
+        sampleCount: SAMPLE_COUNT,
+        format: canvasFormat,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+      this.onViewChange?.(this);
+      this.requestFrame();
+    },
+
+    ensureInstanceBuffer(count) {
+      if (count <= this.instanceCapacity) return;
+      this.instanceBuffer?.destroy();
+      this.instanceCapacity = Math.max(count, Math.max(64, this.instanceCapacity * 2));
+      this.instanceBuffer = device.createBuffer({
+        label: 'spectre-instances',
+        size: this.instanceCapacity * INSTANCE_STRIDE,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      });
+    },
+
+    // Upload `count` instances from the start of `data`, draw them as
+    // leaves with the default spectre mesh.
+    setInstances(data, count) {
+      this.setDrawList({
+        data,
+        totalCount: count,
+        groups: count > 0
+          ? [{ mesh: defaultMesh, instanceOffset: 0, instanceCount: count }]
+          : [],
+      });
+    },
+
+    // Upload `totalCount` instances from `data` and draw them as the
+    // listed groups. Each group has { mesh, instanceOffset, instanceCount }
+    // with instance offsets indexing into the shared instance buffer.
+    setDrawList({ data, totalCount, groups }) {
+      this.ensureInstanceBuffer(totalCount);
+      if (totalCount > 0) {
+        const bytes = totalCount * INSTANCE_STRIDE;
+        const view = ArrayBuffer.isView(data)
+          ? new Uint8Array(data.buffer, data.byteOffset, bytes)
+          : new Uint8Array(data, 0, bytes);
+        device.queue.writeBuffer(this.instanceBuffer, 0, view);
+      }
+      this.drawGroups = groups;
+    },
+
+    requestFrame() {
+      if (this._frameRequested) return;
+      this._frameRequested = true;
+      requestAnimationFrame(() => {
+        this._frameRequested = false;
+        this.draw();
+      });
+    },
+
+    draw() {
+      if (!this.instanceBuffer || !this.pixelWidth || !this.msTexture) return;
+      const sx = 2 * this.pixelScale / this.pixelWidth;
+      const sy = 2 * this.pixelScale / this.pixelHeight;
+      device.queue.writeBuffer(viewUniformBuffer, 0, new Float32Array([
+        sx, sy, -this.centerX * sx, -this.centerY * sy,
+      ]));
+      const encoder = device.createCommandEncoder();
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+          view: this.msTexture.createView(),
+          resolveTarget: context.getCurrentTexture().createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: 'clear',
+          storeOp: 'discard',
+        }],
+      });
+      if (this.drawGroups.length > 0) {
+        pass.setPipeline(fillPipeline);
+        pass.setBindGroup(0, fillBindGroup);
+        pass.setVertexBuffer(1, this.instanceBuffer);
+        for (const g of this.drawGroups) {
+          if (g.instanceCount === 0) continue;
+          pass.setVertexBuffer(0, g.mesh.vertexBuffer);
+          pass.setIndexBuffer(g.mesh.indexBuffer, g.mesh.indexFormat);
+          pass.drawIndexed(g.mesh.indexCount, g.instanceCount, 0, 0, g.instanceOffset);
+        }
+      }
+      pass.end();
+      device.queue.submit([encoder.finish()]);
+    },
+
+    panBy(dxCss, dyCss) {
+      const rect = canvas.getBoundingClientRect();
+      const dpr = this.pixelWidth / Math.max(1, rect.width);
+      this.centerX -= dxCss * dpr / this.pixelScale;
+      this.centerY += dyCss * dpr / this.pixelScale;
+      this.onViewChange?.(this);
+      this.requestFrame();
+    },
+
+    zoomAround(cssX, cssY, k) {
+      const rect = canvas.getBoundingClientRect();
+      const cx = (cssX / rect.width) * 2 - 1;
+      const cy = -((cssY / rect.height) * 2 - 1);
+      const sx = 2 * this.pixelScale / this.pixelWidth;
+      const sy = 2 * this.pixelScale / this.pixelHeight;
+      const wx = this.centerX + cx / sx;
+      const wy = this.centerY + cy / sy;
+      this.pixelScale *= k;
+      const sxN = 2 * this.pixelScale / this.pixelWidth;
+      const syN = 2 * this.pixelScale / this.pixelHeight;
+      this.centerX = wx - cx / sxN;
+      this.centerY = wy - cy / syN;
+      this.onViewChange?.(this);
+      this.requestFrame();
+    },
+  };
+
+  // Pan: 1-pointer drag. Pinch-zoom + 2-finger pan: 2-pointer gesture.
+  const pointers = new Map();
+  let panLastX = 0, panLastY = 0;
+  let pinchDist = 0, pinchMx = 0, pinchMy = 0;
+  const canvasXY = (e) => {
+    const rect = canvas.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+  const recomputePinch = () => {
+    const pts = [...pointers.values()];
+    const dx = pts[0].x - pts[1].x, dy = pts[0].y - pts[1].y;
+    pinchDist = Math.hypot(dx, dy);
+    pinchMx = (pts[0].x + pts[1].x) * 0.5;
+    pinchMy = (pts[0].y + pts[1].y) * 0.5;
+  };
+  canvas.addEventListener('pointerdown', (e) => {
+    canvas.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, canvasXY(e));
+    if (pointers.size === 1) {
+      panLastX = e.clientX; panLastY = e.clientY;
+      canvas.style.cursor = 'grabbing';
+    } else if (pointers.size === 2) {
+      recomputePinch();
+    }
+  });
+  canvas.addEventListener('pointermove', (e) => {
+    if (!pointers.has(e.pointerId)) return;
+    pointers.set(e.pointerId, canvasXY(e));
+    if (pointers.size === 1) {
+      const dx = e.clientX - panLastX, dy = e.clientY - panLastY;
+      panLastX = e.clientX; panLastY = e.clientY;
+      state.panBy(dx, dy);
+    } else if (pointers.size === 2) {
+      const prevDist = pinchDist, prevMx = pinchMx, prevMy = pinchMy;
+      recomputePinch();
+      if (prevDist > 0) {
+        state.zoomAround(pinchMx, pinchMy, pinchDist / prevDist);
+        state.panBy(pinchMx - prevMx, pinchMy - prevMy);
+      }
+    }
+  });
+  const endPointer = (e) => {
+    if (!pointers.delete(e.pointerId)) return;
+    if (pointers.size === 1) {
+      const rect = canvas.getBoundingClientRect();
+      const r = [...pointers.values()][0];
+      panLastX = r.x + rect.left;
+      panLastY = r.y + rect.top;
+    } else if (pointers.size === 0) {
+      canvas.style.cursor = 'grab';
+    }
+  };
+  canvas.addEventListener('pointerup', endPointer);
+  canvas.addEventListener('pointercancel', endPointer);
+  canvas.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
+    state.zoomAround(
+      e.clientX - rect.left,
+      e.clientY - rect.top,
+      Math.exp(-e.deltaY * 0.0015),
+    );
+  }, { passive: false });
+
+  invalidation.then(() => {
+    state.msTexture?.destroy();
+    state.instanceBuffer?.destroy();
+  });
+
+  return { canvas, state };
+}

--- a/src/notebooks/aperiodic-monotile/infinite-walker-worker.js
+++ b/src/notebooks/aperiodic-monotile/infinite-walker-worker.js
@@ -1,0 +1,1067 @@
+// Module worker hosting the Spectre metatile DAG, the view-driven
+// walker, and tree-extension state. Receives view/palette/colorBlend
+// updates from the main thread; posts back instance-buffer results
+// (with the ArrayBuffer transferred). Only the *latest* pending view
+// is processed: if the worker is busy when a new view arrives, the
+// older one is dropped. This way the renderer always converges to the
+// current view without a queue of stale walks piling up.
+//
+// The worker maintains its own copy of:
+//   - the metatile DAG (built deterministically from constants)
+//   - walkerState (currentRoot, currentRootTransform, extensionLevel)
+//   - paletteState mirror, colorBlendState mirror
+// The main thread keeps the renderer + GpuMesh cache. Group bucket
+// keys are translated to `"subLevel:name"` strings so main can look
+// up / build hexagon meshes without needing the DAG.
+
+// ─── Spectre vertex data ────────────────────────────────────────────
+const _SQ3_2 = Math.sqrt(3) / 2;
+const spectreVertices = [
+  [0,           0           ],
+  [1,           0           ],
+  [1.5,        -_SQ3_2      ],
+  [1.5 + _SQ3_2, 0.5 - _SQ3_2],
+  [1.5 + _SQ3_2, 1.5 - _SQ3_2],
+  [2.5 + _SQ3_2, 1.5 - _SQ3_2],
+  [3 + _SQ3_2,  1.5         ],
+  [3,           2           ],
+  [3 - _SQ3_2,  1.5         ],
+  [2.5 - _SQ3_2, 1.5 + _SQ3_2],
+  [1.5 - _SQ3_2, 1.5 + _SQ3_2],
+  [0.5 - _SQ3_2, 1.5 + _SQ3_2],
+  [-_SQ3_2,     1.5         ],
+  [0,           1           ],
+];
+const QUAD_INDICES = [3, 5, 7, 11];
+const baseQuad = QUAD_INDICES.map((i) => spectreVertices[i]);
+const _spectreBoundRadius = (() => {
+  let r = 0;
+  for (const v of spectreVertices) {
+    const d = Math.hypot(v[0], v[1]);
+    if (d > r) r = d;
+  }
+  return r;
+})();
+
+// ─── Transform math (rotation in 30° steps + optional mirror + translate) ──
+const _COS = new Float64Array(12);
+const _SIN = new Float64Array(12);
+for (let k = 0; k < 12; k++) {
+  _COS[k] = Math.cos(k * Math.PI / 6);
+  _SIN[k] = Math.sin(k * Math.PI / 6);
+}
+const txIdentity = { rot: 0, mirror: 0, t: [0, 0] };
+
+function txApply(T, p) {
+  const x = p[0];
+  const y = T.mirror ? -p[1] : p[1];
+  const c = _COS[T.rot], s = _SIN[T.rot];
+  return [c * x - s * y + T.t[0], s * x + c * y + T.t[1]];
+}
+function txApplyLinear(T, p) {
+  const x = p[0];
+  const y = T.mirror ? -p[1] : p[1];
+  const c = _COS[T.rot], s = _SIN[T.rot];
+  return [c * x - s * y, s * x + c * y];
+}
+function txCompose(T1, T2) {
+  const sign = T1.mirror ? -1 : 1;
+  const rot = (((T1.rot + sign * T2.rot) % 12) + 12) % 12;
+  const mirror = (T1.mirror ^ T2.mirror);
+  const lin = txApplyLinear(T1, T2.t);
+  return { rot, mirror, t: [lin[0] + T1.t[0], lin[1] + T1.t[1]] };
+}
+function txTranslate(t) { return { rot: 0, mirror: 0, t }; }
+function txRotate(k) { return { rot: ((k % 12) + 12) % 12, mirror: 0, t: [0, 0] }; }
+function txInverse(T) {
+  if (T.mirror) {
+    const c = _COS[T.rot], s = _SIN[T.rot];
+    const tx = T.t[0], ty = -T.t[1];
+    const rx = c * tx - s * ty;
+    const ry = s * tx + c * ty;
+    return { rot: T.rot, mirror: 1, t: [-rx, -ry] };
+  } else {
+    const invRot = ((-T.rot % 12) + 12) % 12;
+    const ic = _COS[invRot], is = _SIN[invRot];
+    const rx = ic * T.t[0] - is * T.t[1];
+    const ry = is * T.t[0] + ic * T.t[1];
+    return { rot: invRot, mirror: 0, t: [-rx, -ry] };
+  }
+}
+
+// ─── Substitution data ──────────────────────────────────────────────
+const TILE_NAMES = ["Gamma", "Delta", "Theta", "Lambda", "Xi", "Pi", "Sigma", "Phi", "Psi"];
+
+const transformationRules = [
+  [ 2, 3, 1],
+  [ 0, 2, 0],
+  [ 2, 3, 1],
+  [ 2, 3, 1],
+  [ 0, 2, 0],
+  [ 2, 3, 1],
+  [-4, 3, 3],
+];
+
+const superRules = {
+  Gamma:  ["Pi",  "Delta", null,  "Theta", "Sigma", "Xi",  "Phi",    "Gamma"],
+  Delta:  ["Xi",  "Delta", "Xi",  "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+  Theta:  ["Psi", "Delta", "Pi",  "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+  Lambda: ["Psi", "Delta", "Xi",  "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+  Xi:     ["Psi", "Delta", "Pi",  "Phi",   "Sigma", "Psi", "Phi",    "Gamma"],
+  Pi:     ["Psi", "Delta", "Xi",  "Phi",   "Sigma", "Psi", "Phi",    "Gamma"],
+  Sigma:  ["Xi",  "Delta", "Xi",  "Phi",   "Sigma", "Pi",  "Lambda", "Gamma"],
+  Phi:    ["Psi", "Delta", "Psi", "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+  Psi:    ["Psi", "Delta", "Psi", "Phi",   "Sigma", "Psi", "Phi",    "Gamma"],
+};
+
+// ─── DAG construction ───────────────────────────────────────────────
+function buildSpectreBase() {
+  const cluster = {};
+  for (const label of TILE_NAMES) {
+    if (label !== "Gamma") {
+      cluster[label] = { kind: "leaf", label, quad: baseQuad };
+    }
+  }
+  cluster.Gamma = {
+    kind: "meta",
+    name: "Gamma",
+    quad: baseQuad,
+    geometries: [
+      { child: { kind: "leaf", label: "Gamma1", quad: baseQuad }, transform: txIdentity },
+      { child: { kind: "leaf", label: "Gamma2", quad: baseQuad },
+        transform: txCompose(txTranslate(spectreVertices[8]), txRotate(1)) },
+    ],
+  };
+  return cluster;
+}
+
+function buildSupertiles(prev) {
+  const quad = prev.Delta.quad;
+  const transformations = [txIdentity];
+  let totalRot = 0;
+  let rotation = txIdentity;
+  let rotatedQuad = quad;
+  for (const [deltaRot, fromIdx, toIdx] of transformationRules) {
+    if (deltaRot !== 0) {
+      totalRot = (((totalRot + deltaRot) % 12) + 12) % 12;
+      rotation = txRotate(totalRot);
+      rotatedQuad = quad.map((p) => txApplyLinear(rotation, p));
+    }
+    const target = txApply(transformations[transformations.length - 1], quad[fromIdx]);
+    const source = rotatedQuad[toIdx];
+    const delta = [target[0] - source[0], target[1] - source[1]];
+    transformations.push({ rot: rotation.rot, mirror: 0, t: delta });
+  }
+  const R = { rot: 6, mirror: 1, t: [0, 0] };
+  const finalTransforms = transformations.map((T) => txCompose(R, T));
+  const superQuad = [
+    txApply(finalTransforms[6], quad[2]),
+    txApply(finalTransforms[5], quad[1]),
+    txApply(finalTransforms[3], quad[2]),
+    txApply(finalTransforms[0], quad[1]),
+  ];
+  const next = {};
+  for (const label of TILE_NAMES) {
+    const subs = superRules[label];
+    const geometries = [];
+    for (let i = 0; i < subs.length; i++) {
+      const sub = subs[i];
+      if (sub === null) continue;
+      geometries.push({ child: prev[sub], transform: finalTransforms[i] });
+    }
+    next[label] = { kind: "meta", name: label, quad: superQuad, geometries };
+  }
+  return next;
+}
+
+function countLeaves(mt) {
+  if (mt.kind === "leaf") return 1;
+  let n = 0;
+  for (const { child } of mt.geometries) n += countLeaves(child);
+  return n;
+}
+
+// ─── Attach cached metrics (memoized via marker fields) ──────────────
+function attachRadii(mt) {
+  if (mt._localRadius != null) return mt._localRadius;
+  if (mt.kind === "leaf") { mt._localRadius = _spectreBoundRadius; return _spectreBoundRadius; }
+  let r = 0;
+  for (const { child, transform } of mt.geometries) {
+    const cr = attachRadii(child);
+    const d = Math.hypot(transform.t[0], transform.t[1]);
+    if (d + cr > r) r = d + cr;
+  }
+  mt._localRadius = r;
+  return r;
+}
+
+function attachCentroidBounds(mt) {
+  if (mt._cBound != null) return;
+  if (mt.kind === "leaf") {
+    let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
+    for (const v of spectreVertices) {
+      if (v[0] < mnx) mnx = v[0]; if (v[0] > mxx) mxx = v[0];
+      if (v[1] < mny) mny = v[1]; if (v[1] > mxy) mxy = v[1];
+    }
+    const cx = (mnx + mxx) / 2, cy = (mny + mxy) / 2;
+    let r = 0;
+    for (const v of spectreVertices) {
+      const d = Math.hypot(v[0] - cx, v[1] - cy);
+      if (d > r) r = d;
+    }
+    mt._cCx = cx; mt._cCy = cy; mt._cBound = r;
+    return;
+  }
+  const childCx = [], childCy = [], childCr = [];
+  let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
+  for (const { child, transform } of mt.geometries) {
+    attachCentroidBounds(child);
+    let lcx = child._cCx;
+    let lcy = child._cCy;
+    const lcr = child._cBound;
+    if (transform.mirror) lcy = -lcy;
+    const cs = _COS[transform.rot], sn = _SIN[transform.rot];
+    const cx = cs * lcx - sn * lcy + transform.t[0];
+    const cy = sn * lcx + cs * lcy + transform.t[1];
+    childCx.push(cx); childCy.push(cy); childCr.push(lcr);
+    if (cx - lcr < mnx) mnx = cx - lcr;
+    if (cx + lcr > mxx) mxx = cx + lcr;
+    if (cy - lcr < mny) mny = cy - lcr;
+    if (cy + lcr > mxy) mxy = cy + lcr;
+  }
+  const cx = (mnx + mxx) / 2, cy = (mny + mxy) / 2;
+  let r = 0;
+  for (let i = 0; i < childCx.length; i++) {
+    const d = Math.hypot(childCx[i] - cx, childCy[i] - cy) + childCr[i];
+    if (d > r) r = d;
+  }
+  mt._cCx = cx; mt._cCy = cy; mt._cBound = r;
+}
+
+function attachSubLevels(mt) {
+  if (mt._subLevel != null) return mt._subLevel;
+  if (mt.kind === "leaf") { mt._subLevel = 0; return 0; }
+  let maxL = 0;
+  for (const { child } of mt.geometries) {
+    const cl = attachSubLevels(child);
+    if (cl > maxL) maxL = cl;
+  }
+  mt._subLevel = maxL + 1;
+  return maxL + 1;
+}
+
+// Per-metatile colour log-scale: how many factors of `_INFLATION`
+// the cell's bounding radius is bigger than a single leaf's. Used
+// in place of the integer `_subLevel` for the colour-blend kernel
+// — _subLevel is structural (Γ at sub-level 1 is the mystic two-
+// leaf meta), but Γ's actual visual scale is ~0.43, not 1, because
+// two overlapping leaves only marginally exceed one leaf's radius.
+// Float-indexed kernel evaluation places Γ closer to its true
+// visual scale, so the blend doesn't artificially treat it as a
+// full level above its leaf neighbours.
+// Inflation factor matches `_INFLATION` defined later in the walker
+// section. Hardcoded here because attachColorLogScale runs at
+// module-init time, before that const is bound.
+const _LOG_INFLATION = Math.log(2.5);
+function attachColorLogScale(mt) {
+  if (mt._colorLogScale != null) return;
+  mt._colorLogScale = Math.log(mt._localRadius / _spectreBoundRadius) / _LOG_INFLATION;
+  if (mt.kind === "meta") {
+    for (const { child } of mt.geometries) attachColorLogScale(child);
+  }
+}
+
+// ─── Initial DAG and walker state ───────────────────────────────────
+const BASE_DEPTH = 4;
+const baseCluster = (() => {
+  let c = buildSpectreBase();
+  for (let i = 0; i < BASE_DEPTH; i++) c = buildSupertiles(c);
+  return c;
+})();
+const rootMeta = baseCluster.Delta;
+attachRadii(rootMeta);
+attachSubLevels(rootMeta);
+attachCentroidBounds(rootMeta);
+attachColorLogScale(rootMeta);
+
+const walkerState = {
+  currentRoot: baseCluster.Delta,
+  currentRootTransform: txIdentity,
+  currentBaseRecord: baseCluster,
+  extensionLevel: 0,
+};
+
+// rootBounds for the main thread's initial fit. Computed by walking
+// every leaf in the unextended root cluster and unioning leaf-position
+// bounding boxes (padded by _spectreBoundRadius in the leaf's local
+// frame, which is rotation-invariant).
+const rootBounds = (() => {
+  let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
+  const STK = BASE_DEPTH + 4;
+  const stRot = new Uint8Array(STK);
+  const stMir = new Uint8Array(STK);
+  const stTx = new Float64Array(STK);
+  const stTy = new Float64Array(STK);
+  function recurse(mt, d) {
+    if (mt.kind === "leaf") {
+      const tx = stTx[d], ty = stTy[d];
+      const m = _spectreBoundRadius;
+      if (tx - m < mnx) mnx = tx - m;
+      if (tx + m > mxx) mxx = tx + m;
+      if (ty - m < mny) mny = ty - m;
+      if (ty + m > mxy) mxy = ty + m;
+      return;
+    }
+    const pRot = stRot[d], pMir = stMir[d];
+    const pTx = stTx[d], pTy = stTy[d];
+    const pc = _COS[pRot], ps = _SIN[pRot];
+    const d1 = d + 1;
+    for (const { child, transform: T2 } of mt.geometries) {
+      let cx = T2.t[0], cy = T2.t[1];
+      if (pMir) cy = -cy;
+      stTx[d1] = pc * cx - ps * cy + pTx;
+      stTy[d1] = ps * cx + pc * cy + pTy;
+      const rDiff = pMir ? -T2.rot : T2.rot;
+      stRot[d1] = (pRot + rDiff + 12) % 12;
+      stMir[d1] = (pMir ^ T2.mirror);
+      recurse(child, d1);
+    }
+  }
+  stRot[0] = 0; stMir[0] = 0; stTx[0] = 0; stTy[0] = 0;
+  recurse(rootMeta, 0);
+  return { minX: mnx, minY: mny, maxX: mxx, maxY: mxy };
+})();
+
+// ─── Tree extension ────────────────────────────────────────────────
+const _PARENT_OPTIONS = (() => {
+  const out = {};
+  for (const t of TILE_NAMES) out[t] = [];
+  for (const parent of TILE_NAMES) {
+    const subs = superRules[parent];
+    for (let slot = 0; slot < subs.length; slot++) {
+      const c = subs[slot];
+      if (c !== null) out[c].push([parent, slot]);
+    }
+  }
+  return out;
+})();
+
+function extendRootUpward() {
+  const nextRecord = buildSupertiles(walkerState.currentBaseRecord);
+  const root = walkerState.currentRoot;
+  if (root.kind !== 'meta') throw new Error('root must be a meta tile');
+  const currentType = root.name;
+  const opts = _PARENT_OPTIONS[currentType];
+  const [parentType, slot] = opts[walkerState.extensionLevel % opts.length];
+  const newRoot = nextRecord[parentType];
+  attachRadii(newRoot);
+  attachSubLevels(newRoot);
+  attachCentroidBounds(newRoot);
+  attachColorLogScale(newRoot);
+  const subs = superRules[parentType];
+  let geomIdx = 0;
+  for (let s = 0; s < slot; s++) if (subs[s] !== null) geomIdx++;
+  const slot1Transform = newRoot.geometries[geomIdx].transform;
+  walkerState.currentRootTransform = txCompose(
+    walkerState.currentRootTransform,
+    txInverse(slot1Transform),
+  );
+  walkerState.currentRoot = newRoot;
+  walkerState.currentBaseRecord = nextRecord;
+  walkerState.extensionLevel += 1;
+}
+
+function maybeExtend(view) {
+  let safety = 64;
+  while (safety-- > 0) {
+    const root = walkerState.currentRoot;
+    const T = walkerState.currentRootTransform;
+    const lcx = root._cCx;
+    const lcy = root._cCy;
+    const localY = T.mirror ? -lcy : lcy;
+    const c = _COS[T.rot], s = _SIN[T.rot];
+    const cwx = c * lcx - s * localY + T.t[0];
+    const cwy = s * lcx + c * localY + T.t[1];
+    const cBound = root._cBound;
+    const halfW = view.pixelWidth / (2 * view.pixelScale);
+    const halfH = view.pixelHeight / (2 * view.pixelScale);
+    const padW = (view.cullPadPx ?? 0) / view.pixelScale;
+    const dx = Math.abs(view.centerX - cwx) + halfW + padW;
+    const dy = Math.abs(view.centerY - cwy) + halfH + padW;
+    const distToCorner = Math.hypot(dx, dy);
+    if (distToCorner <= 0.5 * cBound) return;
+    extendRootUpward();
+  }
+}
+
+// ─── Find-distant-match (DAG-driven view search) ───────────────────
+// Mulberry32-style seeded RNG. Used to randomly descend into the DAG
+// looking for a leaf whose K-suffix matches the source — a stable
+// seed (derived from the source coords) keeps results reproducible
+// across button presses on the same view.
+function _makeSeededRng(seed) {
+  let state = (seed >>> 0) || 1;
+  return () => {
+    state = (state + 0x6D2B79F5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function _findLeafNear(targetX, targetY) {
+  let mt = walkerState.currentRoot;
+  let tx = walkerState.currentRootTransform;
+  if (mt.kind !== 'meta') return null;
+  const path = [];
+  const types = [mt.name];
+  const rots = [tx.rot];
+  const mirs = [tx.mirror];
+  while (mt.kind === 'meta') {
+    let bestI = -1, bestD = Infinity;
+    for (let i = 0; i < mt.geometries.length; i++) {
+      const geom = mt.geometries[i];
+      const child = geom.child;
+      const childTx = txCompose(tx, geom.transform);
+      const cx = child._cCx ?? 0;
+      const cy = child._cCy ?? 0;
+      const wc = txApply(childTx, [cx, cy]);
+      const d = Math.hypot(wc[0] - targetX, wc[1] - targetY);
+      if (d < bestD) { bestD = d; bestI = i; }
+    }
+    if (bestI < 0) break;
+    path.push(bestI);
+    const geom = mt.geometries[bestI];
+    tx = txCompose(tx, geom.transform);
+    mt = geom.child;
+    if (mt.kind === 'meta') {
+      types.push(mt.name);
+      rots.push(tx.rot);
+      mirs.push(tx.mirror);
+    }
+  }
+  const lcx = mt._cCx ?? 0;
+  const lcy = mt._cCy ?? 0;
+  const wc = txApply(tx, [lcx, lcy]);
+  return { path, types, rots, mirs, leafCx: wc[0], leafCy: wc[1] };
+}
+
+function _findMatchingLeaf(args) {
+  const root = walkerState.currentRoot;
+  const rootTransform = walkerState.currentRootTransform;
+  if (root.kind !== 'meta') return null;
+  const rootSubLevel = root._subLevel;
+  const stepsToParent = rootSubLevel - args.parentSubLevel;
+  if (stepsToParent < 0) return null;
+  const seed = ((Math.floor(args.sourceX) ^ Math.floor(args.sourceY)) >>> 0) || 1;
+  const rng = _makeSeededRng(seed);
+  // 1M default. The random search succeeds at probability roughly
+  // (1 / 8^stepsToParent) × suffix/rotation match fraction, so when
+  // stepsToParent ≥ 5 a few hundred-thousand attempts are usually
+  // enough; deeper searches need more headroom. Worst-case 1M
+  // attempts is ~50 ms on the worker — short enough that a UI block
+  // is acceptable for an explicit user click.
+  const max = args.maxAttempts ?? 1000000;
+  for (let attempt = 0; attempt < max; attempt++) {
+    let mt = root;
+    let tx = rootTransform;
+    let ok = true;
+    for (let d = 0; d < stepsToParent; d++) {
+      if (mt.kind !== 'meta') { ok = false; break; }
+      const i = Math.floor(rng() * mt.geometries.length);
+      const geom = mt.geometries[i];
+      tx = txCompose(tx, geom.transform);
+      mt = geom.child;
+    }
+    if (!ok || mt.kind !== 'meta' || mt.name !== args.parentType) continue;
+    if (tx.rot !== args.parentRot || tx.mirror !== args.parentMir) continue;
+    let suffOk = true;
+    for (const i of args.suffix) {
+      if (mt.kind !== 'meta' || i >= mt.geometries.length) { suffOk = false; break; }
+      const geom = mt.geometries[i];
+      tx = txCompose(tx, geom.transform);
+      mt = geom.child;
+    }
+    if (!suffOk || mt.kind !== 'leaf') continue;
+    const lcx = mt._cCx ?? 0;
+    const lcy = mt._cCy ?? 0;
+    const c = txApply(tx, [lcx, lcy]);
+    const dx = c[0] - args.sourceX, dy = c[1] - args.sourceY;
+    if (Math.hypot(dx, dy) < args.minDistance) continue;
+    return { centerX: c[0], centerY: c[1], attempts: attempt + 1 };
+  }
+  return null;
+}
+
+// ─── Color state (mirrored from main thread) ────────────────────────
+const paletteState = {
+  rgb: {},
+};
+function colorForLevelType(_level, label) {
+  return paletteState.rgb[label]
+      ?? paletteState.rgb[_typeForLabel(label)]
+      ?? [0.5, 0.5, 0.5];
+}
+function _typeForLabel(label) {
+  if (label === "Gamma1" || label === "Gamma2") return "Gamma";
+  return label;
+}
+const colorBlendState = { sigma: 4.0, offset: 0.0, leafNoise: 0.0 };
+
+// ─── Walker ─────────────────────────────────────────────────────────
+const AGG_PX = 25;
+const _LOOSE_RADIUS_FACTOR = 1.55;
+const _INFLATION = 2.5;
+const _LEVEL0_PIXEL_SCALE = AGG_PX / (2 * _spectreBoundRadius);
+function viewLevelFor(pixelScale) {
+  if (pixelScale <= 0) return 0;
+  return -Math.log(pixelScale / _LEVEL0_PIXEL_SCALE) / Math.log(_INFLATION);
+}
+
+function _newBucket(key, initCap) {
+  const capacity = Math.max(16, initCap);
+  const data = new ArrayBuffer(capacity * 16);
+  return {
+    key,
+    data,
+    f32: new Float32Array(data),
+    i16: new Int16Array(data),
+    u8: new Uint8Array(data),
+    count: 0,
+    capacity,
+  };
+}
+
+function _growBucket(b, needed) {
+  if (needed <= b.capacity) return;
+  const newCap = Math.max(needed, b.capacity * 2);
+  const newData = new ArrayBuffer(newCap * 16);
+  new Uint8Array(newData).set(b.u8.subarray(0, b.count * 16));
+  b.data = newData;
+  b.f32 = new Float32Array(newData);
+  b.i16 = new Int16Array(newData);
+  b.u8 = new Uint8Array(newData);
+  b.capacity = newCap;
+}
+
+function makeWalker(initialLeafCap) {
+  const STK = 64;
+  const stRot = new Uint8Array(STK);
+  const stMir = new Uint8Array(STK);
+  const stTx = new Float64Array(STK);
+  const stTy = new Float64Array(STK);
+  const stColR = new Float64Array(STK);
+  const stColG = new Float64Array(STK);
+  const stColB = new Float64Array(STK);
+  // Float colour log-scales pushed onto the ancestor stack. Replaces
+  // the old integer subLevel stack (`stSubL`) for kernel evaluation
+  // — Γ at sub-level 1 is at colour log-scale ~0.43, not 1.
+  const stColLogScale = new Float64Array(STK);
+  let ancDepth = 0;
+  let vMnX = -Infinity, vMxX = Infinity, vMnY = -Infinity, vMxY = Infinity;
+  let pixelScale = 1;
+  let aggPixelScale = 1;
+  let viewLevel = 0;
+  // Pre-walk-computed thresholds in `r`-space (mt._localRadius units).
+  // We compare `r` directly against these instead of computing
+  // `pixelExtent = 2 * r * aggPixelScale` per cell — saves a
+  // multiply on the hottest line in the walker.
+  let aggThreshR = Infinity, upperFadeR = Infinity, lowerFadeR = Infinity;
+  let aggThreshHysteresis = Infinity; // = upperFadeR - aggThreshR, precomputed
+  let lowerFadeHysteresis = Infinity; // = aggThreshR - lowerFadeR
+  let leafNoise = 0;
+  // Per-walk colour-kernel parameters: Gaussian centred on
+  // `viewLevel + colorBlendState.offset` in log-scale space, with
+  // stddev = colorBlendState.sigma. weight(L) = exp((L − kCenter)² *
+  // _negInvTwoSigSq). Set in walk() before each recurse pass.
+  let _kCenter = 0;
+  let _negInvTwoSigSq = -1 / 32;  // = -1/(2σ²) for σ = 4
+  const pathStack = new Uint8Array(STK);
+  const buckets = new Map();
+  buckets.set(null, _newBucket(null, initialLeafCap));
+  // Last-bucket cache. `emit` is the hottest function and Map.get is
+  // ~3x slower than a single identity check; consecutive emits are
+  // overwhelmingly to the same bucket (same metatile via DAG sharing,
+  // or the leaf bucket repeating across siblings), so this saves a
+  // Map lookup on the vast majority of calls.
+  let _lastBucket = buckets.get(null);
+  let _lastBucketKey = null;
+
+  function emit(bucketKey, cellCol, d, cellColorLogScale, alpha) {
+    if (alpha <= 0) return;
+    let b;
+    if (bucketKey === _lastBucketKey) {
+      b = _lastBucket;
+    } else {
+      b = buckets.get(bucketKey);
+      if (!b) { b = _newBucket(bucketKey, 64); buckets.set(bucketKey, b); }
+      _lastBucketKey = bucketKey;
+      _lastBucket = b;
+    }
+    if (b.count >= b.capacity) _growBucket(b, b.count + 1);
+    const i = b.count;
+    const off = i * 16;
+    b.f32[i * 4 + 0] = stTx[d];
+    b.f32[i * 4 + 1] = stTy[d];
+    // _COS/_SIN are exact 30°-multiple values in [-1, 1], so c*32767
+    // is in [-32767, 32767] with no overflow risk — drop the clamps.
+    // Math.round handles the negative-half rounding correctly.
+    const rot = stRot[d];
+    b.i16[i * 8 + 4] = Math.round(_COS[rot] * 32767);
+    b.i16[i * 8 + 5] = Math.round(_SIN[rot] * 32767);
+
+    // Multi-level Gaussian blend over ABSOLUTE colour log-scales.
+    // Each cell emits with weight exp((Lcell − kCenter)² *
+    // negInvTwoSigSq), and each ancestor at log-scale Lanc
+    // contributes with the same kernel evaluated at Lanc. Both the
+    // cell's and the ancestors' log-scales are mt._colorLogScale —
+    // the cluster's true visual size relative to a leaf, not its
+    // structural _subLevel. So Γ at log-scale ~0.43 sits between
+    // its leaf neighbours (log-scale 0) and its parents (log-scale
+    // 1), instead of being lumped with the latter.
+    //
+    // The kernel centre is `viewLevel + offset`, anchored to
+    // pixelScale only — so changing the agg-px threshold (which
+    // moves WHICH cells emit, not which log-scales exist) has no
+    // effect on the rendered colour at any world position.
+    let dl = cellColorLogScale - _kCenter;
+    let w = Math.exp(dl * dl * _negInvTwoSigSq);
+    let total = w, R = w * cellCol[0], G = w * cellCol[1], B = w * cellCol[2];
+    for (let k = 0; k < ancDepth; k++) {
+      dl = stColLogScale[k] - _kCenter;
+      w = Math.exp(dl * dl * _negInvTwoSigSq);
+      total += w;
+      R += w * stColR[k]; G += w * stColG[k]; B += w * stColB[k];
+    }
+    const inv = 1 / total;
+    let normR = R * inv, normG = G * inv, normB = B * inv;
+
+    if (bucketKey === null && leafNoise > 0) {
+      const K_NOISE = 6;
+      const startD = d - K_NOISE + 1 > 1 ? d - K_NOISE + 1 : 1;
+      let h = 0x9e3779b1 | 0;
+      for (let p = startD; p <= d; p++) {
+        h = Math.imul(h ^ pathStack[p], 0x9e3779b1);
+      }
+      h = (h ^ (h >>> 16)) | 0;
+      h = Math.imul(h, 0x85ebca6b);
+      h = (h ^ (h >>> 13)) | 0;
+      h = Math.imul(h, 0xc2b2ae35);
+      h = (h ^ (h >>> 16)) | 0;
+      const j = ((h & 0xFF) - 128) * (leafNoise / 128);
+      normR += j;
+      normG += j;
+      normB += j;
+    }
+
+    // Color quantisation: clamp because `noise` and rounding can
+    // push values slightly past [0, 1].
+    const a127 = Math.round(alpha * 127);
+    let qR = (normR * 255 + 0.5) | 0; if (qR < 0) qR = 0; else if (qR > 255) qR = 255;
+    let qG = (normG * 255 + 0.5) | 0; if (qG < 0) qG = 0; else if (qG > 255) qG = 255;
+    let qB = (normB * 255 + 0.5) | 0; if (qB < 0) qB = 0; else if (qB > 255) qB = 255;
+    b.u8[off + 12] = qR;
+    b.u8[off + 13] = qG;
+    b.u8[off + 14] = qB;
+    b.u8[off + 15] = (stMir[d] ? 128 : 0) | (a127 < 0 ? 0 : a127 > 127 ? 127 : a127);
+    b.count = i + 1;
+  }
+
+  function recurse(mt, d, alphaIn, allowFadeOut) {
+    if (alphaIn <= 0) return;
+    const r = mt._localRadius;
+    const cx = stTx[d], cy = stTy[d];
+    if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
+    if (mt.kind === "leaf") {
+      const leafCol = colorForLevelType(0, mt.label);
+      // Leaves are by construction at colour log-scale 0
+      // (_localRadius == _spectreBoundRadius).
+      emit(null, leafCol, d, 0, alphaIn);
+      return;
+    }
+
+    const myCls = mt._colorLogScale;
+    const myCol = colorForLevelType(mt._subLevel, mt.name);
+
+    // Branch on `r` thresholds (precomputed once per walk) instead of
+    // recomputing pixelExtent per cell. Three regimes:
+    //   r < lowerFadeR : full aggregate, no children.
+    //   r < aggThreshR : full aggregate + fading-out children.
+    //   r < upperFadeR : fading-in parent + full-alpha children.
+    //   r ≥ upperFadeR : no parent, full-alpha children only.
+    if (r < aggThreshR) {
+      // Full aggregate emit.
+      emit(mt, myCol, d, myCls, alphaIn);
+      // Below lowerFadeR: no children at all.
+      if (r < lowerFadeR || !allowFadeOut) return;
+      // Fade-out children band.
+      const u = (r - lowerFadeR) / lowerFadeHysteresis;
+      const childAlpha = alphaIn * (u * u * (3 - 2 * u));
+      stColR[ancDepth] = myCol[0];
+      stColG[ancDepth] = myCol[1];
+      stColB[ancDepth] = myCol[2];
+      stColLogScale[ancDepth] = myCls;
+      ancDepth++;
+      _recurseChildren(mt, d, childAlpha, false);
+      ancDepth--;
+      return;
+    }
+
+    if (r < upperFadeR) {
+      // Fading-in parent + full-alpha children.
+      const u = (upperFadeR - r) / aggThreshHysteresis;
+      const parentFactor = u * u * (3 - 2 * u);
+      emit(mt, myCol, d, myCls, alphaIn * parentFactor);
+    }
+
+    // Full-detail children.
+    stColR[ancDepth] = myCol[0];
+    stColG[ancDepth] = myCol[1];
+    stColB[ancDepth] = myCol[2];
+    stColLogScale[ancDepth] = myCls;
+    ancDepth++;
+    _recurseChildren(mt, d, alphaIn, allowFadeOut);
+    ancDepth--;
+  }
+
+  function _recurseChildren(mt, d, childAlpha, childAllowFadeOut) {
+    const pRot = stRot[d], pMir = stMir[d];
+    const pTx = stTx[d], pTy = stTy[d];
+    const pc = _COS[pRot], ps = _SIN[pRot];
+    const d1 = d + 1;
+    const geoms = mt.geometries;
+    const n = geoms.length;
+    for (let gi = 0; gi < n; gi++) {
+      const g = geoms[gi];
+      const T2 = g.transform;
+      let ccx = T2.t[0], ccy = T2.t[1];
+      if (pMir) ccy = -ccy;
+      stTx[d1] = pc * ccx - ps * ccy + pTx;
+      stTy[d1] = ps * ccx + pc * ccy + pTy;
+      const rDiff = pMir ? -T2.rot : T2.rot;
+      stRot[d1] = (pRot + rDiff + 12) % 12;
+      stMir[d1] = (pMir ^ T2.mirror);
+      pathStack[d1] = gi;
+      recurse(g.child, d1, childAlpha, childAllowFadeOut);
+    }
+  }
+
+  return function walk(rootMetaArg, rootTransform, view) {
+    const halfW = view.pixelWidth / (2 * view.pixelScale);
+    const halfH = view.pixelHeight / (2 * view.pixelScale);
+    const m = _spectreBoundRadius;
+    const padPx = view.cullPadPx ?? 0;
+    const padWorld = padPx / view.pixelScale;
+    vMnX = -halfW - m - padWorld;
+    vMxX = halfW + m + padWorld;
+    vMnY = -halfH - m - padWorld;
+    vMxY = halfH + m + padWorld;
+    pixelScale = view.pixelScale;
+    aggPixelScale = view.aggPixelScale ?? view.pixelScale;
+    viewLevel = viewLevelFor(aggPixelScale);
+    // Per-view aggregation threshold (px). Defaults to AGG_PX; main
+    // sends a smaller value for high-quality renders or a larger
+    // value for fast preview.
+    const aggPx = view.aggPx ?? AGG_PX;
+    // Precompute per-walk r-thresholds so recurse() can compare
+    // mt._localRadius directly without recomputing pixelExtent.
+    const aggThresh = aggPx * _LOOSE_RADIUS_FACTOR;
+    const upperFadeBound = aggThresh * 1.5;
+    const lowerFadeBound = aggThresh / 3;
+    const inv2agg = 1 / (2 * aggPixelScale);
+    aggThreshR  = aggThresh      * inv2agg;
+    upperFadeR  = upperFadeBound * inv2agg;
+    lowerFadeR  = lowerFadeBound * inv2agg;
+    aggThreshHysteresis = upperFadeR - aggThreshR;
+    lowerFadeHysteresis = aggThreshR - lowerFadeR;
+    leafNoise = colorBlendState.leafNoise;
+    const _sigma = colorBlendState.sigma;
+    // Kernel parameters captured into closure-level vars so emit()
+    // can evaluate exp(dl² * negInvTwoSigSq) inline without per-call
+    // closure access to colorBlendState. Centre is anchored to
+    // viewLevel + offset; sigma sets the kernel width in log-scale
+    // space. Eliminating the integer-indexed weightTable lets the
+    // cell and ancestor log-scales be float-valued (Γ at ~0.43,
+    // etc.).
+    _kCenter = viewLevel + colorBlendState.offset;
+    _negInvTwoSigSq = -1 / (2 * _sigma * _sigma);
+    ancDepth = 0;
+    _lastBucketKey = -1; // sentinel: no bucket cached for this walk
+    _lastBucket = null;
+
+    for (const b of buckets.values()) b.count = 0;
+
+    stRot[0] = rootTransform.rot;
+    stMir[0] = rootTransform.mirror;
+    stTx[0] = rootTransform.t[0] - view.centerX;
+    stTy[0] = rootTransform.t[1] - view.centerY;
+    recurse(rootMetaArg, 0, 1.0, true);
+
+    let totalCount = 0;
+    for (const b of buckets.values()) totalCount += b.count;
+    // Fresh ArrayBuffer per walk so the result can be transferred to
+    // main without invalidating worker-internal state.
+    const outData = new ArrayBuffer(Math.max(1, totalCount) * 16);
+    const outU8 = new Uint8Array(outData);
+    const groups = [];
+    let off = 0;
+    const aggBuckets = [];
+    for (const b of buckets.values()) {
+      if (b.key === null) continue;
+      if (b.count === 0) continue;
+      aggBuckets.push(b);
+    }
+    aggBuckets.sort((a, b) => (b.key._subLevel ?? 0) - (a.key._subLevel ?? 0));
+    for (const b of aggBuckets) {
+      outU8.set(b.u8.subarray(0, b.count * 16), off * 16);
+      groups.push({ bucket: b, instanceOffset: off, instanceCount: b.count });
+      off += b.count;
+    }
+    const leafBucket = buckets.get(null);
+    if (leafBucket.count > 0) {
+      outU8.set(leafBucket.u8.subarray(0, leafBucket.count * 16), off * 16);
+      groups.push({ bucket: leafBucket, instanceOffset: off, instanceCount: leafBucket.count });
+      off += leafBucket.count;
+    }
+    return { data: outData, totalCount, groups };
+  };
+}
+
+const walker = makeWalker(countLeaves(rootMeta));
+
+// ─── Message protocol ──────────────────────────────────────────────
+//
+// Concurrency model. The worker is single-threaded, so at most one
+// walk runs at a time. Each `view` message just replaces `pendingView`
+// — it does NOT immediately walk. A pending walk is scheduled via
+// setTimeout(0); meanwhile additional view messages can arrive and
+// overwrite `pendingView`. When the scheduled processNext finally
+// runs, it picks up the LATEST view and discards intermediate ones.
+// So walks happen at roughly (walk_time)⁻¹ per second, regardless of
+// how many view updates main fires; a flurry of pan events between
+// walks coalesces into one re-walk on the most recent view.
+//
+let pendingView = null;
+let scheduled = false;
+let lastView = null;
+let paletteDirty = false;
+let colorBlendDirty = false;
+
+function schedule() {
+  if (scheduled) return;
+  scheduled = true;
+  setTimeout(processNext, 0);
+}
+
+function processNext() {
+  scheduled = false;
+  if (!pendingView) return;
+  const view = pendingView;
+  pendingView = null;
+  lastView = view;
+  // Always walk (and always post a result). A "skip identical view"
+  // optimisation here would silently drop walks that the pool path
+  // is awaiting on a specific seq — e.g., consecutive video sub-frames
+  // that clamp to the same trajectory point. Walks are cheap (a few
+  // ms at hexagon-aggregate detail), and `awaitWorkerResultForSeq`
+  // requires every dispatched view to elicit a matching result.
+  paletteDirty = false;
+  colorBlendDirty = false;
+  doWalk(view);
+  if (pendingView) schedule();
+}
+
+let _walkCount = 0;
+function doWalk(view) {
+  _walkCount++;
+  if (_walkCount <= 3 || _walkCount % 100 === 0) {
+    // eslint-disable-next-line no-console
+    console.log('[worker] doWalk #', _walkCount, 'seq=', view.seq, 'ext=', walkerState.extensionLevel);
+  }
+  try {
+    maybeExtend(view);
+    const result = walker(walkerState.currentRoot, walkerState.currentRootTransform, view);
+    return _postWalkResult(result, view);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[worker] doWalk threw', err);
+    throw err;
+  }
+}
+
+function _postWalkResult(result, view) {
+  // Translate per-bucket MetaTile keys to (subLevel, name) string keys
+  // and embed centroid + radius so main can build hexagon meshes
+  // without needing the DAG.
+  const outGroups = result.groups.map((g) => {
+    if (g.bucket.key === null) {
+      return {
+        key: null,
+        instanceOffset: g.instanceOffset,
+        instanceCount: g.instanceCount,
+      };
+    }
+    const mt = g.bucket.key;
+    return {
+      key: mt._subLevel + ':' + mt.name,
+      cCx: mt._cCx,
+      cCy: mt._cCy,
+      cBound: mt._cBound,
+      instanceOffset: g.instanceOffset,
+      instanceCount: g.instanceCount,
+    };
+  });
+  // Snapshot of hidden tree-state fields that drift with extension.
+  // Main displays these; useful for diagnosing why coloring,
+  // find-distant-match or precision behave differently after a long
+  // zoom session.
+  const root = walkerState.currentRoot;
+  const T = walkerState.currentRootTransform;
+  postMessage({
+    type: 'result',
+    data: result.data,
+    totalCount: result.totalCount,
+    groups: outGroups,
+    instanceCenterX: view.centerX,
+    instanceCenterY: view.centerY,
+    pixelScale: view.pixelScale,
+    extensionLevel: walkerState.extensionLevel,
+    rootName: root.name,
+    rootSubLevel: root._subLevel,
+    rootCBound: root._cBound,
+    rootTxRot: T.rot,
+    rootTxMirror: T.mirror,
+    rootTxTx: T.t[0],
+    rootTxTy: T.t[1],
+    viewSeq: view.seq ?? 0,
+  }, [result.data]);
+}
+
+self.onmessage = (e) => {
+  const m = e.data;
+  if (m.type === 'view') {
+    pendingView = m.view;
+    schedule();
+  } else if (m.type === 'palette') {
+    paletteState.rgb = m.rgb;
+    paletteDirty = true;
+    if (lastView && !pendingView) pendingView = lastView;
+    schedule();
+  } else if (m.type === 'colorBlend') {
+    colorBlendState.sigma = m.sigma;
+    colorBlendState.offset = m.offset;
+    colorBlendState.leafNoise = m.leafNoise;
+    colorBlendDirty = true;
+    if (lastView && !pendingView) pendingView = lastView;
+    schedule();
+  } else if (m.type === 'reset') {
+    // Discard accumulated extension state and snap walkerState back
+    // to the freshly-built baseCluster. Useful when the user wants
+    // to clear the side-effects of a long interactive session:
+    // accumulated extensions affect the multi-level Gaussian colour
+    // blend (more ancestors → different colour averages), the
+    // find-distant-match path (different rootSubLevel changes which
+    // K-suffix levels are reachable), and at extreme depth, fp
+    // precision in the world transforms.
+    walkerState.currentRoot = baseCluster.Delta;
+    walkerState.currentRootTransform = txIdentity;
+    walkerState.currentBaseRecord = baseCluster;
+    walkerState.extensionLevel = 0;
+    postMessage({
+      type: 'resetDone',
+      ackId: m.ackId,
+      rootBounds,
+      extensionLevel: walkerState.extensionLevel,
+    });
+  } else if (m.type === 'extendToLevel') {
+    // Bring this worker's tree to a specific extensionLevel by
+    // calling extendRootUpward sequentially. Used by the
+    // worker-pool-based video export to put every pool worker into
+    // the same DAG state before parallel walks begin — without this,
+    // workers that handle deeper-zoom frames first would extend in a
+    // different order than workers that didn't, and their cluster
+    // shapes around the visible content would diverge.
+    while (walkerState.extensionLevel < (m.level | 0)) {
+      extendRootUpward();
+    }
+    postMessage({
+      type: 'extendDone',
+      ackId: m.ackId,
+      extensionLevel: walkerState.extensionLevel,
+    });
+  } else if (m.type === 'extendForView') {
+    // Run maybeExtend until the cluster covers the supplied view,
+    // then report the achieved level. Main calls this once on a
+    // single pool worker (with the trajectory's most zoomed-out
+    // view) and broadcasts the result via extendToLevel to every
+    // other pool worker. After the broadcast all workers share the
+    // same DAG state.
+    maybeExtend(m.view);
+    postMessage({
+      type: 'extendDone',
+      ackId: m.ackId,
+      extensionLevel: walkerState.extensionLevel,
+    });
+  } else if (m.type === 'findDistantMatch') {
+    // Find a far-away view whose local Spectre pattern matches the
+    // source view's. Two leaves with the same K-suffix (last K
+    // geometry indices in their substitution paths, same metatype
+    // at level K) sit inside identically-substituted level-K
+    // supertiles, so their local environments are byte-identical
+    // out to ~2.45^K world units.
+    //
+    // Headroom: the random search hits when stepsToParent is small
+    // (few branch levels above level-K). If the live cluster is
+    // only just barely deep enough (D == K, stepsToParent = 0),
+    // there's no actual search space — we'd just keep finding the
+    // source itself. Force-extend the root until D ≥ K + δ before
+    // searching, where δ = 3 gives 8^3 = 512 candidate branches —
+    // enough that 1M random attempts have a strong success rate.
+    const TARGET_DELTA = 3;
+    let sourceLeaf = _findLeafNear(m.sourceX, m.sourceY);
+    if (sourceLeaf) {
+      let safety = 16;
+      while (sourceLeaf.path.length < m.K + TARGET_DELTA && safety-- > 0) {
+        extendRootUpward();
+        sourceLeaf = _findLeafNear(m.sourceX, m.sourceY);
+        if (!sourceLeaf) break;
+      }
+    }
+    let result = null;
+    if (sourceLeaf) {
+      const D = sourceLeaf.path.length;
+      if (D >= m.K) {
+        const suffix = sourceLeaf.path.slice(D - m.K);
+        const idx = D - m.K;
+        const root = walkerState.currentRoot;
+        const rootSubLevel = root._subLevel;
+        const parentSubLevel = rootSubLevel - idx;
+        result = _findMatchingLeaf({
+          sourceX: m.sourceX, sourceY: m.sourceY,
+          parentType: sourceLeaf.types[idx],
+          parentRot:  sourceLeaf.rots[idx],
+          parentMir:  sourceLeaf.mirs[idx],
+          parentSubLevel,
+          suffix,
+          minDistance: m.minDistance,
+        });
+      }
+    }
+    postMessage({
+      type: 'findDistantMatchDone',
+      ackId: m.ackId,
+      sourceLeaf, // null if findLeafNear failed
+      result,     // null if findMatchingLeaf failed (or path was shorter than K)
+    });
+  }
+};
+
+// Handshake: tell main the rootBounds (for initial fit) and the
+// starting extensionLevel. Main will follow with a `palette` and
+// `colorBlend` message before its first `view`.
+postMessage({
+  type: 'init',
+  rootBounds,
+  extensionLevel: walkerState.extensionLevel,
+});

--- a/src/notebooks/aperiodic-monotile/infinite-walker-worker.js
+++ b/src/notebooks/aperiodic-monotile/infinite-walker-worker.js
@@ -389,7 +389,17 @@ function maybeExtend(view) {
     const dx = Math.abs(view.centerX - cwx) + halfW + padW;
     const dy = Math.abs(view.centerY - cwy) + halfH + padW;
     const distToCorner = Math.hypot(dx, dy);
-    if (distToCorner <= 0.5 * cBound) return;
+    // Threshold of 0.3 × cBound: requires the viewport corners to
+    // sit well inside the cluster's CENTROID-bounded circle, with
+    // generous safety margin against the cluster's worst-direction
+    // FILLED extent (~0.6–0.7 × cBound for a Spectre supertile).
+    // Each iteration extends the root upward; the cluster's cBound
+    // grows by ~_INFLATION × (≈2.5×) per extension, and each
+    // extension is O(1), so a tighter threshold just means one or
+    // two more extensions for a typical view — well worth it to
+    // eliminate the "blank wedge" on the side of the viewport when
+    // the user pans away from the cluster's centroid.
+    if (distToCorner <= 0.3 * cBound) return;
     extendRootUpward();
   }
 }
@@ -507,7 +517,7 @@ function _typeForLabel(label) {
   if (label === "Gamma1" || label === "Gamma2") return "Gamma";
   return label;
 }
-const colorBlendState = { sigma: 4.0, offset: 0.0, leafNoise: 0.0 };
+const colorBlendState = { sigma: 4.0, offset: 0.0 };
 
 // ─── Walker ─────────────────────────────────────────────────────────
 const AGG_PX = 25;
@@ -570,7 +580,6 @@ function makeWalker(initialLeafCap) {
   let aggThreshR = Infinity, upperFadeR = Infinity, lowerFadeR = Infinity;
   let aggThreshHysteresis = Infinity; // = upperFadeR - aggThreshR, precomputed
   let lowerFadeHysteresis = Infinity; // = aggThreshR - lowerFadeR
-  let leafNoise = 0;
   // Per-walk colour-kernel parameters: Gaussian centred on
   // `viewLevel + colorBlendState.offset` in log-scale space, with
   // stddev = colorBlendState.sigma. weight(L) = exp((L − kCenter)² *
@@ -635,28 +644,10 @@ function makeWalker(initialLeafCap) {
       R += w * stColR[k]; G += w * stColG[k]; B += w * stColB[k];
     }
     const inv = 1 / total;
-    let normR = R * inv, normG = G * inv, normB = B * inv;
+    const normR = R * inv, normG = G * inv, normB = B * inv;
 
-    if (bucketKey === null && leafNoise > 0) {
-      const K_NOISE = 6;
-      const startD = d - K_NOISE + 1 > 1 ? d - K_NOISE + 1 : 1;
-      let h = 0x9e3779b1 | 0;
-      for (let p = startD; p <= d; p++) {
-        h = Math.imul(h ^ pathStack[p], 0x9e3779b1);
-      }
-      h = (h ^ (h >>> 16)) | 0;
-      h = Math.imul(h, 0x85ebca6b);
-      h = (h ^ (h >>> 13)) | 0;
-      h = Math.imul(h, 0xc2b2ae35);
-      h = (h ^ (h >>> 16)) | 0;
-      const j = ((h & 0xFF) - 128) * (leafNoise / 128);
-      normR += j;
-      normG += j;
-      normB += j;
-    }
-
-    // Color quantisation: clamp because `noise` and rounding can
-    // push values slightly past [0, 1].
+    // Color quantisation: clamp in case rounding pushes values
+    // slightly past [0, 1].
     const a127 = Math.round(alpha * 127);
     let qR = (normR * 255 + 0.5) | 0; if (qR < 0) qR = 0; else if (qR > 255) qR = 255;
     let qG = (normG * 255 + 0.5) | 0; if (qG < 0) qG = 0; else if (qG > 255) qG = 255;
@@ -775,7 +766,6 @@ function makeWalker(initialLeafCap) {
     lowerFadeR  = lowerFadeBound * inv2agg;
     aggThreshHysteresis = upperFadeR - aggThreshR;
     lowerFadeHysteresis = aggThreshR - lowerFadeR;
-    leafNoise = colorBlendState.leafNoise;
     const _sigma = colorBlendState.sigma;
     // Kernel parameters captured into closure-level vars so emit()
     // can evaluate exp(dl² * negInvTwoSigSq) inline without per-call
@@ -951,7 +941,6 @@ self.onmessage = (e) => {
   } else if (m.type === 'colorBlend') {
     colorBlendState.sigma = m.sigma;
     colorBlendState.offset = m.offset;
-    colorBlendState.leafNoise = m.leafNoise;
     colorBlendDirty = true;
     if (lastView && !pendingView) pendingView = lastView;
     schedule();

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -439,13 +439,16 @@
     // be untenably slow without simplification. The walker falls back to
     // treating those metatiles as "recurse normally" rather than aggregate.
     const MAX_BOUNDARY_LEAVES = 200_000;
-    // Aggregated cells render at ≤ ~32 px on screen, so the boundary's
-    // fractal detail is below the AA floor. Simplify each cached polygon
-    // via Visvalingam-Whyatt (drop-smallest-triangle until target reached);
-    // 16 vertices ≈ 14 triangles per cell, and for the typical visible
-    // count of a few thousand to a few tens of thousand cells per frame
-    // that's well under 1 M triangles total.
-    const BOUNDARY_VERTEX_BUDGET = 16;
+    // Vertex budget per simplified cluster boundary. At 16 verts a 44-px
+    // aggregate has ~2.7 px segments, and adjacent clusters (especially Γ
+    // vs non-Γ) simplify the same shared fractal edge to different chord
+    // approximations, leaving visible 1–2 px black gaps between them
+    // that no reasonable amount of polygon dilation can hide. At 64 verts
+    // the segments are ~0.7 px and the inter-cluster simplification
+    // mismatch drops to sub-pixel, where 4× MSAA + a small dilation can
+    // reliably cover it. ~62 triangles per aggregate × ~5K visible
+    // aggregates = ~300K triangles per frame, well within budget.
+    const BOUNDARY_VERTEX_BUDGET = 64;
     // Above this sub-level, skip raw extraction — Spectre supertile
     // boundaries are self-similar after simplification to 16 verts, so a
     // donor polygon extracted once at the cap can stand in for all higher
@@ -612,7 +615,7 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.025;
+      const DILATE = 1.012;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -833,13 +833,14 @@
     // own-color saturation. Texture and contrast come from the mid and
     // large scale objects, not the about-to-disappear small ones.
     //
-    // σ ≈ 1.2 spreads the blend across ~5 substitution levels, so
-    // structure at multiple scales contributes to each cell's color
-    // simultaneously. Mid-size cells (~2.5× AGG) read ~51% own / 36%
-    // parent / 13% grandparent — three levels of ancestry visible at
-    // once, which is what makes mid- and large-scale supertile boundaries
-    // legible rather than washing out into per-cell type colors.
-    const SIGMA = 1.2;
+    // σ ≈ 0.7 keeps the dominant ancestor's contribution to ~73% of the
+    // cell's color, with the next two ancestors at ~13% each. That keeps
+    // adjacent same-parent cells visibly distinct (each cell's own type
+    // colour drives most of the result) so the smallest-scale unit reads
+    // as the smallest-scale unit at every zoom — instead of all the
+    // cells in one parent cluster averaging into a single regional
+    // colour the way they would with a wider σ.
+    const SIGMA = 0.7;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Offset of the Gaussian center from viewLevel. With the alpha-fade
     // band handling the visual smoothness at the aggregate-to-children

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -945,16 +945,20 @@
         b.i16[i * 8 + 4] = Math.max(-32768, Math.min(32767, Math.round(c * 32767)));
         b.i16[i * 8 + 5] = Math.max(-32768, Math.min(32767, Math.round(s * 32767)));
 
-        // Single-source Gaussian-weighted RGB blend over the ancestry chain
-        // plus this cell. weightTable was filled at the start of walk() so
-        // this is a few multiply-adds per ancestor instead of an exp per
-        // emit. All perceptual channels move together because they all
-        // come from one weighted sum.
+        // Cell-centered Gaussian-weighted RGB blend over the ancestry chain.
+        // weightTable[d] = exp(-d² / 2σ²) is indexed by level-distance from
+        // the cell. The cell itself gets weight[0] = 1 (peak), each
+        // ancestor d levels up gets weight[d]. This way every cell reads
+        // dominantly its own type color regardless of zoom; the visual
+        // character is consistent across substitution levels because the
+        // blend is intrinsic to the cell's position in the substitution
+        // hierarchy, not to the global zoom state.
         const cellCol = colorForLevelType(cellSubLevel, label);
-        let w = weightTable[cellSubLevel | 0];
+        let w = weightTable[0];
         let total = w, R = w * cellCol[0], G = w * cellCol[1], B = w * cellCol[2];
         for (let k = 0; k < ancDepth; k++) {
-          w = weightTable[stSubL[k] | 0];
+          const d = (stSubL[k] - cellSubLevel) | 0;
+          w = weightTable[d < 0 ? -d : d];
           total += w;
           R += w * stColR[k]; G += w * stColG[k]; B += w * stColB[k];
         }
@@ -1058,14 +1062,18 @@
         vMxY =  halfH + m;
         pixelScale = view.pixelScale;
         viewLevel = viewLevelFor(pixelScale);
-        // Fill the per-frame Gaussian weight table once. emit() then reads
-        // weightTable[L] instead of paying for Math.exp per cell. Center is
-        // shifted up by _COLOR_SHIFT so cells at the AGG threshold pick up
-        // their parent's color instead of their own.
-        const center = viewLevel + _COLOR_SHIFT;
-        for (let L = 0; L < weightTable.length; L++) {
-          const dl = L - center;
-          weightTable[L] = Math.exp(-(dl * dl) / _TWO_SIGMA_SQ);
+        // The weight table is now indexed by ABSOLUTE LEVEL DISTANCE from
+        // the cell being emitted, not by absolute level number. weight[d]
+        // is the weight applied to an ancestor d substitution levels up
+        // from the cell. So the cell's own color always gets weight[0] = 1
+        // (peak) regardless of zoom. Without this, when viewLevel sits
+        // between two integer levels, neither the cell nor its parent
+        // gets peak weight, and the dominant contribution comes from
+        // averaging across many ancestors — at deep zoom that converges
+        // toward the palette mean (a bluish-grey), erasing the per-cell
+        // color variation.
+        for (let d = 0; d < weightTable.length; d++) {
+          weightTable[d] = Math.exp(-(d * d) / _TWO_SIGMA_SQ);
         }
         ancDepth = 0;
 

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -841,11 +841,15 @@
     // legible rather than washing out into per-cell type colors.
     const SIGMA = 1.2;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
-    // Offset of the Gaussian center from viewLevel. +1 means the center
-    // sits one substitution level above the soon-to-aggregate cell, so
-    // small things fade toward their parent's color while big things keep
-    // their own. See the long comment above.
-    const _COLOR_SHIFT = 1.0;
+    // Offset of the Gaussian center from viewLevel. With the alpha-fade
+    // band handling the visual smoothness at the aggregate-to-children
+    // crossover, the Gaussian center can sit on viewLevel itself — each
+    // cell reads at peak weight on its own color, so adjacent cells of
+    // different metatypes look distinct rather than averaging into their
+    // shared parent's color. That keeps smaller-scale structure visible
+    // alongside larger-scale, instead of the level-(K+1) ancestor's
+    // fractal boundary dominating the entire deep-zoom view.
+    const _COLOR_SHIFT = 0.0;
     // Spectre supertile inflation factor — each substitution level's
     // bounding circle scales by ~(1 + √3) ≈ 2.73 versus the previous;
     // I'm using 2.5 here as a tuning compromise.

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -54,7 +54,28 @@
     // Earcut-triangulated 14-gon: 12 triangles, 36 indices. The spectre is
     // non-convex (vertex 2 sits below the v0–v1 baseline, vertex 7 makes a
     // pocket), so a fan won't work — earcut produces a proper triangulation.
-    const meshVertexData = new Float32Array(spectreVertices.flat());
+    //
+    // Each leaf renders this mesh transformed into world; adjacent leaves
+    // share spectre edges in world space, but small float32 drift in the
+    // GPU shader's transform composition would otherwise leave sub-pixel
+    // gaps that 4× MSAA renders as black sliver pixels (each subsample
+    // misses both leaves' coverage). Dilating the mesh slightly around
+    // its centroid makes adjacent leaves overlap by ~0.7% on each side,
+    // covering all such sub-pixel mismatches. The overlap is invisible
+    // because adjacent leaves' fill colors are picked by the walker to
+    // be visually similar at the moment of rendering.
+    const _LEAF_DILATE = 1.012;
+    const meshVertexData = (() => {
+      let cx = 0, cy = 0;
+      for (const v of spectreVertices) { cx += v[0]; cy += v[1]; }
+      cx /= spectreVertices.length; cy /= spectreVertices.length;
+      const out = new Float32Array(spectreVertices.length * 2);
+      for (let i = 0; i < spectreVertices.length; i++) {
+        out[i * 2 + 0] = cx + (spectreVertices[i][0] - cx) * _LEAF_DILATE;
+        out[i * 2 + 1] = cy + (spectreVertices[i][1] - cy) * _LEAF_DILATE;
+      }
+      return out;
+    })();
     const meshFillIndices = new Uint16Array(earcut(spectreVertices.flat()));
   </script>
 
@@ -611,7 +632,7 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.005;
+      const DILATE = 1.012;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {
@@ -735,8 +756,10 @@
     // path's polygon scaling has its source already extracted.
     (function _prewarmAggregatePolygons() {
       const seen = new Set<string>();
+      const visited = new WeakSet<MetaTile>();
       function rec(mt: MetaTile) {
-        if (mt.kind === "leaf") return;
+        if (mt.kind === "leaf" || visited.has(mt)) return;
+        visited.add(mt);
         const sl = (mt as any)._subLevel as number | undefined;
         if (sl != null && sl >= 1 && sl <= EXTRACT_CAP) {
           const isG = mt.name === "Gamma";

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -231,72 +231,46 @@
   </script>
 
   <script id="palette" type="text/x-typescript">
-    // Per-(level, type) coloring. Each metatile type has a distinct base
-    // hue; each substitution level rotates the whole palette by 47°. So
-    // at any single dominant zoom level, the 9 types take 9 well-separated
-    // hues, and as zoom shifts by one substitution level, the palette
-    // rotates as a whole — enough to make supertile structure pop without
-    // making colors confusing across zoom changes.
-    // Hues spread evenly 40° apart across the wheel so any two types at
-    // the same substitution level read as clearly distinct, regardless of
-    // the level rotation. Order is arbitrary — just makes the 9 metatypes
-    // span the full color wheel without clustering.
-    const _TYPE_BASE_HUE: Record<string, number> = {
-      Gamma:  320, Delta:  200, Theta:    0, Lambda: 120,
-      Xi:     280, Pi:      80, Sigma:  240, Phi:     40, Psi: 160,
+    // Per-label palette mirroring the existing aperiodic-monotile notebook.
+    // 11 entries: the 9 metatypes plus Γ₁/Γ₂ for the two leaf labels of the
+    // Γ metatile (which doesn't itself appear as a leaf). The palette is
+    // designed — muted-but-distinct hues with a wide lightness range so
+    // adjacent tiles look different rather than muddy. Multi-scale variation
+    // comes from the Gaussian blend over ancestor LEVELS in the walker,
+    // not from per-level hue rotation; deeper ancestors contribute their
+    // metatype color directly. So at deep zoom, a region dominated by one
+    // ancestor reads as that ancestor's color, and the type's identity
+    // shows through across substitution scales.
+    const _LABEL_HEX: Record<string, string> = {
+      Gamma:  "#458e95",
+      Gamma1: "#50adc2",
+      Gamma2: "#83dcff",
+      Delta:  "#3a041b",
+      Theta:  "#90536e",
+      Lambda: "#7c3d21",
+      Xi:     "#af7648",
+      Pi:     "#8dc3e7",
+      Sigma:  "#de9e81",
+      Phi:    "#006061",
+      Psi:    "#003f5f",
     };
-    const _LEVEL_HUE_STEP = 47; // per substitution level
-    // Per-type saturation and lightness modulators in [-1, 1]. Used by the
-    // walker for HSL-channel hierarchical encoding: a cell's hue comes from
-    // the ancestor at viewLevel, its saturation from the ancestor +1 level
-    // up, its lightness from the ancestor +2 levels up. Each scale's
-    // structure becomes simultaneously visible because each scale drives
-    // a different perceptual channel. Modulators are arbitrary deterministic
-    // values in [-1, 1] picked to give 9 reasonably-distinct points along
-    // each axis. Γ takes the largest deltas so it reads as the strongest
-    // highlight at whichever level it dominates.
-    const _TYPE_SAT_MOD: Record<string, number> = {
-      Gamma:   1.0, Delta: -0.6, Theta:  0.4, Lambda: -0.2,
-      Xi:      0.7, Pi:    -0.8, Sigma:  0.2, Phi:    -0.4, Psi: 0.0,
-    };
-    const _TYPE_LIGHT_MOD: Record<string, number> = {
-      Gamma:   0.7, Delta:  0.5, Theta: -0.5, Lambda:  0.8,
-      Xi:     -0.3, Pi:    -0.8, Sigma:  0.2, Phi:    -0.1, Psi: 0.0,
-    };
-    function _hslToRgb(h: number, s: number, l: number): [number, number, number] {
-      h = ((h % 360) + 360) % 360;
-      const c = (1 - Math.abs(2 * l - 1)) * s;
-      const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-      const m = l - c / 2;
-      let r = 0, g = 0, b = 0;
-      if      (h <  60) { r = c; g = x; }
-      else if (h < 120) { r = x; g = c; }
-      else if (h < 180) { g = c; b = x; }
-      else if (h < 240) { g = x; b = c; }
-      else if (h < 300) { r = x; b = c; }
-      else              { r = c; b = x; }
-      return [r + m, g + m, b + m];
+    const _LABEL_RGB: Record<string, [number, number, number]> = {};
+    for (const [label, hex] of Object.entries(_LABEL_HEX)) {
+      _LABEL_RGB[label] = [
+        parseInt(hex.slice(1, 3), 16) / 255,
+        parseInt(hex.slice(3, 5), 16) / 255,
+        parseInt(hex.slice(5, 7), 16) / 255,
+      ];
     }
     function _typeForLabel(label: string): string {
       return label === "Gamma1" || label === "Gamma2" ? "Gamma" : label;
     }
-    // Sat/light defaults the walker uses when assembling per-level/per-type
-    // colors. Each ancestor's contribution is a single RGB point in this
-    // (hue, sat, light) space; the walker blends those RGBs by a Gaussian
-    // weight over substitution-level distance from viewLevel, so all
-    // channels move together as the user zooms. The per-type mods nudge
-    // sat/light so siblings of the same level still look distinct.
-    const _BASE_SAT = 0.55;
-    const _SAT_DELTA = 0.18;
-    const _BASE_LIGHT = 0.55;
-    const _LIGHT_DELTA = 0.10;
-    function colorForLevelType(level: number, label: string): [number, number, number] {
-      const type = _typeForLabel(label);
-      const base = _TYPE_BASE_HUE[type] ?? 0;
-      const hue = base + level * _LEVEL_HUE_STEP;
-      const sat = Math.max(0, Math.min(1, _BASE_SAT   + _SAT_DELTA   * (_TYPE_SAT_MOD[type]   ?? 0)));
-      const lit = Math.max(0, Math.min(1, _BASE_LIGHT + _LIGHT_DELTA * (_TYPE_LIGHT_MOD[type] ?? 0)));
-      return _hslToRgb(hue, sat, lit);
+    // Walker entry point. Level is unused — kept in the signature so that
+    // multi-scale color variation can later be reintroduced by perturbing
+    // the base color per substitution level (e.g., slight lightness shifts
+    // up and down the hierarchy).
+    function colorForLevelType(_level: number, label: string): [number, number, number] {
+      return _LABEL_RGB[label] ?? _LABEL_RGB[_typeForLabel(label)] ?? [0.5, 0.5, 0.5];
     }
   </script>
 

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -1102,46 +1102,60 @@
         b.count = i + 1;
       }
 
-      function recurse(mt: MetaTile, d: number, alphaIn: number) {
+      function recurse(mt: MetaTile, d: number, alphaIn: number, allowFadeOut: boolean = true) {
         if (alphaIn <= 0) return;
         const cx = stTx[d], cy = stTy[d];
         const r = (mt as any)._localRadius ?? 0;
         if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
         if (mt.kind === "leaf") { emit(null, mt.label, d, 0, alphaIn); return; }
 
-        // Two thresholds bracket a fade band:
-        //   pixelExtent < aggThresh         → pure aggregate (no children)
-        //   aggThresh ≤ pixelExtent < fadeUpper → aggregate at full alpha,
-        //                                          children at lerped alpha
-        //   fadeUpper ≤ pixelExtent          → no aggregate, children at full
+        // Children at α=1 cover their parent fully when the cluster is
+        // big enough on screen, so above aggThresh we skip the parent
+        // emit entirely — the children handle coverage. Below aggThresh
+        // the cluster is too small to recurse into normally, so we emit
+        // the parent. We optionally also recurse into children one
+        // additional level at a fade-out alpha so the just-cull-ing
+        // children blend smoothly out of view as zoom proceeds, masking
+        // any donor-polygon gaps in the parent until they're sub-pixel.
         //
-        // BUT: aggregates at sub-levels above EXTRACT_CAP use scaled donor
-        // polygons (not real-extracted boundaries), and the donor's shape
-        // is the cap-level cluster's boundary, which doesn't match the
-        // higher-level cluster's actual boundary in detail. Adjacent same-
-        // shape donor-scaled cells leave chord-mismatch slivers.
-        // Children, on the other hand, are at sub-level ≤ cap and emit
-        // real-extracted polygons that tile correctly. So when the parent
-        // would be donor-scaled, we *skip* the parent emit and have
-        // children emit at full alpha — they fully cover the cluster
-        // without leaving gaps. This sacrifices the fade-band crossfade
-        // for that one level but eliminates the chord-mismatch artefacts.
+        // Continuity at aggThresh:
+        //   - just above: parent skipped, children at α=1.
+        //   - just below: parent at α=1, children at α=1 (start of fade-
+        //     out, which lerps 1 → 0 down to lowerFadeBound).
+        //
+        // allowFadeOut limits cascade: a child reached via fade-out
+        // doesn't itself get a fade-out band, so we render at most two
+        // levels (parent + one fade-out children level) in the
+        // sub-aggThresh region instead of cascading down to leaves.
         const pixelExtent = 2 * r * aggPixelScale;
         const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
-        const fadeUpper = aggThresh * 4;
+        const lowerFadeBound = aggThresh / 4;
         const mySubLevel = (mt as any)._subLevel as number;
-        const parentIsExtracted = mySubLevel <= EXTRACT_CAP;
 
         let childAlpha = alphaIn;
-        if (pixelExtent < fadeUpper) {
+        let childAllowFadeOut = true;
+        if (pixelExtent < aggThresh) {
           const mesh = getGpuMesh(mt);
           if (mesh) {
             emit(mt, mt.name, d, mySubLevel, alphaIn);
-            if (pixelExtent < aggThresh) return;
-            const t = (pixelExtent - aggThresh) / (fadeUpper - aggThresh);
+            if (pixelExtent < lowerFadeBound || !allowFadeOut) return;
+            // The lower fade-out band is *only* useful at sub-level
+            // EXTRACT_CAP + 1 — there the children are at sub-level
+            // EXTRACT_CAP (real-extracted, tile correctly) and can mask
+            // the parent's donor-scaled gaps. At higher sub-levels both
+            // parent and children are donor-scaled, so the children
+            // can't fix gaps and only multiply cell count. We accept
+            // visible donor-gap slivers at deep zoom rather than blow
+            // up cell counts to billions.
+            if (mySubLevel !== EXTRACT_CAP + 1) return;
+            const t = (pixelExtent - lowerFadeBound) / (aggThresh - lowerFadeBound);
             childAlpha = alphaIn * t;
+            childAllowFadeOut = false;
+          } else {
+            return;
           }
         }
+        // Above aggThresh: parent skipped, children recurse at full alpha.
 
         // Push this meta's RGB onto the ancestry stack, recurse, pop.
         const mySL = (mt as any)._subLevel as number;
@@ -1164,7 +1178,7 @@
           const rDiff = pMir ? -T2.rot : T2.rot;
           stRot[d1] = (pRot + rDiff + 12) % 12;
           stMir[d1] = (pMir ^ T2.mirror) as 0 | 1;
-          recurse(child, d1, childAlpha);
+          recurse(child, d1, childAlpha, childAllowFadeOut);
         }
         ancDepth--;
       }

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -608,7 +608,7 @@
     // from real leaves (~530K leaves max per shape) — its boundary is
     // exact, so adjacent same-shape sub-level 6 cells tile properly.
     // Above 6 we still use the donor (now the sub-level 6 polygon).
-    const EXTRACT_CAP = 6;
+    const EXTRACT_CAP = 7;
 
     type BoundaryMesh = {
       polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
@@ -797,7 +797,7 @@
       // their parents at full alpha (in the fade band), so the heavy
       // dilation doesn't blend colours muddily — adjacent same-α
       // polygons fully replace each other in the overlap.
-      const DILATE = 1.05;
+      const DILATE = 1.00;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {
@@ -844,11 +844,11 @@
     // analytically.
     //
     // baseCluster has subLevel = BASE_DEPTH + 1 = 5 metatiles. We need
-    // donors at EXTRACT_CAP = 6, so we inflate one more time to get
-    // sub-level 6 metatiles. The Γ donor is taken straight from
-    // baseCluster (subLevel 5 + 1 = 6 in the inflated cluster).
+    // donors at EXTRACT_CAP = 7, so we inflate twice to get sub-level 7
+    // metatiles.
     const _donors = (() => {
-      const inflated = buildSupertiles(baseCluster);
+      let inflated = buildSupertiles(baseCluster);
+      inflated = buildSupertiles(inflated);
       attachRadii(inflated.Delta);
       attachSubLevels(inflated.Delta);
       attachRadii(inflated.Gamma);
@@ -887,7 +887,13 @@
         polygon = boundary.polygon;
         indices = boundary.indices;
       } else {
-        // Reuse donor polygon scaled by radius ratio.
+        // Reuse donor polygon scaled by radius ratio. Adjacent same-shape
+        // donor-scaled cells leave chord-mismatch slivers because the
+        // donor's shape doesn't match the actual cluster boundary at
+        // sub-level > EXTRACT_CAP. Apply an *extra* dilation around the
+        // scaled polygon's centroid (on top of the 5% already baked in
+        // by extractBoundary) so adjacent cells overlap by enough to
+        // swallow those slivers (observed up to ~9 px at sub-level 7).
         const donor = _getDonorBoundary(isGamma);
         if (donor === null) {
           _gpuMeshByShape.set(shapeKey, null);
@@ -895,8 +901,22 @@
           return null;
         }
         const scale = ((mt as any)._localRadius as number) / donor.radius;
+        const N = donor.mesh.polygon.length / 2;
+        // Centroid of the scaled polygon.
+        let cx = 0, cy = 0;
+        for (let i = 0; i < N; i++) {
+          cx += donor.mesh.polygon[i * 2] * scale;
+          cy += donor.mesh.polygon[i * 2 + 1] * scale;
+        }
+        cx /= N; cy /= N;
+        const EXTRA_DILATE = 1.00;
         polygon = new Float32Array(donor.mesh.polygon.length);
-        for (let i = 0; i < polygon.length; i++) polygon[i] = donor.mesh.polygon[i] * scale;
+        for (let i = 0; i < N; i++) {
+          const x = donor.mesh.polygon[i * 2] * scale;
+          const y = donor.mesh.polygon[i * 2 + 1] * scale;
+          polygon[i * 2]     = cx + (x - cx) * EXTRA_DILATE;
+          polygon[i * 2 + 1] = cy + (y - cy) * EXTRA_DILATE;
+        }
         indices = donor.mesh.indices;
       }
       const vb = _createVB(device, 'agg-poly-verts', polygon);

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -33,6 +33,9 @@
     _ctrlSeed.type = 'number';
     _ctrlSeed.min = '0';
     _ctrlSeed.value = String(paletteState.seed);
+    // Stable id so the video-export "Load config" button can sync this
+    // input's displayed value when it programmatically changes the seed.
+    _ctrlSeed.id = 'spectre-palette-seed-input';
     _ctrlSeed.style.width = '80px';
     _ctrlSeed.style.fontSize = '12px';
     _ctrlSeed.style.padding = '2px 6px';
@@ -979,6 +982,12 @@
       // Lets the user "freeze" the aggregation level while still zooming
       // the actual rendering in/out.
       aggPixelScale?: number;
+      // Optional extra cull-pad in CSS pixels. The walker pads the
+      // viewport AABB outward by this many pixels (converted to world
+      // units) before testing each cell's bounding ball. Pure safety
+      // margin — set higher to reduce the chance of background
+      // peeking through at the viewport edges.
+      cullPadPx?: number;
     };
 
     // Aggregate at this on-screen pixel extent: a metatile whose actual
@@ -1161,24 +1170,10 @@
 
       function recurse(mt: MetaTile, d: number, alphaIn: number, allowFadeOut: boolean = true) {
         if (alphaIn <= 0) return;
-        // Cull against a centroid-centered bounding ball: tighter than
-        // the corner-based _localRadius (which can be ~2× the cluster's
-        // actual extent because the local origin sits at a cluster
-        // corner, not its centroid). _localRadius is still used below
-        // for pixelExtent (aggregation tuning) and donor scaling, where
-        // the corner reference matters.
-        const myRot = stRot[d], myMir = stMir[d];
-        const myCos = _COS[myRot], mySin = _SIN[myRot];
-        const lcx = (mt as any)._cCx as number;
-        let lcy = (mt as any)._cCy as number;
-        if (myMir) lcy = -lcy;
-        const cCx = myCos * lcx - mySin * lcy + stTx[d];
-        const cCy = mySin * lcx + myCos * lcy + stTy[d];
-        const cBound = ((mt as any)._cBound as number) ?? 0;
-        if (cCx + cBound < vMnX || cCx - cBound > vMxX ||
-            cCy + cBound < vMnY || cCy - cBound > vMxY) return;
-        if (mt.kind === "leaf") { emit(null, mt.label, d, 0, alphaIn); return; }
+        const cx = stTx[d], cy = stTy[d];
         const r = (mt as any)._localRadius ?? 0;
+        if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
+        if (mt.kind === "leaf") { emit(null, mt.label, d, 0, alphaIn); return; }
 
         // We crossfade the parent's self-emit against its children's
         // recursion so neither pops. The parent fades in across an upper
@@ -1194,17 +1189,17 @@
         // sub-aggThresh region instead of cascading down to leaves.
         const pixelExtent = 2 * r * aggPixelScale;
         const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
-        const upperFadeBound = aggThresh * 1.8;
+        const upperFadeBound = aggThresh * 1.5;
         const mySubLevel = (mt as any)._subLevel as number;
         // At and below sub-level EXTRACT_CAP+1, children are real-extracted
-        // (or leaves) and tile correctly, so a wide fade band lets them
+        // (or leaves) and tile correctly, so a wider fade band lets them
         // smoothly disappear without revealing structural gaps. At higher
         // sub-levels the children are also donor-scaled (gaps remain), so
         // we use a narrower band: enough to smooth the level-transition
         // pop without paying full-band cell counts.
         const lowerFadeBound = mySubLevel <= EXTRACT_CAP + 1
-          ? aggThresh / 4
-          : aggThresh * 0.55;
+          ? aggThresh / 3
+          : aggThresh * 0.65;
 
         // Parent self-emit alpha factor: 1 in the lower band, smooth
         // fade-in across the upper band, 0 above the upper band.
@@ -1281,6 +1276,8 @@
         const halfW = view.pixelWidth / (2 * view.pixelScale);
         const halfH = view.pixelHeight / (2 * view.pixelScale);
         const m = _spectreBoundRadius;
+        const padPx = view.cullPadPx ?? 0;
+        const padWorld = padPx / view.pixelScale;
         // Walker accumulates positions in *view-relative* world units: every
         // stTx/stTy is "world coordinate minus viewCenter", computed in Float64
         // throughout the recursion. The instance buffer's iWorld is then a
@@ -1291,10 +1288,10 @@
         // precision once world coordinates pass ~1e6, and shared edges
         // between adjacent cells crack open. (Standard "Relative-To-Center"
         // / RTC trick used by web maps and 3D engines.)
-        vMnX = -halfW - m;
-        vMxX =  halfW + m;
-        vMnY = -halfH - m;
-        vMxY =  halfH + m;
+        vMnX = -halfW - m - padWorld;
+        vMxX =  halfW + m + padWorld;
+        vMnY = -halfH - m - padWorld;
+        vMxY =  halfH + m + padWorld;
         pixelScale = view.pixelScale;
         // aggPixelScale defaults to view.pixelScale, but can be overridden
         // (e.g., by the freeze toggle) so the AGG threshold is computed
@@ -1369,22 +1366,46 @@
     const walker = makeWalker(countLeaves(rootMeta));
 
     // ─── Upward extension ───────────────────────────────────────────────
-    // Wrap the current root in a level-up Δ parent. Slot 1 of Δ is Δ
-    // (per superRules.Delta[1]), so the existing root becomes the slot-1
-    // child of the new root. The new root's pose in absolute world is
-    // chosen so that the slot-1 child's accumulated transform stays
-    // exactly equal to the current root's transform — visible tiles
-    // remain in the same world position.
+    // Wrap the current root in a level-up parent. The new root's pose is
+    // chosen so the slot containing the existing root keeps the existing
+    // root's accumulated transform — visible tiles do not move.
+    //
+    // To avoid the "same surroundings at every zoom-out" effect, we walk
+    // through different (parent_type, slot) options at each extension
+    // rather than always wrapping as slot-1 of Δ. The substitution rules
+    // form a constrained graph: child type C can only sit at the
+    // specific (parent, slot) pairs where superRules[parent][slot] === C.
+    // Some types are bottlenecks (e.g., Θ only fits at slot 3 of Γ, Λ
+    // only at slot 6 of Σ); others have many options.
+    const _PARENT_OPTIONS: Record<TileName, Array<[TileName, number]>> = (() => {
+      const out = {} as Record<TileName, Array<[TileName, number]>>;
+      for (const t of TILE_NAMES) out[t] = [];
+      for (const parent of TILE_NAMES) {
+        const subs = superRules[parent];
+        for (let slot = 0; slot < subs.length; slot++) {
+          const c = subs[slot];
+          if (c !== null) out[c].push([parent, slot]);
+        }
+      }
+      return out;
+    })();
     function extendRootUpward() {
       const nextRecord = buildSupertiles(walkerState.currentBaseRecord);
-      const newRoot = nextRecord.Delta;
+      const currentType = (walkerState.currentRoot as any).name as TileName;
+      const opts = _PARENT_OPTIONS[currentType];
+      // Cycle through options. The simple modulo is good enough; for
+      // bottleneck types (Θ, Λ) opts.length === 1 and we always pick it.
+      const [parentType, slot] = opts[walkerState.extensionLevel % opts.length];
+      const newRoot = nextRecord[parentType];
       attachRadii(newRoot);
       attachSubLevels(newRoot);
       attachCentroidBounds(newRoot);
-      // Non-Γ types: geometries[i] corresponds directly to slot i (no
-      // null slots). Slot 1 of Δ is "Delta", so newRoot.geometries[1]
-      // is the geometry whose child === walkerState.currentRoot.
-      const slot1Transform = newRoot.geometries[1].transform;
+      // Find geometry index for slot, accounting for null entries that
+      // buildSupertiles filters out (only Γ has a null, at slot 2).
+      const subs = superRules[parentType];
+      let geomIdx = 0;
+      for (let s = 0; s < slot; s++) if (subs[s] !== null) geomIdx++;
+      const slot1Transform = newRoot.geometries[geomIdx].transform;
       walkerState.currentRootTransform = txCompose(
         walkerState.currentRootTransform,
         txInverse(slot1Transform),
@@ -1411,8 +1432,9 @@
         const cy = walkerState.currentRootTransform.t[1];
         const halfW = view.pixelWidth / (2 * view.pixelScale);
         const halfH = view.pixelHeight / (2 * view.pixelScale);
-        const dx = Math.abs(view.centerX - cx) + halfW;
-        const dy = Math.abs(view.centerY - cy) + halfH;
+        const padW = (view.cullPadPx ?? 0) / view.pixelScale;
+        const dx = Math.abs(view.centerX - cx) + halfW + padW;
+        const dy = Math.abs(view.centerY - cy) + halfH + padW;
         const distToCorner = Math.hypot(dx, dy);
         if (distToCorner <= 0.3 * r) return;
         extendRootUpward();
@@ -1432,6 +1454,10 @@
     // structure stays at its captured aggregation level while the user
     // zooms the camera in/out for inspection.
     const freezeState: { aggPixelScale: number | null } = { aggPixelScale: null };
+    // Cull-padding (CSS pixels) applied around the viewport before
+    // per-cell cull tests. Mutated by the video-export slider; defaults
+    // to 0 so live interaction is unchanged.
+    const cullState: { padPx: number } = { padPx: 0 };
     function repackInstances(): void {
       if (viewerState.pixelWidth === 0) return;
       const view = {
@@ -1441,6 +1467,7 @@
         pixelWidth: viewerState.pixelWidth,
         pixelHeight: viewerState.pixelHeight,
         aggPixelScale: freezeState.aggPixelScale ?? undefined,
+        cullPadPx: cullState.padPx,
       };
       maybeExtend(view);
       const result = walker(walkerState.currentRoot, walkerState.currentRootTransform, view);
@@ -1581,5 +1608,600 @@
     _viewLabel2.style.flex = '0 0 auto';
     _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput, _freezeCb, _freezeLabel);
     display(_viewRow);
+  </script>
+
+  <script id="video-export" type="text/x-typescript">
+    // Offline mp4 export: programmatically animates the view (zoom out →
+    // pan → zoom in), captures each frame from the canvas via
+    // copyTextureToBuffer, and feeds RGBA pixels to h264-mp4-encoder.
+    // Not realtime — frames render synchronously, one at a time.
+
+    // h264-mp4-encoder is a UMD bundle that registers `window.HME`. Loaded
+    // via <script> tag (not npm) because the wasm binary isn't bundled
+    // through Vite cleanly and the CDN copy is what the original Observable
+    // notebook uses.
+    const HME: any = await new Promise((resolve, reject) => {
+      if ((window as any).HME) return resolve((window as any).HME);
+      const s = document.createElement('script');
+      s.src = 'https://unpkg.com/h264-mp4-encoder/embuild/dist/h264-mp4-encoder.web.js';
+      s.onload = () => {
+        const m = (window as any).HME;
+        if (m) resolve(m); else reject(new Error('HME global not set'));
+      };
+      s.onerror = () => reject(new Error('failed to load h264-mp4-encoder'));
+      document.head.appendChild(s);
+    });
+
+    function _lerp(a: number, b: number, t: number): number { return a + (b - a) * t; }
+    function _logLerp(a: number, b: number, t: number): number {
+      return a * Math.exp(Math.log(b / a) * t);
+    }
+
+    type View = { centerX: number; centerY: number; pixelScale: number };
+    type Ease = 'linear' | 'cubic' | 'quintic';
+    type SegConfig = { sec: number; ease: Ease };
+
+    function _easeFn(name: Ease): (t: number) => number {
+      // cubic = standard smoothstep (C¹ at endpoints).
+      // quintic = smootherstep (C² at endpoints — zero velocity AND zero
+      // acceleration). For a long zoom that starts/ends at rest, quintic
+      // is what makes the very-beginning and very-end feel smooth.
+      if (name === 'cubic')   return (t) => t * t * (3 - 2 * t);
+      if (name === 'quintic') return (t) => t * t * t * (t * (t * 6 - 15) + 10);
+      return (t) => t;
+    }
+
+    // Mutable trajectory state. Initial values are the user's debugging
+    // script (start → zoom-out → pan → zoom-in). The widget below mutates
+    // these in place; _recordVideo reads them at click time.
+    const _kf: View[] = [
+      { centerX: 62.90020681398703,        centerY: -69.41475882293156,    pixelScale: 159.57638576360853 },
+      { centerX: -276309144.8722216,       centerY: 813097338.8738983,     pixelScale: 8.685921175201373e-8 },
+      { centerX: 52490654572.06181,        centerY: 31946543152.550705,    pixelScale: 8.685921175201373e-8 },
+      { centerX: 52651834944.69957,        centerY: 31501858022.634777,    pixelScale: 118.57227795600912 },
+    ];
+    const _seg: SegConfig[] = [
+      { sec: 6, ease: 'quintic' },
+      { sec: 4, ease: 'cubic' },
+      { sec: 6, ease: 'quintic' },
+    ];
+
+    function _viewAt(frac: number): View {
+      // Map overall progress into a particular segment and apply that
+      // segment's local ease. Use quintic on the first/last segments to
+      // get a smooth video start/end (zero velocity AND zero acceleration
+      // at endpoints), and cubic or linear on interior segments to avoid
+      // visible pauses at intermediate keyframes.
+      //
+      // Pan interpolates in *log-pixelScale space*, not linearly. Linear
+      // world-coord pan during a logarithmic zoom-out shoots off-screen
+      // mid-segment (the camera covers ~half the world distance while
+      // pixelScale is still small, so half-distance × small-scale = many
+      // screen pixels). The exponential form below makes the pan's
+      // screen-pixel velocity constant under the simultaneous zoom:
+      //
+      //   p(t) = p₀ · (p₁/p₀)ᵗ          (log interp of pixelScale)
+      //   x(t) = x₀ + (x₁−x₀) · fac(t)
+      //   fac(t) = (1 − e^{−tL}) / (1 − e^{−L})   with L = ln(p₁/p₀)
+      //
+      // fac(t) → t as L → 0, so pure-pan segments degenerate to linear.
+      const total = _seg.reduce((a, s) => a + s.sec, 0);
+      let elapsed = Math.max(0, Math.min(1, frac)) * total;
+      let prev = _kf[0];
+      for (let i = 0; i < _seg.length; i++) {
+        const s = _seg[i];
+        if (elapsed <= s.sec || i === _seg.length - 1) {
+          const lt = Math.max(0, Math.min(1, elapsed / s.sec));
+          const t = _easeFn(s.ease)(lt);
+          const next = _kf[i + 1];
+          const p0 = prev.pixelScale, p1 = next.pixelScale;
+          const L = Math.log(p1 / p0);
+          const fac = Math.abs(L) < 1e-6
+            ? t
+            : (1 - Math.exp(-t * L)) / (1 - Math.exp(-L));
+          return {
+            centerX: prev.centerX + (next.centerX - prev.centerX) * fac,
+            centerY: prev.centerY + (next.centerY - prev.centerY) * fac,
+            pixelScale: p0 * Math.exp(t * L),
+          };
+        }
+        elapsed -= s.sec;
+        prev = _kf[i + 1];
+      }
+      return _kf[_kf.length - 1];
+    }
+
+    interface RecordOpts {
+      width: number;
+      height: number;
+      fps: number;
+      qp: number;
+      samples: number;
+      fitMode: 'fit' | 'fill';
+      progress?: (f: number, t: number, ms: number) => void;
+    }
+
+    async function _recordVideo(opts: RecordOpts): Promise<Uint8Array> {
+      const w = opts.width  - (opts.width  & 1);
+      const h = opts.height - (opts.height & 1);
+      if (w < 16 || h < 16) throw new Error('width/height too small');
+      if (_kf.length < 2) throw new Error('need ≥2 keyframes');
+      if (_seg.length !== _kf.length - 1) {
+        throw new Error('segments out of sync with keyframes');
+      }
+      const liveW = viewerState.pixelWidth;
+      const liveH = viewerState.pixelHeight;
+      if (liveW === 0 || liveH === 0) throw new Error('live canvas not yet sized');
+      // Resolution-independent framing: the keyframes' pixelScale was
+      // captured against the live canvas size. To keep framed content the
+      // same on-screen size at the capture resolution, scale pixelScale
+      // by capture-vs-live size ratio.
+      //   fill = max ratio  → live's framing fills the capture; the off-axis
+      //                       of a wider/taller capture crops vs. live.
+      //   fit  = min ratio  → captures everything live showed; the off-axis
+      //                       gets extra context (no cropping).
+      const wR = w / liveW, hR = h / liveH;
+      const psScale = opts.fitMode === 'fit' ? Math.min(wR, hR) : Math.max(wR, hR);
+
+      const totalSec = _seg.reduce((a, s) => a + s.sec, 0);
+      const totalFrames = Math.max(2, Math.round(totalSec * opts.fps));
+      const savedView = viewerState.getView();
+
+      const enc = await HME.createH264MP4Encoder();
+      enc.outputFilename = 'spectre-zoom.mp4';
+      enc.width = w;
+      enc.height = h;
+      enc.frameRate = opts.fps;
+      enc.quantizationParameter = opts.qp;
+      enc.initialize();
+
+      // Temporal supersampling: per output frame, render N sub-frames at
+      // fractional times spanning the output frame's interval, then
+      // average. Only the time parameter varies between sub-samples;
+      // palette, cull pad, etc. stay fixed. N=1 is plain (no blur).
+      const N = Math.max(1, Math.floor(opts.samples) | 0);
+      const dFrac = 1 / Math.max(1, totalFrames - 1);
+      const accLen = w * h * 4;
+      const acc = N > 1 ? new Float64Array(accLen) : null;
+
+      (viewerState as any).beginCapture(w, h);
+      const t0 = performance.now();
+      try {
+        for (let i = 0; i < totalFrames; i++) {
+          const fracI = i / Math.max(1, totalFrames - 1);
+          let frame: Uint8Array | null = null;
+          if (acc) acc.fill(0);
+          for (let k = 0; k < N; k++) {
+            const subOff = ((k + 0.5) / N - 0.5) * dFrac;
+            const subFrac = Math.max(0, Math.min(1, fracI + subOff));
+            const v = _viewAt(subFrac);
+            viewerState.setView({
+              centerX: v.centerX,
+              centerY: v.centerY,
+              pixelScale: v.pixelScale * psScale,
+            });
+            const rgba = await (viewerState as any).captureFrame();
+            if (acc) {
+              for (let j = 0; j < accLen; j++) acc[j] += rgba[j];
+            } else {
+              frame = rgba;
+            }
+          }
+          if (acc) {
+            frame = new Uint8Array(accLen);
+            const inv = 1 / N;
+            for (let j = 0; j < accLen; j++) {
+              frame[j] = Math.round(acc[j] * inv);
+            }
+          }
+          enc.addFrameRgba(frame!);
+          opts.progress?.(i + 1, totalFrames, performance.now() - t0);
+        }
+        enc.finalize();
+        return enc.FS.readFile(enc.outputFilename) as Uint8Array;
+      } finally {
+        enc.delete();
+        (viewerState as any).endCapture();
+        viewerState.setView(savedView);
+      }
+    }
+
+    // ─── Keyframe widget ──────────────────────────────────────────────
+    // Per-keyframe row: three numeric inputs (centerX, centerY,
+    // pixelScale). Text inputs (not type="number") so scientific
+    // notation round-trips cleanly through Number(); also avoids a
+    // browser-side spinner on huge values like 5.2e10.
+    function _viewInput(value: number, w: string): HTMLInputElement {
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.value = String(value);
+      inp.style.flex = '1';
+      inp.style.minWidth = w;
+      inp.style.fontFamily = 'var(--mono, monospace)';
+      inp.style.fontSize = '10px';
+      inp.style.padding = '2px 4px';
+      return inp;
+    }
+    function _smallBtn(text: string, title?: string): HTMLButtonElement {
+      const b = document.createElement('button');
+      b.textContent = text;
+      if (title) b.title = title;
+      b.style.padding = '2px 6px';
+      b.style.fontSize = '11px';
+      b.style.fontFamily = 'var(--sans-serif)';
+      return b;
+    }
+
+    const _kfContainer = document.createElement('div');
+    _kfContainer.style.display = 'flex';
+    _kfContainer.style.flexDirection = 'column';
+    _kfContainer.style.gap = '4px';
+    _kfContainer.style.margin = '8px 0';
+    _kfContainer.style.fontFamily = 'var(--sans-serif)';
+    _kfContainer.style.fontSize = '11px';
+
+    function _rebuildKfWidget(): void {
+      _kfContainer.innerHTML = '';
+      for (let i = 0; i < _kf.length; i++) {
+        // Keyframe row.
+        const kfRow = document.createElement('div');
+        kfRow.style.display = 'flex';
+        kfRow.style.gap = '6px';
+        kfRow.style.alignItems = 'center';
+
+        const idx = document.createElement('span');
+        idx.textContent = `KF${i}`;
+        idx.style.flex = '0 0 28px';
+        idx.style.fontFamily = 'var(--mono, monospace)';
+        idx.style.fontWeight = 'bold';
+
+        const cxLbl = document.createElement('span'); cxLbl.textContent = 'cx';
+        const cyLbl = document.createElement('span'); cyLbl.textContent = 'cy';
+        const psLbl = document.createElement('span'); psLbl.textContent = 'ps';
+        for (const lbl of [cxLbl, cyLbl, psLbl]) {
+          lbl.style.flex = '0 0 auto';
+          lbl.style.opacity = '0.6';
+        }
+        const cxInp = _viewInput(_kf[i].centerX,    '120px');
+        const cyInp = _viewInput(_kf[i].centerY,    '120px');
+        const psInp = _viewInput(_kf[i].pixelScale, '90px');
+        const _bind = (inp: HTMLInputElement, key: 'centerX' | 'centerY' | 'pixelScale') => {
+          inp.addEventListener('change', () => {
+            const v = Number(inp.value);
+            if (Number.isFinite(v)) { _kf[i][key] = v; inp.style.outline = ''; }
+            else                     { inp.style.outline = '1px solid red'; }
+          });
+        };
+        _bind(cxInp, 'centerX'); _bind(cyInp, 'centerY'); _bind(psInp, 'pixelScale');
+
+        const captureBtn = _smallBtn('grab', 'set this keyframe to the current view');
+        captureBtn.addEventListener('click', () => {
+          _kf[i] = viewerState.getView();
+          cxInp.value = String(_kf[i].centerX);
+          cyInp.value = String(_kf[i].centerY);
+          psInp.value = String(_kf[i].pixelScale);
+          for (const inp of [cxInp, cyInp, psInp]) inp.style.outline = '';
+        });
+        const gotoBtn = _smallBtn('go', 'jump the live view to this keyframe');
+        gotoBtn.addEventListener('click', () => {
+          viewerState.setView(_kf[i]);
+        });
+        const removeBtn = _smallBtn('×', 'remove this keyframe');
+        removeBtn.disabled = _kf.length <= 2;
+        removeBtn.addEventListener('click', () => {
+          if (_kf.length <= 2) return;
+          _kf.splice(i, 1);
+          // Drop the segment that fed this keyframe (or the last one if i=0).
+          const segIdx = i === 0 ? 0 : i - 1;
+          _seg.splice(segIdx, 1);
+          _rebuildKfWidget();
+        });
+
+        kfRow.append(idx, cxLbl, cxInp, cyLbl, cyInp, psLbl, psInp, captureBtn, gotoBtn, removeBtn);
+        _kfContainer.append(kfRow);
+
+        // Segment row (between this kf and the next, if any).
+        if (i < _kf.length - 1) {
+          const sRow = document.createElement('div');
+          sRow.style.display = 'flex';
+          sRow.style.gap = '6px';
+          sRow.style.alignItems = 'center';
+          sRow.style.paddingLeft = '34px';
+          sRow.style.opacity = '0.85';
+
+          const arrow = document.createElement('span');
+          arrow.textContent = '↓';
+          arrow.style.flex = '0 0 14px';
+
+          const durLbl = document.createElement('span');
+          durLbl.textContent = 'sec';
+          const dur = document.createElement('input');
+          dur.type = 'number';
+          dur.step = '0.1';
+          dur.value = String(_seg[i].sec);
+          dur.style.width = '60px';
+          dur.style.fontFamily = 'var(--mono, monospace)';
+          dur.style.fontSize = '11px';
+          dur.style.padding = '2px 4px';
+          dur.addEventListener('change', () => {
+            const v = +dur.value;
+            if (Number.isFinite(v) && v > 0) _seg[i].sec = v;
+          });
+
+          const eaLbl = document.createElement('span');
+          eaLbl.textContent = 'ease';
+          const ea = document.createElement('select');
+          ea.style.fontSize = '11px';
+          for (const name of ['linear', 'cubic', 'quintic'] as Ease[]) {
+            const opt = document.createElement('option');
+            opt.value = name; opt.textContent = name;
+            if (_seg[i].ease === name) opt.selected = true;
+            ea.append(opt);
+          }
+          ea.addEventListener('change', () => { _seg[i].ease = ea.value as Ease; });
+
+          const insertBtn = _smallBtn('+', 'insert a keyframe here (current view)');
+          insertBtn.addEventListener('click', () => {
+            _kf.splice(i + 1, 0, viewerState.getView());
+            _seg.splice(i + 1, 0, { sec: 1, ease: 'linear' });
+            // Halve the existing segment's duration so total time is preserved.
+            _seg[i].sec = Math.max(0.1, _seg[i].sec / 2);
+            _seg[i + 1].sec = _seg[i].sec;
+            _rebuildKfWidget();
+          });
+
+          sRow.append(arrow, durLbl, dur, eaLbl, ea, insertBtn);
+          _kfContainer.append(sRow);
+        }
+      }
+
+      // Append-keyframe button at the bottom.
+      const tail = document.createElement('div');
+      tail.style.display = 'flex';
+      tail.style.gap = '6px';
+      tail.style.paddingLeft = '34px';
+      const appendBtn = _smallBtn('+ append keyframe (current view)');
+      appendBtn.addEventListener('click', () => {
+        _kf.push(viewerState.getView());
+        _seg.push({ sec: 2, ease: 'linear' });
+        _rebuildKfWidget();
+      });
+      tail.append(appendBtn);
+      _kfContainer.append(tail);
+    }
+    _rebuildKfWidget();
+
+    // ─── Render-action row ────────────────────────────────────────────
+    function _numInput(label: string, value: number, w = '64px') {
+      const wrap = document.createElement('label');
+      wrap.style.display = 'inline-flex';
+      wrap.style.gap = '4px';
+      wrap.style.alignItems = 'center';
+      const span = document.createElement('span'); span.textContent = label;
+      const inp = document.createElement('input');
+      inp.type = 'number'; inp.value = String(value);
+      inp.style.width = w; inp.style.fontFamily = 'var(--mono, monospace)';
+      inp.style.fontSize = '11px'; inp.style.padding = '2px 4px';
+      wrap.append(span, inp);
+      return { wrap, inp };
+    }
+
+    const _w    = _numInput('w',     1280);
+    const _h    = _numInput('h',      720);
+    const _fps  = _numInput('fps',     30);
+    const _qp   = _numInput('qp',      24);
+    const _samp = _numInput('samples',  1);
+
+    // fit  — captures everything the live canvas showed (extra context on
+    //        the off-axis if the capture aspect differs).
+    // fill — content stays at its live on-screen size; if capture aspect
+    //        differs, the off-axis gets cropped vs. live.
+    const _fitWrap = document.createElement('label');
+    _fitWrap.style.display = 'inline-flex';
+    _fitWrap.style.gap = '4px';
+    _fitWrap.style.alignItems = 'center';
+    const _fitSpan = document.createElement('span');
+    _fitSpan.textContent = 'frame';
+    const _fitSel = document.createElement('select');
+    _fitSel.style.fontSize = '11px';
+    for (const mode of ['fill', 'fit']) {
+      const o = document.createElement('option');
+      o.value = mode; o.textContent = mode;
+      _fitSel.append(o);
+    }
+    _fitWrap.append(_fitSpan, _fitSel);
+
+    // Cull-pad slider: extra viewport padding (CSS pixels) before the
+    // walker tests each cell against the AABB. Higher = let through more
+    // off-screen geometry → less chance of background bleeding in at the
+    // viewport edges, at the cost of a larger cell count and slower walks.
+    // Default 0 keeps live interaction at current speed; bump it during
+    // a recording session if you spot blanks.
+    const _cullWrap = document.createElement('label');
+    _cullWrap.style.display = 'inline-flex';
+    _cullWrap.style.gap = '4px';
+    _cullWrap.style.alignItems = 'center';
+    const _cullLabel = document.createElement('span');
+    _cullLabel.textContent = 'cull pad';
+    const _cullSlider = document.createElement('input');
+    _cullSlider.type = 'range';
+    _cullSlider.min = '0'; _cullSlider.max = '500'; _cullSlider.step = '5';
+    _cullSlider.value = '0';
+    _cullSlider.style.width = '120px';
+    const _cullVal = document.createElement('span');
+    _cullVal.textContent = '0 px';
+    _cullVal.style.fontFamily = 'var(--mono, monospace)';
+    _cullVal.style.minWidth = '44px';
+    _cullSlider.addEventListener('input', () => {
+      const v = +_cullSlider.value;
+      cullState.padPx = v;
+      _cullVal.textContent = `${v} px`;
+      // Live-rebuild so the user can see the effect at the current zoom.
+      repackInstances();
+      viewerState.requestFrame();
+    });
+    _cullWrap.append(_cullLabel, _cullSlider, _cullVal);
+
+    // ─── Save / load entire config (palette + keyframes + video opts) ──
+    function _gatherConfig() {
+      return {
+        palette: { seed: paletteState.seed },
+        keyframes: _kf.map((k) => ({
+          centerX: k.centerX, centerY: k.centerY, pixelScale: k.pixelScale,
+        })),
+        segments: _seg.map((s) => ({ sec: s.sec, ease: s.ease })),
+        video: {
+          width:    +_w.inp.value,
+          height:   +_h.inp.value,
+          fps:      +_fps.inp.value,
+          qp:       +_qp.inp.value,
+          samples:  +_samp.inp.value,
+          fitMode:  _fitSel.value,
+          cullPadPx: cullState.padPx,
+        },
+      };
+    }
+    function _applyConfig(cfg: any): void {
+      if (cfg.palette?.seed != null) {
+        paletteState.setSeed(cfg.palette.seed);
+        // Sync the seed input in the palette-controls cell so its
+        // displayed value reflects the loaded seed.
+        const seedInput = document.getElementById('spectre-palette-seed-input') as HTMLInputElement | null;
+        if (seedInput) seedInput.value = String(paletteState.seed);
+        // Trigger a fresh repack so the new colours land.
+        viewerState.onViewChange?.(viewerState);
+      }
+      if (Array.isArray(cfg.keyframes) && cfg.keyframes.length >= 2) {
+        _kf.length = 0;
+        for (const k of cfg.keyframes) {
+          _kf.push({
+            centerX: +k.centerX, centerY: +k.centerY, pixelScale: +k.pixelScale,
+          });
+        }
+      }
+      if (Array.isArray(cfg.segments) && cfg.segments.length === _kf.length - 1) {
+        _seg.length = 0;
+        for (const s of cfg.segments) {
+          _seg.push({
+            sec: +s.sec,
+            ease: (s.ease === 'linear' || s.ease === 'cubic' || s.ease === 'quintic')
+              ? s.ease : 'linear',
+          });
+        }
+      }
+      if (cfg.video) {
+        if (cfg.video.width  != null) _w.inp.value   = String(cfg.video.width);
+        if (cfg.video.height != null) _h.inp.value   = String(cfg.video.height);
+        if (cfg.video.fps    != null) _fps.inp.value = String(cfg.video.fps);
+        if (cfg.video.qp     != null) _qp.inp.value  = String(cfg.video.qp);
+        if (cfg.video.samples != null) _samp.inp.value = String(cfg.video.samples);
+        if (cfg.video.fitMode === 'fit' || cfg.video.fitMode === 'fill') {
+          _fitSel.value = cfg.video.fitMode;
+        }
+        if (cfg.video.cullPadPx != null) {
+          cullState.padPx = +cfg.video.cullPadPx;
+          _cullSlider.value = String(cullState.padPx);
+          _cullVal.textContent = `${cullState.padPx} px`;
+        }
+      }
+      _rebuildKfWidget();
+      viewerState.requestFrame();
+    }
+    const _saveBtn = document.createElement('button');
+    _saveBtn.textContent = 'Save config';
+    _saveBtn.style.padding = '4px 10px';
+    _saveBtn.style.fontSize = '11px';
+    _saveBtn.addEventListener('click', () => {
+      const cfg = _gatherConfig();
+      const blob = new Blob([JSON.stringify(cfg, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = 'spectre-config.json';
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 5000);
+    });
+    const _loadBtn = document.createElement('button');
+    _loadBtn.textContent = 'Load config';
+    _loadBtn.style.padding = '4px 10px';
+    _loadBtn.style.fontSize = '11px';
+    const _loadInput = document.createElement('input');
+    _loadInput.type = 'file';
+    _loadInput.accept = 'application/json,.json';
+    _loadInput.style.display = 'none';
+    _loadInput.addEventListener('change', async () => {
+      const f = _loadInput.files?.[0];
+      if (!f) return;
+      try {
+        const text = await f.text();
+        const cfg = JSON.parse(text);
+        _applyConfig(cfg);
+        _status.textContent = `loaded ${f.name}`;
+      } catch (e) {
+        _status.textContent = 'load error: ' + (e as Error).message;
+      } finally {
+        _loadInput.value = '';
+      }
+    });
+    _loadBtn.addEventListener('click', () => _loadInput.click());
+
+    const _btn = document.createElement('button');
+    _btn.textContent = 'Render mp4';
+    _btn.style.padding = '4px 10px';
+    _btn.style.fontFamily = 'var(--sans-serif)';
+    _btn.style.fontSize = '11px';
+
+    const _status = document.createElement('span');
+    _status.style.fontFamily = 'var(--mono, monospace)';
+    _status.style.fontSize = '11px';
+    _status.style.minWidth = '160px';
+
+    let _busy = false;
+    _btn.addEventListener('click', async () => {
+      if (_busy) return;
+      _busy = true; _btn.disabled = true;
+      _status.textContent = 'rendering…';
+      try {
+        const bytes = await _recordVideo({
+          width: +_w.inp.value,
+          height: +_h.inp.value,
+          fps: +_fps.inp.value,
+          qp: +_qp.inp.value,
+          samples: Math.max(1, +_samp.inp.value),
+          fitMode: _fitSel.value as 'fit' | 'fill',
+          progress: (f, t, ms) => {
+            _status.textContent = `${f} / ${t}  (${(ms / f).toFixed(0)} ms/frame)`;
+          },
+        });
+        const blob = new Blob([bytes], { type: 'video/mp4' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url; a.download = 'spectre-zoom.mp4';
+        document.body.appendChild(a); a.click(); a.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 5000);
+        _status.textContent = `${(bytes.length / 1e6).toFixed(2)} MB`;
+      } catch (e) {
+        _status.textContent = 'error: ' + (e as Error).message;
+        console.error(e);
+      } finally {
+        _busy = false; _btn.disabled = false;
+      }
+    });
+
+    const _actionRow = document.createElement('div');
+    _actionRow.style.display = 'flex';
+    _actionRow.style.gap = '8px';
+    _actionRow.style.alignItems = 'center';
+    _actionRow.style.flexWrap = 'wrap';
+    _actionRow.style.margin = '8px 0';
+    _actionRow.style.fontFamily = 'var(--sans-serif)';
+    _actionRow.style.fontSize = '11px';
+    _actionRow.append(
+      _w.wrap, _h.wrap, _fps.wrap, _qp.wrap, _samp.wrap, _fitWrap, _cullWrap,
+      _saveBtn, _loadBtn, _loadInput,
+      _btn, _status,
+    );
+
+    display(_kfContainer);
+    display(_actionRow);
   </script>
 </notebook>

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -744,12 +744,12 @@
     //
     // The walker descends until the first cell falls under the threshold
     // and aggregates there, so cell sizes after aggregation land in
-    // (AGG_PX/inflation, AGG_PX] = (~AGG_PX/2.8, AGG_PX]. Picking 56 puts
-    // typical aggregate cells around 20–55 px on screen — small enough
-    // that any solid-color region reads as a single mosaic tile rather
-    // than a monolithic block, large enough that the eye can resolve
-    // individual cells and the per-cell color differences register.
-    const AGG_PX = 56;
+    // (AGG_PX/inflation, AGG_PX] = (~AGG_PX/2.8, AGG_PX]. Picking 44 puts
+    // typical aggregate cells around 16–44 px — small enough that
+    // individual aggregates read as single mosaic tiles rather than
+    // monolithic blocks, but small enough also that detail persists
+    // farther into zoom-out before the level-aggregation kicks in.
+    const AGG_PX = 44;
     // _localRadius is measured from the spectre's corner origin (vertex 0),
     // so for any supertile it's ~1.5× the cluster's true centered radius
     // (empirically 1.44 at sub-level 3, growing to 1.64 at sub-level 5).
@@ -775,12 +775,13 @@
     // own-color saturation. Texture and contrast come from the mid and
     // large scale objects, not the about-to-disappear small ones.
     //
-    // σ ≈ 0.7 makes the dominant ancestor account for ~50% of the blend,
-    // its two immediate neighbors ~25% each, and the rest negligible.
-    // Enough multi-scale information that adjacent supertiles still read
-    // as different metatypes at a single zoom, but smooth enough that an
-    // animated zoom doesn't feel stepwise.
-    const SIGMA = 0.7;
+    // σ ≈ 1.2 spreads the blend across ~5 substitution levels, so
+    // structure at multiple scales contributes to each cell's color
+    // simultaneously. Mid-size cells (~2.5× AGG) read ~51% own / 36%
+    // parent / 13% grandparent — three levels of ancestry visible at
+    // once, which is what makes mid- and large-scale supertile boundaries
+    // legible rather than washing out into per-cell type colors.
+    const SIGMA = 1.2;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Offset of the Gaussian center from viewLevel. +1 means the center
     // sits one substitution level above the soon-to-aggregate cell, so

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -445,6 +445,54 @@
       }
     }
 
+    // Decimate the boundary by keeping anchors (the metatile's 4 superQuad
+    // corners) plus a fixed number of evenly-spaced intermediate vertices
+    // on each side between consecutive anchors.
+    //
+    // Cross-cluster consistency: two adjacent clusters share a side
+    // between the same two anchors C1 and C2, traversed in opposite
+    // directions but covering the same L vertices. Both compute m =
+    // min(maxExtraPerSide, L − 1) intermediate samples and keep verts at
+    // index offsets {round(k · L / (m + 1)) : k = 1..m}. That offset set
+    // is symmetric under k → m + 1 − k, so reversing the traversal
+    // direction picks the same world-space vertices. The polygons agree
+    // exactly along every shared side; the anchors pin the side
+    // endpoints so even sub-pixel index-rounding asymmetries can't open
+    // a corner gap.
+    function _decimateBetweenAnchors(
+      pts: Vec2[],
+      anchorIndices: number[],
+      maxExtraPerSide: number,
+    ): Vec2[] {
+      const n = pts.length;
+      if (anchorIndices.length < 2) {
+        // No usable anchors: just keep every k-th vertex around the loop.
+        const target = Math.min(48, n);
+        if (target >= n) return pts.slice();
+        const out: Vec2[] = [];
+        const step = n / target;
+        for (let i = 0; i < target; i++) out.push(pts[Math.round(i * step) % n]);
+        return out;
+      }
+      const sorted = [...anchorIndices].sort((a, b) => a - b);
+      const out: Vec2[] = [];
+      for (let a = 0; a < sorted.length; a++) {
+        const start = sorted[a];
+        const end = sorted[(a + 1) % sorted.length];
+        out.push(pts[start]);
+        const sideLen = (end - start + n) % n;
+        if (sideLen <= 1) continue;
+        const m = Math.min(maxExtraPerSide, sideLen - 1);
+        for (let k = 1; k <= m; k++) {
+          const offset = Math.round((k * sideLen) / (m + 1));
+          if (offset > 0 && offset < sideLen) {
+            out.push(pts[(start + offset) % n]);
+          }
+        }
+      }
+      return out.length >= 3 ? out : pts;
+    }
+
     function extractBoundary(mt: MetaTile): BoundaryMesh | null {
       if (mt.kind === "leaf") return null;
       const cached = _boundaryCache.get(mt);
@@ -528,25 +576,47 @@
       loops.sort((a, b) => b.length - a.length);
       const outer = loops[0];
 
-      // 6. Materialize the outer-boundary as Vec2 points and dilate slightly
-      // around the polygon's centroid so any sub-pixel f32 precision drift
-      // in the GPU shader's transform composition is covered by overlap.
-      // We don't simplify: keeping every spectre-edge boundary vertex is
-      // what makes adjacent clusters' shared edges share their entire
-      // vertex sequence by construction (no chord-vs-chord mismatch). The
-      // metatile's local origin is at one corner of the cluster bbox, so
-      // dilating around the polygon centroid (not the origin) is what
-      // keeps the expansion isotropic.
+      // 6. Mark the metatile's superQuad corners as anchors. These are the
+      // 4 supertile corners where adjacent same-level clusters' boundaries
+      // meet — pinning them keeps every shared edge's start and end
+      // identical between the two sides regardless of how the in-between
+      // vertices simplify.
+      const anchorVertIds = new Set<number>();
+      if (mt.kind === "meta") {
+        for (const corner of mt.quad) {
+          const qx = Math.round(corner[0] * Q);
+          const qy = Math.round(corner[1] * Q);
+          const id = vertMap.get(qx + "," + qy);
+          if (id !== undefined) anchorVertIds.add(id);
+        }
+      }
       const outerPts: Vec2[] = outer.map((id) => vertList[id]);
+      const anchorIndices: number[] = [];
+      for (let i = 0; i < outer.length; i++) {
+        if (anchorVertIds.has(outer[i])) anchorIndices.push(i);
+      }
+
+      // 7. Uniformly decimate each side between two anchors. ~12
+      // intermediates per side gives ~52 verts total at any subLevel
+      // (4 anchors + 4×12 intermediates), coarse but sufficient. Adjacent
+      // clusters' shared sides agree exactly because the offsets are
+      // symmetric under traversal reversal.
+      const simplified = _decimateBetweenAnchors(outerPts, anchorIndices, 12);
+
+      // 8. Dilate slightly around the polygon centroid so any sub-pixel
+      // f32 precision drift in the GPU shader's transform composition is
+      // covered by overlap. The metatile's local origin sits at a corner
+      // of the cluster bbox, not the centroid, so dilating around the
+      // polygon centroid (not the origin) keeps the expansion isotropic.
       let cx = 0, cy = 0;
-      for (const p of outerPts) { cx += p[0]; cy += p[1]; }
-      cx /= outerPts.length; cy /= outerPts.length;
+      for (const p of simplified) { cx += p[0]; cy += p[1]; }
+      cx /= simplified.length; cy /= simplified.length;
       const DILATE = 1.005;
-      const polygon = new Float32Array(outerPts.length * 2);
-      const flat: number[] = new Array(outerPts.length * 2);
-      for (let i = 0; i < outerPts.length; i++) {
-        const x = cx + (outerPts[i][0] - cx) * DILATE;
-        const y = cy + (outerPts[i][1] - cy) * DILATE;
+      const polygon = new Float32Array(simplified.length * 2);
+      const flat: number[] = new Array(simplified.length * 2);
+      for (let i = 0; i < simplified.length; i++) {
+        const x = cx + (simplified[i][0] - cx) * DILATE;
+        const y = cy + (simplified[i][1] - cy) * DILATE;
         polygon[i * 2 + 0] = x;
         polygon[i * 2 + 1] = y;
         flat[i * 2 + 0] = x;
@@ -649,6 +719,42 @@
       _gpuMeshCache.set(mt, mesh);
       return mesh;
     }
+
+    // Pre-extract every aggregate-polygon shape we'll use during normal
+    // interaction. Without this, the first time the user zooms out far
+    // enough to cross a substitution-level boundary, the walker calls
+    // `extractBoundary` cold for that level — at sub-level 5 (the donor)
+    // that walks ~4400 leaves and hashes ~62K edges synchronously,
+    // which shows up as a 30+ ms hitch on the main thread. Pre-warming
+    // moves all that work into module init time, where it's spent
+    // before the first frame.
+    //
+    // Walks the live root and a Γ representative, calling getGpuMesh on
+    // one metatile per (subLevel ≤ EXTRACT_CAP, isGamma) combo to fill
+    // _gpuMeshByShape. Then forces both donors so the > EXTRACT_CAP
+    // path's polygon scaling has its source already extracted.
+    (function _prewarmAggregatePolygons() {
+      const seen = new Set<string>();
+      function rec(mt: MetaTile) {
+        if (mt.kind === "leaf") return;
+        const sl = (mt as any)._subLevel as number | undefined;
+        if (sl != null && sl >= 1 && sl <= EXTRACT_CAP) {
+          const isG = mt.name === "Gamma";
+          const key = sl + (isG ? "g" : "n");
+          if (!seen.has(key)) {
+            seen.add(key);
+            getGpuMesh(mt);
+          }
+        }
+        for (const { child } of mt.geometries) rec(child);
+      }
+      rec(walkerState.currentRoot);
+      rec(baseCluster.Gamma);
+      // Donors for subLevel > EXTRACT_CAP — extract once so the first
+      // scaled-polygon emission doesn't pay the donor's extraction cost.
+      _getDonorBoundary(false);
+      _getDonorBoundary(true);
+    })();
   </script>
 
   <script id="walker" type="text/x-typescript">

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -925,7 +925,8 @@
       // frames. Aggregate buckets are created lazily and reset each frame.
       buckets.set(null, _newBucket(null, initialLeafCap));
 
-      function emit(bucketKey: MetaTile | null, label: string, d: number, cellSubLevel: number) {
+      function emit(bucketKey: MetaTile | null, label: string, d: number, cellSubLevel: number, alpha: number) {
+        if (alpha <= 0) return;
         let b = buckets.get(bucketKey);
         if (!b) { b = _newBucket(bucketKey, 64); buckets.set(bucketKey, b); }
         if (b.count >= b.capacity) _growBucket(b, b.count + 1);
@@ -951,30 +952,48 @@
         }
         const inv = 1 / total;
 
+        // Pack mirror flag (high bit) and alpha (low 7 bits) into byte 15.
+        // 0..127 = non-mirrored, alpha 0..1; 128..255 = mirrored, alpha 0..1.
+        // Shader decodes via select() on byte >= 128 and divides by 127.
+        const a127 = Math.max(0, Math.min(127, Math.round(alpha * 127)));
         const off = i * 16;
         b.u8[off + 12] = Math.max(0, Math.min(255, Math.round(R * inv * 255)));
         b.u8[off + 13] = Math.max(0, Math.min(255, Math.round(G * inv * 255)));
         b.u8[off + 14] = Math.max(0, Math.min(255, Math.round(B * inv * 255)));
-        b.u8[off + 15] = stMir[d] ? 255 : 0;
+        b.u8[off + 15] = (stMir[d] ? 128 : 0) | a127;
         b.count = i + 1;
       }
 
-      function recurse(mt: MetaTile, d: number) {
+      function recurse(mt: MetaTile, d: number, alphaIn: number) {
+        if (alphaIn <= 0) return;
         const cx = stTx[d], cy = stTy[d];
         const r = (mt as any)._localRadius ?? 0;
         if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
-        if (mt.kind === "leaf") { emit(null, mt.label, d, 0); return; }
+        if (mt.kind === "leaf") { emit(null, mt.label, d, 0, alphaIn); return; }
 
-        // Aggregate if this metatile would render below the threshold.
-        // 2·r is the bounding-circle diameter; pixelExtent is its size
-        // in screen pixels. If the boundary cache yields a polygon, emit
-        // one aggregate instance using the metatile's name color; if the
-        // metatile is too big to extract a boundary for, fall through
-        // to the recursive case.
+        // Two thresholds bracket a fade band:
+        //   pixelExtent < aggThresh         → pure aggregate (no children)
+        //   aggThresh ≤ pixelExtent < fadeUpper → aggregate at full alpha,
+        //                                          children at lerped alpha
+        //   fadeUpper ≤ pixelExtent          → no aggregate, children at full
+        // The lerped alpha smoothly fades the next refinement level in over
+        // a 2× zoom band, hiding the visual snap at the threshold. When the
+        // cell crosses out of the band on the high side, the aggregate stops
+        // being drawn just as the children reach alpha 1, so they fully
+        // cover whatever the aggregate was hiding — no discontinuity.
         const pixelExtent = 2 * r * pixelScale;
-        if (pixelExtent < AGG_PX * _LOOSE_RADIUS_FACTOR) {
+        const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
+        const fadeUpper = aggThresh * 2;
+
+        let childAlpha = alphaIn;
+        if (pixelExtent < fadeUpper) {
           const mesh = getGpuMesh(mt);
-          if (mesh) { emit(mt, mt.name, d, (mt as any)._subLevel); return; }
+          if (mesh) {
+            emit(mt, mt.name, d, (mt as any)._subLevel, alphaIn);
+            if (pixelExtent < aggThresh) return;
+            const t = (pixelExtent - aggThresh) / (fadeUpper - aggThresh);
+            childAlpha = alphaIn * t;
+          }
         }
 
         // Push this meta's RGB onto the ancestry stack, recurse, pop.
@@ -998,7 +1017,7 @@
           const rDiff = pMir ? -T2.rot : T2.rot;
           stRot[d1] = (pRot + rDiff + 12) % 12;
           stMir[d1] = (pMir ^ T2.mirror) as 0 | 1;
-          recurse(child, d1);
+          recurse(child, d1, childAlpha);
         }
         ancDepth--;
       }
@@ -1049,10 +1068,11 @@
         stMir[0] = rootTransform.mirror;
         stTx[0]  = rootTransform.t[0] - view.centerX;
         stTy[0]  = rootTransform.t[1] - view.centerY;
-        recurse(rootMeta, 0);
+        recurse(rootMeta, 0, 1.0);
 
-        // Concatenate buckets into outData. Leaves first (key === null),
-        // then aggregates in insertion order.
+        // Concatenate buckets into outData. Aggregates first (so the
+        // fading-in next level draws on top of them with alpha blending),
+        // then leaves last on top of all aggregates.
         let totalCount = 0;
         for (const b of buckets.values()) totalCount += b.count;
         if (totalCount * 16 > outData.byteLength) {
@@ -1062,18 +1082,28 @@
         }
         const groups: Array<{ key: MetaTile | null; instanceOffset: number; instanceCount: number }> = [];
         let off = 0;
+        // Sort aggregate buckets coarsest-first (highest subLevel first) so
+        // a parent aggregate draws under its child sub-aggregates during
+        // the fade-band overlap. Leaves (subLevel 0) come last.
+        const aggBuckets: WalkBucket[] = [];
+        for (const b of buckets.values()) {
+          if (b.key === null) continue;
+          if (b.count === 0) continue;
+          aggBuckets.push(b);
+        }
+        aggBuckets.sort((a, b) =>
+          ((b.key as any)._subLevel ?? 0) - ((a.key as any)._subLevel ?? 0)
+        );
+        for (const b of aggBuckets) {
+          outU8.set(b.u8.subarray(0, b.count * 16), off * 16);
+          groups.push({ key: b.key, instanceOffset: off, instanceCount: b.count });
+          off += b.count;
+        }
         const leafBucket = buckets.get(null)!;
         if (leafBucket.count > 0) {
           outU8.set(leafBucket.u8.subarray(0, leafBucket.count * 16), off * 16);
           groups.push({ key: null, instanceOffset: off, instanceCount: leafBucket.count });
           off += leafBucket.count;
-        }
-        for (const b of buckets.values()) {
-          if (b.key === null) continue;
-          if (b.count === 0) continue;
-          outU8.set(b.u8.subarray(0, b.count * 16), off * 16);
-          groups.push({ key: b.key, instanceOffset: off, instanceCount: b.count });
-          off += b.count;
         }
         return { data: outData, totalCount, groups };
       };

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -802,12 +802,12 @@
     //
     // The walker descends until the first cell falls under the threshold
     // and aggregates there, so cell sizes after aggregation land in
-    // (AGG_PX/inflation, AGG_PX] = (~AGG_PX/2.8, AGG_PX]. Picking 44 puts
-    // typical aggregate cells around 16–44 px — small enough that
-    // individual aggregates read as single mosaic tiles rather than
-    // monolithic blocks, but small enough also that detail persists
-    // farther into zoom-out before the level-aggregation kicks in.
-    const AGG_PX = 44;
+    // (AGG_PX/inflation, AGG_PX] = (~AGG_PX/2.8, AGG_PX]. Refinement
+    // (the transition from aggregate polygon back to individual leaves
+    // as the user zooms in) happens at the same threshold, so a smaller
+    // AGG_PX pushes refinement to fire at a smaller on-screen size —
+    // detail persists farther into zoom-out.
+    const AGG_PX = 22;
     // _localRadius is measured from the spectre's corner origin (vertex 0),
     // so for any supertile it's ~1.5× the cluster's true centered radius
     // (empirically 1.44 at sub-level 3, growing to 1.64 at sub-level 5).

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -413,16 +413,16 @@
     // be untenably slow without simplification. The walker falls back to
     // treating those metatiles as "recurse normally" rather than aggregate.
     const MAX_BOUNDARY_LEAVES = 200_000;
-    // Vertex budget per simplified cluster boundary. At 16 verts a 44-px
-    // aggregate has ~2.7 px segments, and adjacent clusters (especially Γ
-    // vs non-Γ) simplify the same shared fractal edge to different chord
-    // approximations, leaving visible 1–2 px black gaps between them
-    // that no reasonable amount of polygon dilation can hide. At 64 verts
-    // the segments are ~0.7 px and the inter-cluster simplification
-    // mismatch drops to sub-pixel, where 4× MSAA + a small dilation can
-    // reliably cover it. ~62 triangles per aggregate × ~5K visible
-    // aggregates = ~300K triangles per frame, well within budget.
-    const BOUNDARY_VERTEX_BUDGET = 64;
+    // No vertex budget — keep every spectre edge that's on the cluster
+    // boundary. Adjacent clusters' shared edges are *the same* sequence
+    // of leaf-spectre edges traversed from each side, so two adjacent
+    // clusters' polygons share the entire vertex sequence on the shared
+    // boundary by construction. Any simplification breaks that invariant
+    // (each cluster picks a different chord approximation, leaving gaps).
+    // Without simplification, gaps reduce to f32 precision drift in the
+    // GPU shader, which the small DILATE below covers. Sub-level 5
+    // boundary is ~3200 verts → ~3200 triangles per aggregate × ~5K
+    // visible = ~16M triangles, well within GPU fill rate at 1.8M pixels.
     // Above this sub-level, skip raw extraction — Spectre supertile
     // boundaries are self-similar after simplification to 16 verts, so a
     // donor polygon extracted once at the cap can stand in for all higher
@@ -431,54 +431,6 @@
     // metatiles with billions of leaves, falls back to recursion, and
     // emits millions of instances per frame.
     const EXTRACT_CAP = 5;
-
-    // Visvalingam-Whyatt for closed polygons. Removes the vertex whose
-    // triangle (with neighbors) has the smallest area; repeats until
-    // length === budget. Implemented with a doubly-linked-list ring and
-    // a linear search for the min — quadratic in polygon size, but
-    // bounded by MAX_BOUNDARY_LEAVES × 14 edges and only paid once per
-    // metatile thanks to the cache.
-    function _simplifyClosedPolygon(pts: Vec2[], budget: number): Vec2[] {
-      const n = pts.length;
-      if (n <= budget) return pts;
-      const next = new Int32Array(n);
-      const prev = new Int32Array(n);
-      const alive = new Uint8Array(n);
-      for (let i = 0; i < n; i++) { next[i] = (i + 1) % n; prev[i] = (i - 1 + n) % n; alive[i] = 1; }
-      const area = new Float64Array(n);
-      function _triArea(i: number) {
-        const a = pts[prev[i]], b = pts[i], c = pts[next[i]];
-        return Math.abs((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])) * 0.5;
-      }
-      for (let i = 0; i < n; i++) area[i] = _triArea(i);
-      let remaining = n;
-      while (remaining > budget) {
-        // Find smallest-area alive vertex.
-        let mi = -1, ma = Infinity;
-        for (let i = 0; i < n; i++) {
-          if (!alive[i]) continue;
-          if (area[i] < ma) { ma = area[i]; mi = i; }
-        }
-        if (mi === -1) break;
-        const p = prev[mi], q = next[mi];
-        next[p] = q; prev[q] = p;
-        alive[mi] = 0;
-        remaining--;
-        area[p] = _triArea(p);
-        area[q] = _triArea(q);
-      }
-      const out: Vec2[] = [];
-      // Find any alive vertex to start the walk.
-      let start = -1;
-      for (let i = 0; i < n; i++) if (alive[i]) { start = i; break; }
-      if (start === -1) return pts;
-      let cur = start;
-      do {
-        out.push(pts[cur]);
-        cur = next[cur];
-      } while (cur !== start);
-      return out;
-    }
 
     type BoundaryMesh = {
       polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
@@ -576,25 +528,25 @@
       loops.sort((a, b) => b.length - a.length);
       const outer = loops[0];
 
-      // 6. Materialize the outer-boundary as Vec2 points, simplify with
-      // Visvalingam-Whyatt down to the vertex budget, then dilate slightly
-      // around the polygon's centroid so adjacent aggregates overlap by a
-      // small amount and the visible black streaks from FP-precision drift
-      // (and from simplification-induced edge-mismatch with neighbors) are
-      // hidden under the overlap. The metatile's local origin is at one
-      // corner of the cluster bbox, so dilating around the polygon centroid
-      // (not the origin) is what keeps the expansion isotropic.
+      // 6. Materialize the outer-boundary as Vec2 points and dilate slightly
+      // around the polygon's centroid so any sub-pixel f32 precision drift
+      // in the GPU shader's transform composition is covered by overlap.
+      // We don't simplify: keeping every spectre-edge boundary vertex is
+      // what makes adjacent clusters' shared edges share their entire
+      // vertex sequence by construction (no chord-vs-chord mismatch). The
+      // metatile's local origin is at one corner of the cluster bbox, so
+      // dilating around the polygon centroid (not the origin) is what
+      // keeps the expansion isotropic.
       const outerPts: Vec2[] = outer.map((id) => vertList[id]);
-      const simplified = _simplifyClosedPolygon(outerPts, BOUNDARY_VERTEX_BUDGET);
       let cx = 0, cy = 0;
-      for (const p of simplified) { cx += p[0]; cy += p[1]; }
-      cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.012;
-      const polygon = new Float32Array(simplified.length * 2);
-      const flat: number[] = new Array(simplified.length * 2);
-      for (let i = 0; i < simplified.length; i++) {
-        const x = cx + (simplified[i][0] - cx) * DILATE;
-        const y = cy + (simplified[i][1] - cy) * DILATE;
+      for (const p of outerPts) { cx += p[0]; cy += p[1]; }
+      cx /= outerPts.length; cy /= outerPts.length;
+      const DILATE = 1.005;
+      const polygon = new Float32Array(outerPts.length * 2);
+      const flat: number[] = new Array(outerPts.length * 2);
+      for (let i = 0; i < outerPts.length; i++) {
+        const x = cx + (outerPts[i][0] - cx) * DILATE;
+        const y = cy + (outerPts[i][1] - cy) * DILATE;
         polygon[i * 2 + 0] = x;
         polygon[i * 2 + 1] = y;
         flat[i * 2 + 0] = x;

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -2230,7 +2230,6 @@
           type: 'colorBlend',
           sigma:     colorBlendState.sigma,
           offset:    colorBlendState.offset,
-          leafNoise: colorBlendState.leafNoise,
         });
         // Walk every sampled trajectory point through maybeExtend on
         // pool worker 0 to find the cumulative extensionLevel needed
@@ -2777,7 +2776,6 @@
         colorBlend: {
           sigma:     colorBlendState.sigma,
           offset:    colorBlendState.offset,
-          leafNoise: colorBlendState.leafNoise,
         },
         aggHex: {
           dilation: aggHexState.dilation,
@@ -2844,7 +2842,6 @@
         const cb = cfg.colorBlend;
         if (Number.isFinite(+cb.sigma)  && +cb.sigma > 0)   colorBlendState.sigma     = +cb.sigma;
         if (Number.isFinite(+cb.offset))                    colorBlendState.offset    = +cb.offset;
-        if (Number.isFinite(+cb.leafNoise) && +cb.leafNoise >= 0) colorBlendState.leafNoise = +cb.leafNoise;
         (window as any)._spectreSyncColorBlend?.();
         viewerState.onViewChange?.(viewerState);
       }

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -51,6 +51,9 @@
       }
       const n = _ALL_LABELS.length;
       viewerState.clearValue = { r: r / n, g: g / n, b: b / n, a: 1 };
+      viewerState.clearValue.r = 1;
+      viewerState.clearValue.g = 0;
+      viewerState.clearValue.b = 0;
     }
     function _applySeed(s: number) {
       paletteState.setSeed(s);
@@ -132,7 +135,7 @@
     // covering all such sub-pixel mismatches. The overlap is invisible
     // because adjacent leaves' fill colors are picked by the walker to
     // be visually similar at the moment of rendering.
-    const _LEAF_DILATE = 3.0;
+    const _LEAF_DILATE = 8.0;
     const meshVertexData = (() => {
       let cx = 0, cy = 0;
       for (const v of spectreVertices) { cx += v[0]; cy += v[1]; }
@@ -784,13 +787,12 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      // 1.05 (5% per side) is enough to swallow the chord-vs-chord
-      // mismatches between the parent polygon's decimation and its
-      // children's decimations of the same shared boundary segments,
-      // plus the donor-approximation mismatches at sub-levels > 5
-      // where adjacent clusters use scaled donor shapes that don't
-      // exactly match the actual cluster boundary at that level.
-      const DILATE = 1.05;
+      // DIAGNOSTIC: 5× aggregate-polygon dilation. If gaps persist with
+      // this much overdraw, they're not from chord-vs-chord mismatches
+      // between adjacent cells — there must be world-space regions
+      // where no cell of any kind is being emitted. Dial back once root
+      // cause is found.
+      const DILATE = 5.0;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -135,7 +135,7 @@
     // covering all such sub-pixel mismatches. The overlap is invisible
     // because adjacent leaves' fill colors are picked by the walker to
     // be visually similar at the moment of rendering.
-    const _LEAF_DILATE = 1.05;
+    const _LEAF_DILATE = 1.00;
     const meshVertexData = (() => {
       let cx = 0, cy = 0;
       for (const v of spectreVertices) { cx += v[0]; cy += v[1]; }
@@ -599,14 +599,16 @@
     // GPU shader, which the small DILATE below covers. Sub-level 5
     // boundary is ~3200 verts → ~3200 triangles per aggregate × ~5K
     // visible = ~16M triangles, well within GPU fill rate at 1.8M pixels.
-    // Above this sub-level, skip raw extraction — Spectre supertile
-    // boundaries are self-similar after simplification to 16 verts, so a
-    // donor polygon extracted once at the cap can stand in for all higher
-    // levels by scaling up by the radius ratio. Without this cap, extension
-    // level 9 would mean the walker tries to extract polygons from
-    // metatiles with billions of leaves, falls back to recursion, and
-    // emits millions of instances per frame.
-    const EXTRACT_CAP = 5;
+    // Above this sub-level, skip raw extraction and use a scaled donor
+    // polygon. The donor's shape is the cap-level cluster boundary;
+    // higher sub-levels' actual boundaries have additional fractal
+    // detail that the donor smooths over, which causes adjacent
+    // donor-scaled polygons to leave visible chord-mismatch slivers.
+    // Bumping the cap to 6 means a sub-level 6 cluster is extracted
+    // from real leaves (~530K leaves max per shape) — its boundary is
+    // exact, so adjacent same-shape sub-level 6 cells tile properly.
+    // Above 6 we still use the donor (now the sub-level 6 polygon).
+    const EXTRACT_CAP = 6;
 
     type BoundaryMesh = {
       polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
@@ -787,6 +789,14 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
+      // Adjacent aggregate polygons leave chord-mismatch slivers from
+      // independent anchor-decimation and from donor-approximation
+      // mismatches at sub-levels > 5. With cluster size ~50 px on
+      // screen, DILATE = 1.5 gives ~12 px overlap per pair, enough to
+      // swallow runs of ~10 px or less. Aggregates draw on top of
+      // their parents at full alpha (in the fade band), so the heavy
+      // dilation doesn't blend colours muddily — adjacent same-α
+      // polygons fully replace each other in the overlap.
       const DILATE = 1.05;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
@@ -826,20 +836,24 @@
     const _gpuMeshCache = new WeakMap<MetaTile, GpuMesh | null>();
     const _gpuMeshByShape = new Map<string, GpuMesh | null>();
 
-    // Donor metatiles for boundary extraction, one per shape (Γ vs non-Γ).
-    // Their polygons are extracted on first demand and reused (scaled) for
-    // any same-shape metatile with subLevel > EXTRACT_CAP. The donor's
-    // _localRadius is captured so we can compute the scale factor without
-    // needing the Spectre inflation constant analytically.
+    // Donor metatiles for boundary extraction, one per shape (Γ vs non-Γ),
+    // at sub-level EXTRACT_CAP. Their polygons are extracted on first
+    // demand and reused (scaled) for any same-shape metatile with
+    // subLevel > EXTRACT_CAP. The donor's _localRadius is captured so we
+    // can compute the scale factor without needing the inflation constant
+    // analytically.
     //
-    // After BASE_DEPTH inflations every metatile in baseCluster has
-    // subLevel = BASE_DEPTH + 1, so we use baseCluster.Delta (non-Γ) and
-    // baseCluster.Gamma directly. baseCluster.Gamma isn't reachable from
-    // baseCluster.Delta, so its radii/sublevels aren't attached yet.
+    // baseCluster has subLevel = BASE_DEPTH + 1 = 5 metatiles. We need
+    // donors at EXTRACT_CAP = 6, so we inflate one more time to get
+    // sub-level 6 metatiles. The Γ donor is taken straight from
+    // baseCluster (subLevel 5 + 1 = 6 in the inflated cluster).
     const _donors = (() => {
-      attachRadii(baseCluster.Gamma);
-      attachSubLevels(baseCluster.Gamma);
-      return { nonGamma: baseCluster.Delta, gamma: baseCluster.Gamma };
+      const inflated = buildSupertiles(baseCluster);
+      attachRadii(inflated.Delta);
+      attachSubLevels(inflated.Delta);
+      attachRadii(inflated.Gamma);
+      attachSubLevels(inflated.Gamma);
+      return { nonGamma: inflated.Delta, gamma: inflated.Gamma };
     })();
 
     function _getDonorBoundary(isGamma: boolean): { mesh: BoundaryMesh; radius: number } | null {
@@ -927,7 +941,8 @@
         for (const { child } of mt.geometries) rec(child);
       }
       rec(walkerState.currentRoot);
-      rec(baseCluster.Gamma);
+      rec(_donors.nonGamma);
+      rec(_donors.gamma);
       // Donors for subLevel > EXTRACT_CAP — extract once so the first
       // scaled-polygon emission doesn't pay the donor's extraction cost.
       _getDonorBoundary(false);

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -964,6 +964,10 @@
       centerX: number; centerY: number;
       pixelScale: number;
       pixelWidth: number; pixelHeight: number;
+      // Optional: if set, used for AGG threshold instead of pixelScale.
+      // Lets the user "freeze" the aggregation level while still zooming
+      // the actual rendering in/out.
+      aggPixelScale?: number;
     };
 
     // Aggregate at this on-screen pixel extent: a metatile whose actual
@@ -1089,6 +1093,7 @@
 
       let vMnX = -Infinity, vMxX = Infinity, vMnY = -Infinity, vMxY = Infinity;
       let pixelScale = 1;
+      let aggPixelScale = 1; // used for AGG threshold; can be frozen
       let viewLevel = 0;
       // Per-frame precomputed Gaussian weight table: weight[L] =
       // exp(-(L − viewLevel)² / 2σ²). 64 entries cover any plausible
@@ -1155,24 +1160,29 @@
         //   aggThresh ≤ pixelExtent < fadeUpper → aggregate at full alpha,
         //                                          children at lerped alpha
         //   fadeUpper ≤ pixelExtent          → no aggregate, children at full
-        // The lerped alpha smoothly fades the next refinement level in over
-        // a 2× zoom band, hiding the visual snap at the threshold. When the
-        // cell crosses out of the band on the high side, the aggregate stops
-        // being drawn just as the children reach alpha 1, so they fully
-        // cover whatever the aggregate was hiding — no discontinuity.
-        const pixelExtent = 2 * r * pixelScale;
+        //
+        // BUT: aggregates at sub-levels above EXTRACT_CAP use scaled donor
+        // polygons (not real-extracted boundaries), and the donor's shape
+        // is the cap-level cluster's boundary, which doesn't match the
+        // higher-level cluster's actual boundary in detail. Adjacent same-
+        // shape donor-scaled cells leave chord-mismatch slivers.
+        // Children, on the other hand, are at sub-level ≤ cap and emit
+        // real-extracted polygons that tile correctly. So when the parent
+        // would be donor-scaled, we *skip* the parent emit and have
+        // children emit at full alpha — they fully cover the cluster
+        // without leaving gaps. This sacrifices the fade-band crossfade
+        // for that one level but eliminates the chord-mismatch artefacts.
+        const pixelExtent = 2 * r * aggPixelScale;
         const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
-        // 4× zoom range for the fade band (~1.5 substitution levels)
-        // gives a noticeably gentler crossfade than 2× — both refinement
-        // levels stay alive long enough for the eye to register the
-        // transition rather than seeing it snap by.
         const fadeUpper = aggThresh * 4;
+        const mySubLevel = (mt as any)._subLevel as number;
+        const parentIsExtracted = mySubLevel <= EXTRACT_CAP;
 
         let childAlpha = alphaIn;
         if (pixelExtent < fadeUpper) {
           const mesh = getGpuMesh(mt);
           if (mesh) {
-            emit(mt, mt.name, d, (mt as any)._subLevel, alphaIn);
+            emit(mt, mt.name, d, mySubLevel, alphaIn);
             if (pixelExtent < aggThresh) return;
             const t = (pixelExtent - aggThresh) / (fadeUpper - aggThresh);
             childAlpha = alphaIn * t;
@@ -1232,7 +1242,13 @@
         vMnY = -halfH - m;
         vMxY =  halfH + m;
         pixelScale = view.pixelScale;
-        viewLevel = viewLevelFor(pixelScale);
+        // aggPixelScale defaults to view.pixelScale, but can be overridden
+        // (e.g., by the freeze toggle) so the AGG threshold is computed
+        // against a frozen pixelScale even though the actual rendering
+        // uses view.pixelScale. That lets the user zoom in on a captured
+        // structure without it re-aggregating.
+        aggPixelScale = (view as any).aggPixelScale ?? view.pixelScale;
+        viewLevel = viewLevelFor(aggPixelScale);
         // The weight table is now indexed by ABSOLUTE LEVEL DISTANCE from
         // the cell being emitted, not by absolute level number. weight[d]
         // is the weight applied to an ancestor d substitution levels up
@@ -1356,6 +1372,11 @@
     // Rebuilt on every view change; the walker's scratch buffer is
     // reused so this call is allocation-free in the hot path.
     let _initialFitDone = false;
+    // Mutable freeze state: when non-null, the aggregation threshold is
+    // computed against this pixelScale instead of the live one, so the
+    // structure stays at its captured aggregation level while the user
+    // zooms the camera in/out for inspection.
+    const freezeState: { aggPixelScale: number | null } = { aggPixelScale: null };
     function repackInstances(): void {
       if (viewerState.pixelWidth === 0) return;
       const view = {
@@ -1364,6 +1385,7 @@
         pixelScale: viewerState.pixelScale,
         pixelWidth: viewerState.pixelWidth,
         pixelHeight: viewerState.pixelHeight,
+        aggPixelScale: freezeState.aggPixelScale ?? undefined,
       };
       maybeExtend(view);
       const result = walker(walkerState.currentRoot, walkerState.currentRootTransform, view);
@@ -1471,6 +1493,24 @@
       }
     });
 
+    // Freeze checkbox: locks the aggregation level to whatever it was at
+    // the moment the box was checked, so zooming in past the threshold
+    // doesn't trigger refinement. Useful for inspecting a specific
+    // aggregation level's geometry up close.
+    const _freezeCb = document.createElement('input');
+    _freezeCb.type = 'checkbox';
+    _freezeCb.id = 'spectre-freeze';
+    const _freezeLabel = document.createElement('label');
+    _freezeLabel.htmlFor = 'spectre-freeze';
+    _freezeLabel.textContent = 'freeze structure';
+    _freezeLabel.style.flex = '0 0 auto';
+    _freezeLabel.style.cursor = 'pointer';
+    _freezeCb.addEventListener('change', () => {
+      freezeState.aggPixelScale = _freezeCb.checked ? viewerState.pixelScale : null;
+      viewerState.onViewChange?.(viewerState);
+      viewerState.requestFrame();
+    });
+
     const _viewRow = document.createElement('div');
     _viewRow.style.display = 'flex';
     _viewRow.style.gap = '8px';
@@ -1484,7 +1524,7 @@
     const _viewLabel2 = document.createElement('label');
     _viewLabel2.textContent = 'set:';
     _viewLabel2.style.flex = '0 0 auto';
-    _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput);
+    _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput, _freezeCb, _freezeLabel);
     display(_viewRow);
   </script>
 </notebook>

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -608,7 +608,7 @@
     // from real leaves (~530K leaves max per shape) — its boundary is
     // exact, so adjacent same-shape sub-level 6 cells tile properly.
     // Above 6 we still use the donor (now the sub-level 6 polygon).
-    const EXTRACT_CAP = 7;
+    const EXTRACT_CAP = 6;
 
     type BoundaryMesh = {
       polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
@@ -844,11 +844,10 @@
     // analytically.
     //
     // baseCluster has subLevel = BASE_DEPTH + 1 = 5 metatiles. We need
-    // donors at EXTRACT_CAP = 7, so we inflate twice to get sub-level 7
+    // donors at EXTRACT_CAP = 6, so we inflate once to get sub-level 6
     // metatiles.
     const _donors = (() => {
-      let inflated = buildSupertiles(baseCluster);
-      inflated = buildSupertiles(inflated);
+      const inflated = buildSupertiles(baseCluster);
       attachRadii(inflated.Delta);
       attachSubLevels(inflated.Delta);
       attachRadii(inflated.Gamma);

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -280,6 +280,24 @@
     function _typeForLabel(label: string): string {
       return label === "Gamma1" || label === "Gamma2" ? "Gamma" : label;
     }
+    // Sat/light defaults the walker uses when assembling per-level/per-type
+    // colors. Each ancestor's contribution is a single RGB point in this
+    // (hue, sat, light) space; the walker blends those RGBs by a Gaussian
+    // weight over substitution-level distance from viewLevel, so all
+    // channels move together as the user zooms. The per-type mods nudge
+    // sat/light so siblings of the same level still look distinct.
+    const _BASE_SAT = 0.55;
+    const _SAT_DELTA = 0.18;
+    const _BASE_LIGHT = 0.55;
+    const _LIGHT_DELTA = 0.10;
+    function colorForLevelType(level: number, label: string): [number, number, number] {
+      const type = _typeForLabel(label);
+      const base = _TYPE_BASE_HUE[type] ?? 0;
+      const hue = base + level * _LEVEL_HUE_STEP;
+      const sat = Math.max(0, Math.min(1, _BASE_SAT   + _SAT_DELTA   * (_TYPE_SAT_MOD[type]   ?? 0)));
+      const lit = Math.max(0, Math.min(1, _BASE_LIGHT + _LIGHT_DELTA * (_TYPE_LIGHT_MOD[type] ?? 0)));
+      return _hslToRgb(hue, sat, lit);
+    }
   </script>
 
   <script id="cluster" type="text/x-typescript">
@@ -741,23 +759,26 @@
     // ~5× more cells than necessary.
     const _LOOSE_RADIUS_FACTOR = 1.55;
 
-    // Zoom-dependent color via HSL channel encoding. The cell carries a
-    // color whose hue is read from the cell itself, saturation from its
-    // immediate parent meta, lightness from its grandparent, with viewLevel
-    // sliding the whole window up the ancestry chain in lockstep with the
-    // user's zoom-out. Three different substitution levels drive three
-    // perceptual axes simultaneously, so coarse, medium, and fine
-    // structure are all visible at once instead of any single one
-    // dominating. Transitions are continuous because each channel pick
-    // linearly interpolates between integer "levels-up" stack slots.
+    // Zoom-dependent color via Gaussian-weighted ancestor blend. Each
+    // visible cell has a precomputed RGB at every ancestor level (cell
+    // color at its own subLevel, plus one RGB per ancestor on the stack).
+    // viewLevel — derived from pixelScale so viewLevel = 0 places leaves
+    // exactly at the AGG_PX threshold, and each unit grows by one
+    // substitution step's worth of zoom-out — picks the center of the
+    // Gaussian. The walker writes a single weighted RGB sum to the
+    // instance buffer, so all perceptual channels (hue, sat, light) shift
+    // together as viewLevel slides. That coordinated motion is what makes
+    // a continuous zoom look seamless: adjacent viewLevels produce
+    // adjacent colors, instead of the channels each transitioning at
+    // different stack offsets and "flashing" against each other.
     //
-    // viewLevel = 0 places leaves at the AGG_PX threshold (i.e., it's the
-    // log_inflation of how many supertile levels the user has zoomed past
-    // the leaf-aggregation boundary). At fine zoom (low viewLevel) the
-    // cell's own type colors the hue. At deep zoom each channel reads
-    // from progressively-higher ancestors, so what the eye picks up as
-    // hue/sat/lightness all reflect levels relevant to that zoom.
-    //
+    // σ ≈ 0.7 makes the dominant ancestor account for ~50% of the blend,
+    // its two immediate neighbors ~25% each, and the rest negligible.
+    // That's enough multi-scale information that adjacent supertiles still
+    // read as different metatypes at a single zoom, but smooth enough
+    // that an animated zoom doesn't feel stepwise.
+    const SIGMA = 0.7;
+    const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Spectre supertile inflation factor — each substitution level's
     // bounding circle scales by ~(1 + √3) ≈ 2.73 versus the previous;
     // I'm using 2.5 here as a tuning compromise.
@@ -813,63 +834,29 @@
       const stMir = new Uint8Array(STK);
       const stTx  = new Float64Array(STK);
       const stTy  = new Float64Array(STK);
-      // Ancestry channel stack: each entered meta pushes its (subLevel, hue,
-      // satMod, lightMod). The walker picks one ancestor per perceptual
-      // channel (different stack distances) so multiple substitution levels
-      // remain visible at once instead of any single one dominating.
-      // Stack is ordered with index 0 = root (highest subLevel) and
-      // index ancDepth−1 = immediate parent (lowest subLevel).
-      const stHue   = new Float64Array(STK);
-      const stSatM  = new Float64Array(STK);
-      const stLitM  = new Float64Array(STK);
-      const stSubL  = new Float64Array(STK);
+      // Ancestry color stack: each entered meta pushes its (subLevel, RGB).
+      // emit() blends the cell's own RGB with these ancestor RGBs using a
+      // Gaussian weight on (subLevel − viewLevel). Stack is ordered with
+      // index 0 = root (highest subLevel) and index ancDepth−1 = immediate
+      // parent (lowest subLevel).
+      const stColR = new Float64Array(STK);
+      const stColG = new Float64Array(STK);
+      const stColB = new Float64Array(STK);
+      const stSubL = new Float64Array(STK);
       let ancDepth = 0;
 
       let vMnX = -Infinity, vMxX = Infinity, vMnY = -Infinity, vMxY = Infinity;
       let pixelScale = 1;
       let viewLevel = 0;
+      // Per-frame precomputed Gaussian weight table: weight[L] =
+      // exp(-(L − viewLevel)² / 2σ²). 64 entries cover any plausible
+      // substitution level, replacing per-emit Math.exp calls with array
+      // lookups. Filled at the start of each walk().
+      const weightTable = new Float64Array(64);
       const buckets = new Map<MetaTile | null, WalkBucket>();
       // Pre-seed the leaf bucket at the requested size; it reuses across
       // frames. Aggregate buckets are created lazily and reset each frame.
       buckets.set(null, _newBucket(null, initialLeafCap));
-
-      // Channel-offset assignments. Cell (level 0 in the "levels-up" sense)
-      // contributes hue. Each step up the ancestry chain adds 1 to the
-      // levels-up count, so an offset of N means "N levels above the cell."
-      // Picking saturation from the +1 ancestor and lightness from the +2
-      // ancestor encodes three substitution scales into the cell's color
-      // simultaneously.
-      const _HUE_OFFSET   = 0;
-      const _SAT_OFFSET   = 1;
-      const _LIGHT_OFFSET = 2;
-      const _BASE_SAT   = 0.55;
-      const _SAT_AMP    = 0.30;
-      const _BASE_LIGHT = 0.55;
-      const _LIGHT_AMP  = 0.20;
-
-      // Pick a channel value at a given "levels-up" target with linear
-      // interpolation between the two adjacent stack levels. levelsUp is
-      // continuous and viewLevel-dependent, so transitions between integer
-      // levels remain smooth as the user zooms.
-      //
-      // levelsUp = 0 → cell itself; 1 → parent; 2 → grandparent; clamped at
-      // root for values past the stack height.
-      function _pickChannel(
-        levelsUp: number,
-        cellValue: number,
-        getter: (idx: number) => number,
-      ): number {
-        const f = levelsUp;
-        const lo = Math.floor(f);
-        const t = f - lo;
-        const getAt = (li: number): number => {
-          if (li <= 0) return cellValue;
-          const idx = ancDepth - li;
-          if (idx < 0) return ancDepth > 0 ? getter(0) : cellValue;
-          return getter(idx);
-        };
-        return getAt(lo) * (1 - t) + getAt(lo + 1) * t;
-      }
 
       function emit(bucketKey: MetaTile | null, label: string, d: number, cellSubLevel: number) {
         let b = buckets.get(bucketKey);
@@ -882,28 +869,25 @@
         b.i16[i * 8 + 4] = Math.max(-32768, Math.min(32767, Math.round(c * 32767)));
         b.i16[i * 8 + 5] = Math.max(-32768, Math.min(32767, Math.round(s * 32767)));
 
-        // Cell's own (hue, satMod, lightMod) — used when no ancestor exists
-        // at the requested levels-up.
-        const type = _typeForLabel(label);
-        const cellHue = (_TYPE_BASE_HUE[type] ?? 0) + cellSubLevel * _LEVEL_HUE_STEP;
-        const cellSatMod = _TYPE_SAT_MOD[type] ?? 0;
-        const cellLitMod = _TYPE_LIGHT_MOD[type] ?? 0;
-
-        // Channel encoding: each scale's structure shows up in a different
-        // perceptual axis. levelsUp targets are positive offsets from the
-        // cell, advanced by viewLevel so as the user zooms out the whole
-        // window slides up the ancestry chain in lockstep.
-        const huePick   = _pickChannel(viewLevel + _HUE_OFFSET,   cellHue,    (k) => stHue[k]);
-        const satPick   = _pickChannel(viewLevel + _SAT_OFFSET,   cellSatMod, (k) => stSatM[k]);
-        const litPick   = _pickChannel(viewLevel + _LIGHT_OFFSET, cellLitMod, (k) => stLitM[k]);
-        const sat   = Math.max(0, Math.min(1, _BASE_SAT   + _SAT_AMP   * satPick));
-        const light = Math.max(0, Math.min(1, _BASE_LIGHT + _LIGHT_AMP * litPick));
-        const [R, G, B] = _hslToRgb(huePick, sat, light);
+        // Single-source Gaussian-weighted RGB blend over the ancestry chain
+        // plus this cell. weightTable was filled at the start of walk() so
+        // this is a few multiply-adds per ancestor instead of an exp per
+        // emit. All perceptual channels move together because they all
+        // come from one weighted sum.
+        const cellCol = colorForLevelType(cellSubLevel, label);
+        let w = weightTable[cellSubLevel | 0];
+        let total = w, R = w * cellCol[0], G = w * cellCol[1], B = w * cellCol[2];
+        for (let k = 0; k < ancDepth; k++) {
+          w = weightTable[stSubL[k] | 0];
+          total += w;
+          R += w * stColR[k]; G += w * stColG[k]; B += w * stColB[k];
+        }
+        const inv = 1 / total;
 
         const off = i * 16;
-        b.u8[off + 12] = Math.max(0, Math.min(255, Math.round(R * 255)));
-        b.u8[off + 13] = Math.max(0, Math.min(255, Math.round(G * 255)));
-        b.u8[off + 14] = Math.max(0, Math.min(255, Math.round(B * 255)));
+        b.u8[off + 12] = Math.max(0, Math.min(255, Math.round(R * inv * 255)));
+        b.u8[off + 13] = Math.max(0, Math.min(255, Math.round(G * inv * 255)));
+        b.u8[off + 14] = Math.max(0, Math.min(255, Math.round(B * inv * 255)));
         b.u8[off + 15] = stMir[d] ? 255 : 0;
         b.count = i + 1;
       }
@@ -926,11 +910,12 @@
           if (mesh) { emit(mt, mt.name, d, (mt as any)._subLevel); return; }
         }
 
-        // Push this meta's channel info onto the ancestry stack, recurse, pop.
+        // Push this meta's RGB onto the ancestry stack, recurse, pop.
         const mySL = (mt as any)._subLevel as number;
-        stHue [ancDepth] = (_TYPE_BASE_HUE [mt.name] ?? 0) + mySL * _LEVEL_HUE_STEP;
-        stSatM[ancDepth] = _TYPE_SAT_MOD  [mt.name] ?? 0;
-        stLitM[ancDepth] = _TYPE_LIGHT_MOD[mt.name] ?? 0;
+        const myCol = colorForLevelType(mySL, mt.name);
+        stColR[ancDepth] = myCol[0];
+        stColG[ancDepth] = myCol[1];
+        stColB[ancDepth] = myCol[2];
         stSubL[ancDepth] = mySL;
         ancDepth++;
 
@@ -963,12 +948,28 @@
         const halfW = view.pixelWidth / (2 * view.pixelScale);
         const halfH = view.pixelHeight / (2 * view.pixelScale);
         const m = _spectreBoundRadius;
-        vMnX = view.centerX - halfW - m;
-        vMxX = view.centerX + halfW + m;
-        vMnY = view.centerY - halfH - m;
-        vMxY = view.centerY + halfH + m;
+        // Walker accumulates positions in *view-relative* world units: every
+        // stTx/stTy is "world coordinate minus viewCenter", computed in Float64
+        // throughout the recursion. The instance buffer's iWorld is then a
+        // small-magnitude Float32 (bounded by the viewport radius), and the
+        // GPU shader doesn't have to subtract two large numbers to project to
+        // clip space. Without this trick, the cancellation of (world - center)
+        // inside `world * view.scale + view.offset` chews through Float32
+        // precision once world coordinates pass ~1e6, and shared edges
+        // between adjacent cells crack open. (Standard "Relative-To-Center"
+        // / RTC trick used by web maps and 3D engines.)
+        vMnX = -halfW - m;
+        vMxX =  halfW + m;
+        vMnY = -halfH - m;
+        vMxY =  halfH + m;
         pixelScale = view.pixelScale;
         viewLevel = viewLevelFor(pixelScale);
+        // Fill the per-frame Gaussian weight table once. emit() then reads
+        // weightTable[L] instead of paying for Math.exp per cell.
+        for (let L = 0; L < weightTable.length; L++) {
+          const dl = L - viewLevel;
+          weightTable[L] = Math.exp(-(dl * dl) / _TWO_SIGMA_SQ);
+        }
         ancDepth = 0;
 
         // Reset all buckets.
@@ -976,8 +977,8 @@
 
         stRot[0] = rootTransform.rot;
         stMir[0] = rootTransform.mirror;
-        stTx[0]  = rootTransform.t[0];
-        stTy[0]  = rootTransform.t[1];
+        stTx[0]  = rootTransform.t[0] - view.centerX;
+        stTy[0]  = rootTransform.t[1] - view.centerY;
         recurse(rootMeta, 0);
 
         // Concatenate buckets into outData. Leaves first (key === null),

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -19,6 +19,55 @@
     </figcaption>`);
   </script>
 
+  <script id="palette-controls" type="text/x-typescript">
+    // A "Randomize" button that picks a new palette seed and triggers a
+    // redraw. paletteState.rgb is mutated in place, so the next frame's
+    // walker reads the new colours without re-running any cells.
+    const _ctrlBtn = document.createElement('button');
+    _ctrlBtn.type = 'button';
+    _ctrlBtn.textContent = 'Randomize colours';
+    _ctrlBtn.style.padding = '4px 12px';
+    _ctrlBtn.style.fontSize = '12px';
+    _ctrlBtn.style.cursor = 'pointer';
+    const _ctrlSeed = document.createElement('input');
+    _ctrlSeed.type = 'number';
+    _ctrlSeed.min = '0';
+    _ctrlSeed.value = String(paletteState.seed);
+    _ctrlSeed.style.width = '80px';
+    _ctrlSeed.style.fontSize = '12px';
+    _ctrlSeed.style.padding = '2px 6px';
+    function _applySeed(s: number) {
+      paletteState.setSeed(s);
+      _ctrlSeed.value = String(paletteState.seed);
+      // requestFrame just redraws the existing instance buffer with the
+      // colours it already has. To pick up the new palette we need to
+      // re-run the walker, which packs each instance's colour at emit
+      // time — that's what onViewChange (= repackInstances) does.
+      viewerState.onViewChange?.(viewerState);
+      viewerState.requestFrame();
+    }
+    _ctrlBtn.addEventListener('click', () => {
+      _applySeed(Math.floor(Math.random() * 99999));
+    });
+    _ctrlSeed.addEventListener('input', () => {
+      _applySeed(parseInt(_ctrlSeed.value, 10) || 0);
+    });
+    const _ctrlRow = document.createElement('div');
+    _ctrlRow.style.display = 'flex';
+    _ctrlRow.style.gap = '8px';
+    _ctrlRow.style.alignItems = 'center';
+    _ctrlRow.style.margin = '8px 0';
+    _ctrlRow.style.fontFamily = 'var(--sans-serif)';
+    const _ctrlSeedLabel = document.createElement('label');
+    _ctrlSeedLabel.style.display = 'inline-flex';
+    _ctrlSeedLabel.style.gap = '6px';
+    _ctrlSeedLabel.style.alignItems = 'center';
+    _ctrlSeedLabel.style.fontSize = '12px';
+    _ctrlSeedLabel.append('seed ', _ctrlSeed);
+    _ctrlRow.append(_ctrlBtn, _ctrlSeedLabel);
+    display(_ctrlRow);
+  </script>
+
   <script id="gpu-context" type="text/x-typescript">
     import { createWebGPUContext } from './lib/webgpu-canvas.js';
     const _gpuCtx = await createWebGPUContext();
@@ -252,46 +301,130 @@
   </script>
 
   <script id="palette" type="text/x-typescript">
-    // Per-label palette mirroring the existing aperiodic-monotile notebook.
-    // 11 entries: the 9 metatypes plus Γ₁/Γ₂ for the two leaf labels of the
-    // Γ metatile (which doesn't itself appear as a leaf). The palette is
-    // designed — muted-but-distinct hues with a wide lightness range so
-    // adjacent tiles look different rather than muddy. Multi-scale variation
+    // Per-label palette: 11 entries — the 9 metatypes plus Γ₁/Γ₂ for the
+    // two leaf labels of the Γ metatile. Generated from a seed via the
+    // same OKLCH-clustered scheme used in the sister notebook
+    // (src/notebooks/aperiodic-monotile/index.html), so the same seed
+    // yields the same palette across both. Multi-scale colour variation
     // comes from the Gaussian blend over ancestor LEVELS in the walker,
     // not from per-level hue rotation; deeper ancestors contribute their
-    // metatype color directly. So at deep zoom, a region dominated by one
-    // ancestor reads as that ancestor's color, and the type's identity
-    // shows through across substitution scales.
-    const _LABEL_HEX: Record<string, string> = {
-      Gamma:  "#458e95",
-      Gamma1: "#50adc2",
-      Gamma2: "#83dcff",
-      Delta:  "#3a041b",
-      Theta:  "#90536e",
-      Lambda: "#7c3d21",
-      Xi:     "#af7648",
-      Pi:     "#8dc3e7",
-      Sigma:  "#de9e81",
-      Phi:    "#006061",
-      Psi:    "#003f5f",
-    };
-    const _LABEL_RGB: Record<string, [number, number, number]> = {};
-    for (const [label, hex] of Object.entries(_LABEL_HEX)) {
-      _LABEL_RGB[label] = [
+    // metatype colour directly.
+    const _ALL_LABELS = [
+      "Gamma", "Gamma1", "Gamma2",
+      "Delta", "Theta", "Lambda", "Xi", "Pi", "Sigma", "Phi", "Psi",
+    ];
+    function _typeForLabel(label: string): string {
+      return label === "Gamma1" || label === "Gamma2" ? "Gamma" : label;
+    }
+    function _hexToRgb(hex: string): [number, number, number] {
+      return [
         parseInt(hex.slice(1, 3), 16) / 255,
         parseInt(hex.slice(3, 5), 16) / 255,
         parseInt(hex.slice(5, 7), 16) / 255,
       ];
     }
-    function _typeForLabel(label: string): string {
-      return label === "Gamma1" || label === "Gamma2" ? "Gamma" : label;
+    // OKLCH → sRGB hex. Uniform-lightness colour space so equal-L points
+    // read as equally bright; muted colours come from a low chroma rather
+    // than a low lightness.
+    function _oklchToHex(L: number, C: number, hueDeg: number): string {
+      const h = hueDeg * Math.PI / 180;
+      const a = C * Math.cos(h);
+      const b = C * Math.sin(h);
+      const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+      const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+      const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+      const l3 = l_ * l_ * l_;
+      const m3 = m_ * m_ * m_;
+      const s3 = s_ * s_ * s_;
+      let r = +4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+      let g = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+      let bl = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
+      const toSrgb = (x: number) => {
+        if (x <= 0) return 0;
+        if (x >= 1) return 1;
+        return x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1/2.4) - 0.055;
+      };
+      r = toSrgb(r); g = toSrgb(g); bl = toSrgb(bl);
+      const hh = (x: number) => Math.round(255 * x).toString(16).padStart(2, '0');
+      return '#' + hh(r) + hh(g) + hh(bl);
     }
+    // Mulberry32 — small, fast, seedable PRNG. Returns [0, 1). Same
+    // sequence for the same seed across page reloads, so palettes are
+    // reproducible.
+    function _makeSeededRng(seed: number): () => number {
+      let state = (seed >>> 0) || 1;
+      return () => {
+        state = (state + 0x6D2B79F5) >>> 0;
+        let t = state;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+    // Pick 2 or 3 cluster centers spread evenly around the wheel
+    // (complementary or triadic), then scatter the 11 tile colours across
+    // those clusters with ±~30° hue jitter per cluster. Wide lightness
+    // range gives visual punch; the cluster-anchored hues keep the whole
+    // set looking like one palette.
+    function _pleasantPalette(seed: number): Record<string, string> {
+      const rand = _makeSeededRng(seed);
+      const baseHue = rand() * 360;
+      const numClusters = 2 + Math.floor(rand() * 2);
+      const clusterSpread = 25 + rand() * 15;
+      const Cc = 0.08 + rand() * 0.04;
+      const clusterHues: number[] = [];
+      for (let k = 0; k < numClusters; k++) {
+        clusterHues.push((baseHue + k * 360 / numClusters) % 360);
+      }
+      const slotOrder = _ALL_LABELS.map((_, i) => i);
+      for (let i = slotOrder.length - 1; i > 0; i--) {
+        const j = Math.floor(rand() * (i + 1));
+        [slotOrder[i], slotOrder[j]] = [slotOrder[j], slotOrder[i]];
+      }
+      const pal: Record<string, string> = {};
+      slotOrder.forEach((labelIdx, slot) => {
+        const cluster = slot % numClusters;
+        const h = (clusterHues[cluster]
+                  + (rand() - 0.5) * 2 * clusterSpread + 360) % 360;
+        const L = 0.15 + rand() * 0.78;
+        const C = Cc + (rand() - 0.5) * 0.04;
+        pal[_ALL_LABELS[labelIdx]] = _oklchToHex(L, C, h);
+      });
+      return pal;
+    }
+    // Mutable palette state — properties are mutated in place when the
+    // user hits Randomize, and the next-frame walker reads the current
+    // values. Keeping the OBJECT identity stable means cells that
+    // captured a reference to it don't need to re-execute when the
+    // user changes the palette. setSeed() is exposed as a method so
+    // the controls cell can drive it (cell-private underscored helpers
+    // wouldn't cross the cell boundary).
+    type PaletteState = {
+      seed: number;
+      hex: Record<string, string>;
+      rgb: Record<string, [number, number, number]>;
+      setSeed(seed: number): void;
+    };
+    const paletteState: PaletteState = {
+      seed: 12345,
+      hex: {},
+      rgb: {},
+      setSeed(seed: number) {
+        this.seed = Math.max(0, seed | 0);
+        this.hex = _pleasantPalette(this.seed);
+        for (const label of _ALL_LABELS) {
+          this.rgb[label] = _hexToRgb(this.hex[label]);
+        }
+      },
+    };
+    paletteState.setSeed(paletteState.seed);
     // Walker entry point. Level is unused — kept in the signature so that
-    // multi-scale color variation can later be reintroduced by perturbing
-    // the base color per substitution level (e.g., slight lightness shifts
-    // up and down the hierarchy).
+    // multi-scale colour variation can later be reintroduced by perturbing
+    // the base colour per substitution level.
     function colorForLevelType(_level: number, label: string): [number, number, number] {
-      return _LABEL_RGB[label] ?? _LABEL_RGB[_typeForLabel(label)] ?? [0.5, 0.5, 0.5];
+      return paletteState.rgb[label]
+          ?? paletteState.rgb[_typeForLabel(label)]
+          ?? [0.5, 0.5, 0.5];
     }
   </script>
 
@@ -632,7 +765,13 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.02;
+      // 1.05 (5% per side) is enough to swallow the chord-vs-chord
+      // mismatches between the parent polygon's decimation and its
+      // children's decimations of the same shared boundary segments,
+      // plus the donor-approximation mismatches at sub-levels > 5
+      // where adjacent clusters use scaled donor shapes that don't
+      // exactly match the actual cluster boundary at that level.
+      const DILATE = 1.05;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {
@@ -840,7 +979,7 @@
     // across zooms. Adjacent cells differ at ~6 visible scales at once
     // — per-cell, per-parent, per-grandparent, per-great-grandparent,
     // etc. — instead of just one or two.
-    const SIGMA = 3.0;
+    const SIGMA = 4.0;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Offset of the Gaussian center from viewLevel. With the alpha-fade
     // band handling the visual smoothness at the aggregate-to-children

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -764,21 +764,29 @@
     // color at its own subLevel, plus one RGB per ancestor on the stack).
     // viewLevel — derived from pixelScale so viewLevel = 0 places leaves
     // exactly at the AGG_PX threshold, and each unit grows by one
-    // substitution step's worth of zoom-out — picks the center of the
-    // Gaussian. The walker writes a single weighted RGB sum to the
-    // instance buffer, so all perceptual channels (hue, sat, light) shift
-    // together as viewLevel slides. That coordinated motion is what makes
-    // a continuous zoom look seamless: adjacent viewLevels produce
-    // adjacent colors, instead of the channels each transitioning at
-    // different stack offsets and "flashing" against each other.
+    // substitution step's worth of zoom-out — picks the *base* of the
+    // Gaussian. We then shift the actual center up by COLOR_SHIFT, so a
+    // cell about to aggregate (at AGG_PX, where S = viewLevel) is biased
+    // toward its parent's color rather than its own. Result: tiny tiles
+    // fade toward their parent (so the leaf-to-aggregate handoff is
+    // visually continuous, and the new aggregate's color matches the
+    // children that just merged into it), mid-size tiles (~2.5× AGG)
+    // pick up most of their own color, and large tiles render with full
+    // own-color saturation. Texture and contrast come from the mid and
+    // large scale objects, not the about-to-disappear small ones.
     //
     // σ ≈ 0.7 makes the dominant ancestor account for ~50% of the blend,
     // its two immediate neighbors ~25% each, and the rest negligible.
-    // That's enough multi-scale information that adjacent supertiles still
-    // read as different metatypes at a single zoom, but smooth enough
-    // that an animated zoom doesn't feel stepwise.
+    // Enough multi-scale information that adjacent supertiles still read
+    // as different metatypes at a single zoom, but smooth enough that an
+    // animated zoom doesn't feel stepwise.
     const SIGMA = 0.7;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
+    // Offset of the Gaussian center from viewLevel. +1 means the center
+    // sits one substitution level above the soon-to-aggregate cell, so
+    // small things fade toward their parent's color while big things keep
+    // their own. See the long comment above.
+    const _COLOR_SHIFT = 1.0;
     // Spectre supertile inflation factor — each substitution level's
     // bounding circle scales by ~(1 + √3) ≈ 2.73 versus the previous;
     // I'm using 2.5 here as a tuning compromise.
@@ -965,9 +973,12 @@
         pixelScale = view.pixelScale;
         viewLevel = viewLevelFor(pixelScale);
         // Fill the per-frame Gaussian weight table once. emit() then reads
-        // weightTable[L] instead of paying for Math.exp per cell.
+        // weightTable[L] instead of paying for Math.exp per cell. Center is
+        // shifted up by _COLOR_SHIFT so cells at the AGG threshold pick up
+        // their parent's color instead of their own.
+        const center = viewLevel + _COLOR_SHIFT;
         for (let L = 0; L < weightTable.length; L++) {
-          const dl = L - viewLevel;
+          const dl = L - center;
           weightTable[L] = Math.exp(-(dl * dl) / _TWO_SIGMA_SQ);
         }
         ancDepth = 0;

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -681,13 +681,9 @@
         return null;
       }
 
-      // 1. Collect every leaf's accumulated transform in mt's local frame.
       const xforms: Transform[] = [];
       _collectLeafTransforms(mt, txIdentity, xforms);
 
-      // 2. Quantize vertices to integer IDs. Substitution math involves
-      // sums of unit-length vectors at multiples of 30°, so 1e-7 rounding
-      // is well above the FP noise floor at any depth we'd extract here.
       const Q = 1e7;
       const vertMap = new Map<string, number>();
       const vertList: Vec2[] = [];
@@ -700,9 +696,6 @@
         return id;
       }
 
-      // 3. For each leaf, compute its 14 vertex IDs and 14 edge keys.
-      // edgeMult counts how many leaves share each edge; multiplicity 1
-      // means it's on the cluster boundary.
       const edgeMult = new Map<number, number>();
       for (const T of xforms) {
         const ids: number[] = new Array(14);
@@ -711,14 +704,11 @@
           const a = ids[i], b = ids[(i + 1) % 14];
           const lo = a < b ? a : b;
           const hi = a < b ? b : a;
-          const key = lo * 0x100000 + hi;     // safe up to ~1M unique vertices
+          const key = lo * 0x100000 + hi;
           edgeMult.set(key, (edgeMult.get(key) ?? 0) + 1);
         }
       }
 
-      // 4. Adjacency map: vertId → 2 boundary neighbors (for a closed loop
-      // each boundary vertex has degree 2; degenerate cases would have
-      // higher degree, which we don't expect here).
       const adj = new Map<number, number[]>();
       for (const [key, mult] of edgeMult) {
         if (mult !== 1) continue;
@@ -728,9 +718,6 @@
         let lb = adj.get(hi); if (!lb) { lb = []; adj.set(hi, lb); } lb.push(lo);
       }
 
-      // 5. Stitch into closed loops. Pick the longest as the outer
-      // boundary (Spectre clusters are simply connected, so there should
-      // only be one).
       const visited = new Set<number>();
       const loops: number[][] = [];
       for (const start of adj.keys()) {
@@ -754,11 +741,6 @@
       loops.sort((a, b) => b.length - a.length);
       const outer = loops[0];
 
-      // 6. Mark the metatile's superQuad corners as anchors. These are the
-      // 4 supertile corners where adjacent same-level clusters' boundaries
-      // meet — pinning them keeps every shared edge's start and end
-      // identical between the two sides regardless of how the in-between
-      // vertices simplify.
       const anchorVertIds = new Set<number>();
       if (mt.kind === "meta") {
         for (const corner of mt.quad) {
@@ -774,29 +756,10 @@
         if (anchorVertIds.has(outer[i])) anchorIndices.push(i);
       }
 
-      // 7. Uniformly decimate each side between two anchors. ~12
-      // intermediates per side gives ~52 verts total at any subLevel
-      // (4 anchors + 4×12 intermediates), coarse but sufficient. Adjacent
-      // clusters' shared sides agree exactly because the offsets are
-      // symmetric under traversal reversal.
       const simplified = _decimateBetweenAnchors(outerPts, anchorIndices, 12);
-
-      // 8. Dilate slightly around the polygon centroid so any sub-pixel
-      // f32 precision drift in the GPU shader's transform composition is
-      // covered by overlap. The metatile's local origin sits at a corner
-      // of the cluster bbox, not the centroid, so dilating around the
-      // polygon centroid (not the origin) keeps the expansion isotropic.
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      // Adjacent aggregate polygons leave chord-mismatch slivers from
-      // independent anchor-decimation and from donor-approximation
-      // mismatches at sub-levels > 5. With cluster size ~50 px on
-      // screen, DILATE = 1.5 gives ~12 px overlap per pair, enough to
-      // swallow runs of ~10 px or less. Aggregates draw on top of
-      // their parents at full alpha (in the fade band), so the heavy
-      // dilation doesn't blend colours muddily — adjacent same-α
-      // polygons fully replace each other in the overlap.
       const DILATE = 1.00;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
@@ -809,9 +772,9 @@
         flat[i * 2 + 1] = y;
       }
       const indices = new Uint32Array(earcut(flat));
-      const mesh: BoundaryMesh = { polygon, indices };
-      _boundaryCache.set(mt, mesh);
-      return mesh;
+      const built: BoundaryMesh = { polygon, indices };
+      _boundaryCache.set(mt, built);
+      return built;
     }
 
     // ─── GPU mesh handles ──────────────────────────────────────────────
@@ -876,7 +839,6 @@
       let polygon: Float32Array;
       let indices: Uint32Array;
       if (subLevel <= EXTRACT_CAP) {
-        // Extract directly from this metatile.
         const boundary = extractBoundary(mt);
         if (boundary === null) {
           _gpuMeshByShape.set(shapeKey, null);
@@ -886,13 +848,6 @@
         polygon = boundary.polygon;
         indices = boundary.indices;
       } else {
-        // Reuse donor polygon scaled by radius ratio. Adjacent same-shape
-        // donor-scaled cells leave chord-mismatch slivers because the
-        // donor's shape doesn't match the actual cluster boundary at
-        // sub-level > EXTRACT_CAP. Apply an *extra* dilation around the
-        // scaled polygon's centroid (on top of the 5% already baked in
-        // by extractBoundary) so adjacent cells overlap by enough to
-        // swallow those slivers (observed up to ~9 px at sub-level 7).
         const donor = _getDonorBoundary(isGamma);
         if (donor === null) {
           _gpuMeshByShape.set(shapeKey, null);
@@ -900,22 +855,8 @@
           return null;
         }
         const scale = ((mt as any)._localRadius as number) / donor.radius;
-        const N = donor.mesh.polygon.length / 2;
-        // Centroid of the scaled polygon.
-        let cx = 0, cy = 0;
-        for (let i = 0; i < N; i++) {
-          cx += donor.mesh.polygon[i * 2] * scale;
-          cy += donor.mesh.polygon[i * 2 + 1] * scale;
-        }
-        cx /= N; cy /= N;
-        const EXTRA_DILATE = 1.00;
         polygon = new Float32Array(donor.mesh.polygon.length);
-        for (let i = 0; i < N; i++) {
-          const x = donor.mesh.polygon[i * 2] * scale;
-          const y = donor.mesh.polygon[i * 2 + 1] * scale;
-          polygon[i * 2]     = cx + (x - cx) * EXTRA_DILATE;
-          polygon[i * 2 + 1] = cy + (y - cy) * EXTRA_DILATE;
-        }
+        for (let i = 0; i < polygon.length; i++) polygon[i] = donor.mesh.polygon[i] * scale;
         indices = donor.mesh.indices;
       }
       const vb = _createVB(device, 'agg-poly-verts', polygon);
@@ -938,10 +879,6 @@
     // moves all that work into module init time, where it's spent
     // before the first frame.
     //
-    // Walks the live root and a Γ representative, calling getGpuMesh on
-    // one metatile per (subLevel ≤ EXTRACT_CAP, isGamma) combo to fill
-    // _gpuMeshByShape. Then forces both donors so the > EXTRACT_CAP
-    // path's polygon scaling has its source already extracted.
     (function _prewarmAggregatePolygons() {
       const seen = new Set<string>();
       const visited = new WeakSet<MetaTile>();
@@ -962,8 +899,6 @@
       rec(walkerState.currentRoot);
       rec(_donors.nonGamma);
       rec(_donors.gamma);
-      // Donors for subLevel > EXTRACT_CAP — extract once so the first
-      // scaled-polygon emission doesn't pay the donor's extraction cost.
       _getDonorBoundary(false);
       _getDonorBoundary(true);
     })();

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -833,17 +833,17 @@
     // own-color saturation. Texture and contrast come from the mid and
     // large scale objects, not the about-to-disappear small ones.
     //
-    // σ ≈ 0.45 makes the dominant ancestor account for ~88% of the cell's
-    // color and the next ancestor only ~12%. With shift = 0, that means
-    // adjacent same-parent cells share at most 12% of their color via the
-    // shared parent — too little for the eye to group them as a single
-    // region. The visual scale stays at the per-cell level at every zoom,
-    // even though the cell's own substitution level grows with zoom.
-    // Wider σ values let the parent contribution dominate enough that 8
-    // siblings under the same level-(K+1) parent average together into a
-    // single coloured region, giving the deep-zoom view a qualitatively
-    // larger-scale character than the moderate-zoom view.
-    const SIGMA = 0.45;
+    // σ ≈ 1.5 spreads each cell's blend across ~5 levels of ancestry:
+    // self ~28%, parent ~22%, grandparent ~12%, great-grandparent ~5%,
+    // and a long tail. With cell-centered weights this is intrinsic to
+    // the cell's position in the hierarchy (no zoom dependence), so the
+    // multi-scale structure is *consistent* across zooms instead of
+    // collapsing or rotating. Adjacent cells of different types differ at
+    // the per-cell scale; cells under different parents differ at the
+    // per-parent scale; cells under different grandparents differ at the
+    // per-grandparent scale — three scales of visible structure at once,
+    // showing up at every zoom level.
+    const SIGMA = 1.5;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Offset of the Gaussian center from viewLevel. With the alpha-fade
     // band handling the visual smoothness at the aggregate-to-children
@@ -995,7 +995,11 @@
         // cover whatever the aggregate was hiding — no discontinuity.
         const pixelExtent = 2 * r * pixelScale;
         const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
-        const fadeUpper = aggThresh * 2;
+        // 4× zoom range for the fade band (~1.5 substitution levels)
+        // gives a noticeably gentler crossfade than 2× — both refinement
+        // levels stay alive long enough for the eye to register the
+        // transition rather than seeing it snap by.
+        const fadeUpper = aggThresh * 4;
 
         let childAlpha = alphaIn;
         if (pixelExtent < fadeUpper) {

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -833,14 +833,17 @@
     // own-color saturation. Texture and contrast come from the mid and
     // large scale objects, not the about-to-disappear small ones.
     //
-    // σ ≈ 0.7 keeps the dominant ancestor's contribution to ~73% of the
-    // cell's color, with the next two ancestors at ~13% each. That keeps
-    // adjacent same-parent cells visibly distinct (each cell's own type
-    // colour drives most of the result) so the smallest-scale unit reads
-    // as the smallest-scale unit at every zoom — instead of all the
-    // cells in one parent cluster averaging into a single regional
-    // colour the way they would with a wider σ.
-    const SIGMA = 0.7;
+    // σ ≈ 0.45 makes the dominant ancestor account for ~88% of the cell's
+    // color and the next ancestor only ~12%. With shift = 0, that means
+    // adjacent same-parent cells share at most 12% of their color via the
+    // shared parent — too little for the eye to group them as a single
+    // region. The visual scale stays at the per-cell level at every zoom,
+    // even though the cell's own substitution level grows with zoom.
+    // Wider σ values let the parent contribution dominate enough that 8
+    // siblings under the same level-(K+1) parent average together into a
+    // single coloured region, giving the deep-zoom view a qualitatively
+    // larger-scale character than the moderate-zoom view.
+    const SIGMA = 0.45;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Offset of the Gaussian center from viewLevel. With the alpha-fade
     // band handling the visual smoothness at the aggregate-to-children

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -833,17 +833,14 @@
     // own-color saturation. Texture and contrast come from the mid and
     // large scale objects, not the about-to-disappear small ones.
     //
-    // σ ≈ 1.5 spreads each cell's blend across ~5 levels of ancestry:
-    // self ~28%, parent ~22%, grandparent ~12%, great-grandparent ~5%,
-    // and a long tail. With cell-centered weights this is intrinsic to
-    // the cell's position in the hierarchy (no zoom dependence), so the
-    // multi-scale structure is *consistent* across zooms instead of
-    // collapsing or rotating. Adjacent cells of different types differ at
-    // the per-cell scale; cells under different parents differ at the
-    // per-parent scale; cells under different grandparents differ at the
-    // per-grandparent scale — three scales of visible structure at once,
-    // showing up at every zoom level.
-    const SIGMA = 1.5;
+    // σ ≈ 3.0 blends ~8 levels of ancestry into each cell's color:
+    // self ~23%, parent ~22%, gp ~18%, ggp ~14%, gggp ~9%, ggggp ~6%,
+    // and a long tail. Cell-centered, so this multi-scale blend is
+    // intrinsic to the substitution hierarchy and stays consistent
+    // across zooms. Adjacent cells differ at ~6 visible scales at once
+    // — per-cell, per-parent, per-grandparent, per-great-grandparent,
+    // etc. — instead of just one or two.
+    const SIGMA = 3.0;
     const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
     // Offset of the Gaussian center from viewLevel. With the alpha-fade
     // band handling the visual smoothness at the aggregate-to-children

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -1407,4 +1407,74 @@
       },
     });
   </script>
+
+  <script id="view-state-display" type="text/x-typescript">
+    // Live view-state read-out + paste-to-restore. Lets the user copy the
+    // current zoom/pan state out of the page (to share, screenshot,
+    // reproduce a bug report) and paste it back later to return to the
+    // exact same view.
+    const _viewOutput = document.createElement('input');
+    _viewOutput.type = 'text';
+    _viewOutput.readOnly = true;
+    _viewOutput.style.flex = '1';
+    _viewOutput.style.minWidth = '0';
+    _viewOutput.style.fontFamily = 'var(--mono, monospace)';
+    _viewOutput.style.fontSize = '11px';
+    _viewOutput.style.padding = '2px 6px';
+    _viewOutput.title = 'Current view as JSON. Click to select, copy to share.';
+    _viewOutput.addEventListener('focus', () => _viewOutput.select());
+    function _formatView(): string {
+      const v = viewerState.getView();
+      return JSON.stringify({
+        centerX: v.centerX,
+        centerY: v.centerY,
+        pixelScale: v.pixelScale,
+      });
+    }
+    function _refreshViewOutput() { _viewOutput.value = _formatView(); }
+    // Wrap the existing onViewChange so each view update also refreshes
+    // the read-out. Done here (not in renderer.js) so the display logic
+    // stays a notebook-level concern.
+    const _origOnViewChange = viewerState.onViewChange;
+    viewerState.onViewChange = function (...args: any[]) {
+      _origOnViewChange?.apply(this, args);
+      _refreshViewOutput();
+    };
+    _refreshViewOutput();
+
+    const _viewInput = document.createElement('input');
+    _viewInput.type = 'text';
+    _viewInput.placeholder = 'Paste view JSON to restore';
+    _viewInput.style.flex = '1';
+    _viewInput.style.minWidth = '0';
+    _viewInput.style.fontFamily = 'var(--mono, monospace)';
+    _viewInput.style.fontSize = '11px';
+    _viewInput.style.padding = '2px 6px';
+    _viewInput.addEventListener('change', () => {
+      try {
+        const parsed = JSON.parse(_viewInput.value);
+        viewerState.setView(parsed);
+        _viewInput.value = '';
+      } catch (e) {
+        _viewInput.style.outline = '1px solid red';
+        setTimeout(() => { _viewInput.style.outline = ''; }, 600);
+      }
+    });
+
+    const _viewRow = document.createElement('div');
+    _viewRow.style.display = 'flex';
+    _viewRow.style.gap = '8px';
+    _viewRow.style.alignItems = 'center';
+    _viewRow.style.margin = '8px 0';
+    _viewRow.style.fontFamily = 'var(--sans-serif)';
+    _viewRow.style.fontSize = '11px';
+    const _viewLabel1 = document.createElement('label');
+    _viewLabel1.textContent = 'view:';
+    _viewLabel1.style.flex = '0 0 auto';
+    const _viewLabel2 = document.createElement('label');
+    _viewLabel2.textContent = 'set:';
+    _viewLabel2.style.flex = '0 0 auto';
+    _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput);
+    display(_viewRow);
+  </script>
 </notebook>

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -51,9 +51,9 @@
       }
       const n = _ALL_LABELS.length;
       viewerState.clearValue = { r: r / n, g: g / n, b: b / n, a: 1 };
-      viewerState.clearValue.r = 1;
-      viewerState.clearValue.g = 0;
-      viewerState.clearValue.b = 0;
+      //viewerState.clearValue.r = 1;
+      //viewerState.clearValue.g = 0;
+      //viewerState.clearValue.b = 0;
     }
     function _applySeed(s: number) {
       paletteState.setSeed(s);
@@ -512,6 +512,61 @@
     // memoized on _localRadius, so walking just the root covers the rest.
     attachRadii(rootMeta);
 
+    // ─── Centroid-based bounding ball (for tighter culling) ───────────
+    // _localRadius above is centered at the cell's local origin (a
+    // corner of the cluster), so for deep substitutions the bounding
+    // circle around the origin is several × the cluster's actual
+    // extent. We additionally compute a tight bounding ball centered on
+    // the cell's centroid and use *that* for view-frustum culling and
+    // for the pixel-extent threshold that triggers aggregation. The
+    // corner-based _localRadius is kept for donor-polygon scaling,
+    // which references the corner origin.
+    function attachCentroidBounds(mt: MetaTile): void {
+      if ((mt as any)._cBound != null) return;
+      if (mt.kind === "leaf") {
+        let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
+        for (const v of spectreVertices) {
+          if (v[0] < mnx) mnx = v[0]; if (v[0] > mxx) mxx = v[0];
+          if (v[1] < mny) mny = v[1]; if (v[1] > mxy) mxy = v[1];
+        }
+        const cx = (mnx + mxx) / 2, cy = (mny + mxy) / 2;
+        let r = 0;
+        for (const v of spectreVertices) {
+          const d = Math.hypot(v[0] - cx, v[1] - cy);
+          if (d > r) r = d;
+        }
+        (mt as any)._cCx = cx; (mt as any)._cCy = cy; (mt as any)._cBound = r;
+        return;
+      }
+      // Pass 1: each child's centroid+radius mapped into mt's frame.
+      const childCx: number[] = [], childCy: number[] = [], childCr: number[] = [];
+      let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
+      for (const { child, transform } of mt.geometries) {
+        attachCentroidBounds(child);
+        let lcx = (child as any)._cCx as number;
+        let lcy = (child as any)._cCy as number;
+        const lcr = (child as any)._cBound as number;
+        if (transform.mirror) lcy = -lcy;
+        const cs = _COS[transform.rot], sn = _SIN[transform.rot];
+        const cx = cs * lcx - sn * lcy + transform.t[0];
+        const cy = sn * lcx + cs * lcy + transform.t[1];
+        childCx.push(cx); childCy.push(cy); childCr.push(lcr);
+        if (cx - lcr < mnx) mnx = cx - lcr;
+        if (cx + lcr > mxx) mxx = cx + lcr;
+        if (cy - lcr < mny) mny = cy - lcr;
+        if (cy + lcr > mxy) mxy = cy + lcr;
+      }
+      // Pass 2: AABB-center, then radius = max child-ball reach from there.
+      const cx = (mnx + mxx) / 2, cy = (mny + mxy) / 2;
+      let r = 0;
+      for (let i = 0; i < childCx.length; i++) {
+        const d = Math.hypot(childCx[i] - cx, childCy[i] - cy) + childCr[i];
+        if (d > r) r = d;
+      }
+      (mt as any)._cCx = cx; (mt as any)._cCy = cy; (mt as any)._cBound = r;
+    }
+    attachCentroidBounds(rootMeta);
+
     // ─── Substitution level (for zoom-dependent color blending) ────────
     // _subLevel = how many substitution steps away from a leaf this
     // metatile sits. Leaves are level 0; Γ at base depth is level 1
@@ -608,7 +663,7 @@
     // from real leaves (~530K leaves max per shape) — its boundary is
     // exact, so adjacent same-shape sub-level 6 cells tile properly.
     // Above 6 we still use the donor (now the sub-level 6 polygon).
-    const EXTRACT_CAP = 6;
+    const EXTRACT_CAP = 5;
 
     type BoundaryMesh = {
       polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
@@ -760,7 +815,7 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.00;
+      const DILATE = 1.05;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {
@@ -813,8 +868,10 @@
       const inflated = buildSupertiles(baseCluster);
       attachRadii(inflated.Delta);
       attachSubLevels(inflated.Delta);
+      attachCentroidBounds(inflated.Delta);
       attachRadii(inflated.Gamma);
       attachSubLevels(inflated.Gamma);
+      attachCentroidBounds(inflated.Gamma);
       return { nonGamma: inflated.Delta, gamma: inflated.Gamma };
     })();
 
@@ -935,7 +992,7 @@
     // as the user zooms in) happens at the same threshold, so a smaller
     // AGG_PX pushes refinement to fire at a smaller on-screen size —
     // detail persists farther into zoom-out.
-    const AGG_PX = 20;
+    const AGG_PX = 25;
     // _localRadius is measured from the spectre's corner origin (vertex 0),
     // so for any supertile it's ~1.5× the cluster's true centered radius
     // (empirically 1.44 at sub-level 3, growing to 1.64 at sub-level 5).
@@ -1104,24 +1161,32 @@
 
       function recurse(mt: MetaTile, d: number, alphaIn: number, allowFadeOut: boolean = true) {
         if (alphaIn <= 0) return;
-        const cx = stTx[d], cy = stTy[d];
-        const r = (mt as any)._localRadius ?? 0;
-        if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
+        // Cull against a centroid-centered bounding ball: tighter than
+        // the corner-based _localRadius (which can be ~2× the cluster's
+        // actual extent because the local origin sits at a cluster
+        // corner, not its centroid). _localRadius is still used below
+        // for pixelExtent (aggregation tuning) and donor scaling, where
+        // the corner reference matters.
+        const myRot = stRot[d], myMir = stMir[d];
+        const myCos = _COS[myRot], mySin = _SIN[myRot];
+        const lcx = (mt as any)._cCx as number;
+        let lcy = (mt as any)._cCy as number;
+        if (myMir) lcy = -lcy;
+        const cCx = myCos * lcx - mySin * lcy + stTx[d];
+        const cCy = mySin * lcx + myCos * lcy + stTy[d];
+        const cBound = ((mt as any)._cBound as number) ?? 0;
+        if (cCx + cBound < vMnX || cCx - cBound > vMxX ||
+            cCy + cBound < vMnY || cCy - cBound > vMxY) return;
         if (mt.kind === "leaf") { emit(null, mt.label, d, 0, alphaIn); return; }
+        const r = (mt as any)._localRadius ?? 0;
 
-        // Children at α=1 cover their parent fully when the cluster is
-        // big enough on screen, so above aggThresh we skip the parent
-        // emit entirely — the children handle coverage. Below aggThresh
-        // the cluster is too small to recurse into normally, so we emit
-        // the parent. We optionally also recurse into children one
-        // additional level at a fade-out alpha so the just-cull-ing
-        // children blend smoothly out of view as zoom proceeds, masking
-        // any donor-polygon gaps in the parent until they're sub-pixel.
-        //
-        // Continuity at aggThresh:
-        //   - just above: parent skipped, children at α=1.
-        //   - just below: parent at α=1, children at α=1 (start of fade-
-        //     out, which lerps 1 → 0 down to lowerFadeBound).
+        // We crossfade the parent's self-emit against its children's
+        // recursion so neither pops. The parent fades in across an upper
+        // band [aggThresh, upperFadeBound] (at α=0 above, α=1 at and
+        // below aggThresh) while children render at full alpha. Below
+        // aggThresh the parent stays at α=1 and children fade out across
+        // [lowerFadeBound, aggThresh]. Below lowerFadeBound only the
+        // parent renders.
         //
         // allowFadeOut limits cascade: a child reached via fade-out
         // doesn't itself get a fade-out band, so we render at most two
@@ -1129,33 +1194,54 @@
         // sub-aggThresh region instead of cascading down to leaves.
         const pixelExtent = 2 * r * aggPixelScale;
         const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
-        const lowerFadeBound = aggThresh / 4;
+        const upperFadeBound = aggThresh * 1.8;
         const mySubLevel = (mt as any)._subLevel as number;
+        // At and below sub-level EXTRACT_CAP+1, children are real-extracted
+        // (or leaves) and tile correctly, so a wide fade band lets them
+        // smoothly disappear without revealing structural gaps. At higher
+        // sub-levels the children are also donor-scaled (gaps remain), so
+        // we use a narrower band: enough to smooth the level-transition
+        // pop without paying full-band cell counts.
+        const lowerFadeBound = mySubLevel <= EXTRACT_CAP + 1
+          ? aggThresh / 4
+          : aggThresh * 0.55;
 
-        let childAlpha = alphaIn;
-        let childAllowFadeOut = true;
+        // Parent self-emit alpha factor: 1 in the lower band, smooth
+        // fade-in across the upper band, 0 above the upper band.
+        let parentFactor = 0;
         if (pixelExtent < aggThresh) {
+          parentFactor = 1;
+        } else if (pixelExtent < upperFadeBound) {
+          const u = (upperFadeBound - pixelExtent) / (upperFadeBound - aggThresh);
+          parentFactor = u * u * (3 - 2 * u);
+        }
+
+        if (parentFactor > 0) {
           const mesh = getGpuMesh(mt);
           if (mesh) {
-            emit(mt, mt.name, d, mySubLevel, alphaIn);
-            if (pixelExtent < lowerFadeBound || !allowFadeOut) return;
-            // The lower fade-out band is *only* useful at sub-level
-            // EXTRACT_CAP + 1 — there the children are at sub-level
-            // EXTRACT_CAP (real-extracted, tile correctly) and can mask
-            // the parent's donor-scaled gaps. At higher sub-levels both
-            // parent and children are donor-scaled, so the children
-            // can't fix gaps and only multiply cell count. We accept
-            // visible donor-gap slivers at deep zoom rather than blow
-            // up cell counts to billions.
-            if (mySubLevel !== EXTRACT_CAP + 1) return;
-            const t = (pixelExtent - lowerFadeBound) / (aggThresh - lowerFadeBound);
-            childAlpha = alphaIn * t;
-            childAllowFadeOut = false;
-          } else {
+            emit(mt, mt.name, d, mySubLevel, alphaIn * parentFactor);
+          } else if (pixelExtent < aggThresh) {
+            // No mesh available and we're in the lower band where the
+            // parent must carry coverage; abort before recursing into
+            // children we can't fall back on.
             return;
           }
         }
-        // Above aggThresh: parent skipped, children recurse at full alpha.
+
+        let childAlpha: number;
+        let childAllowFadeOut: boolean;
+        if (pixelExtent < aggThresh) {
+          // Lower band: only recurse children if a fade-out applies.
+          if (pixelExtent < lowerFadeBound || !allowFadeOut) return;
+          const u = (pixelExtent - lowerFadeBound) / (aggThresh - lowerFadeBound);
+          const t = u * u * (3 - 2 * u);
+          childAlpha = alphaIn * t;
+          childAllowFadeOut = false;
+        } else {
+          // Upper fade band or beyond: children recurse at full alpha.
+          childAlpha = alphaIn;
+          childAllowFadeOut = allowFadeOut;
+        }
 
         // Push this meta's RGB onto the ancestry stack, recurse, pop.
         const mySL = (mt as any)._subLevel as number;
@@ -1294,6 +1380,7 @@
       const newRoot = nextRecord.Delta;
       attachRadii(newRoot);
       attachSubLevels(newRoot);
+      attachCentroidBounds(newRoot);
       // Non-Γ types: geometries[i] corresponds directly to slot i (no
       // null slots). Slot 1 of Δ is "Delta", so newRoot.geometries[1]
       // is the geometry whose child === walkerState.currentRoot.

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -236,6 +236,21 @@
     </style>
   </script>
 
+  <script id="controls-container" type="text/x-typescript">
+    // Single container that hosts every control card on the page —
+    // following the convention from `index.html` so the viewer's
+    // expandable can move the whole bundle into a floating panel
+    // when the figure goes full-screen via `controls: '#spectre-controls'`.
+    // Subsequent card cells append to `controlsContainer` instead
+    // of calling `display(card)` directly; one final cell displays
+    // the container at the bottom of the page.
+    const controlsContainer = document.createElement('div');
+    controlsContainer.id = 'spectre-controls';
+    controlsContainer.style.display = 'flex';
+    controlsContainer.style.flexDirection = 'column';
+    controlsContainer.style.gap = '12px';
+  </script>
+
   <script id="palette-controls" type="text/x-typescript">
     // 11 colour swatches (one per tile label, including Γ₁/Γ₂) plus a
     // Randomize button + seed input. paletteState.rgb is mutated in place,
@@ -426,30 +441,20 @@
         colorBlendState.offset = v;
         viewerState.onViewChange?.(viewerState);
       });
-    const _cbLeafNoise = _tmSlider('leaf noise', 0.0, 0.25, 0.005, colorBlendState.leafNoise,
+    // Detail = 100 / aggPx. Larger detail = smaller agg-px threshold
+    // = more cells emitted = higher visual quality, slower walks.
+    // The internal storage stays as `qualityState.aggPx` (which is
+    // what the worker reads); this slider just exposes its
+    // reciprocal so a higher slider value reads as "more detail".
+    // aggPx range [5, 100] → detail range [1, 20].
+    const _DETAIL_K = 100;
+    const _qSlider = _tmSlider('detail', _DETAIL_K / 100, _DETAIL_K / 10, 0.1,
+      _DETAIL_K / qualityState.aggPx,
       (v) => {
-        colorBlendState.leafNoise = v;
-        viewerState.onViewChange?.(viewerState);
-      });
-    // Hexagon dilation: scales each aggregate hexagon's circumradius
-    // around its centroid. Changing this only affects mesh geometry
-    // (not the worker's instance data), so we just rebuild the
-    // hexagon meshes and re-render — no walker round-trip needed.
-    const _aggDilation = _tmSlider('hex dilate', 0.5, 1.5, 0.01, aggHexState.dilation,
-      (v) => {
-        aggHexState.dilation = v;
-        refreshAggMeshes();
-      });
-    // Quality / aggregation threshold (px). Smaller = more cells
-    // visible (higher quality, slower walks); larger = aggregates
-    // sooner (lower quality, faster walks). Drives view.aggPx in
-    // every walk message — the worker recomputes its r-thresholds
-    // per walk, so changes take effect on the next walk with no
-    // worker-state churn. Display rounds to integer px since the
-    // worker uses it as a screen-pixel threshold.
-    const _qSlider = _tmSlider('agg px', 5, 100, 1, qualityState.aggPx,
-      (v) => {
-        qualityState.aggPx = Math.max(1, Math.round(v));
+        if (v <= 0) return;
+        const newPx = Math.max(1, Math.round(_DETAIL_K / v));
+        if (newPx === qualityState.aggPx) return;
+        qualityState.aggPx = newPx;
         viewerState.onViewChange?.(viewerState);
       });
     // Per-leaf outline opacity. The renderer fades the outlines from
@@ -465,13 +470,11 @@
     function _syncColorBlend() {
       _cbWidth.set(colorBlendState.sigma);
       _cbOffset.set(colorBlendState.offset);
-      _cbLeafNoise.set(colorBlendState.leafNoise);
-      _aggDilation.set(aggHexState.dilation);
-      _qSlider.set(qualityState.aggPx);
+      _qSlider.set(_DETAIL_K / qualityState.aggPx);
       _outlineSlider.set(viewerState.outline.opacity);
     }
     (window as any)._spectreSyncColorBlend = _syncColorBlend;
-    (window as any)._spectreSyncQuality = () => _qSlider.set(qualityState.aggPx);
+    (window as any)._spectreSyncQuality = () => _qSlider.set(_DETAIL_K / qualityState.aggPx);
 
     const _paletteCard = document.createElement('div');
     _paletteCard.className = 'spectre-card';
@@ -484,11 +487,13 @@
     _sliderGrid.className = 'spectre-slider-grid';
     _sliderGrid.append(
       _tmContrast.wrap, _tmSat.wrap, _tmBright.wrap,
-      _cbWidth.wrap, _cbOffset.wrap, _cbLeafNoise.wrap,
-      _aggDilation.wrap, _qSlider.wrap, _outlineSlider.wrap,
+      _cbWidth.wrap, _cbOffset.wrap,
+      _qSlider.wrap, _outlineSlider.wrap,
     );
     _paletteCard.append(_paletteHead, _swatchRow, _ctrlRow, _sliderGrid);
-    display(_paletteCard);
+    // Append ordering for the controls box happens in the
+    // `controls-display` cell so it isn't at the mercy of which cell
+    // happens to run first under the dependency resolver.
   </script>
 
   <script id="figure" type="text/x-typescript">
@@ -834,7 +839,7 @@
       setHex(label: string, hex: string): void;
     };
     const paletteState: PaletteState = {
-      seed: 12345,
+      seed: 27223,
       hex: {},
       rgb: {},
       setSeed(seed: number) {
@@ -851,6 +856,27 @@
       },
     };
     paletteState.setSeed(paletteState.seed);
+    // Per-label hex overrides baked in from the user's saved config.
+    // setSeed seeds the procedural palette; these explicit values
+    // overwrite specific labels the user manually tuned.
+    {
+      const _initialHex: Record<string, string> = {
+        Xi:     '#00727a',
+        Delta:  '#3d2f6a',
+        Gamma2: '#7b3d27',
+        Pi:     '#002117',
+        Psi:    '#583e6f',
+        Gamma:  '#cd8b7b',
+        Sigma:  '#41b092',
+        Lambda: '#a8c2fd',
+        Theta:  '#e8ad64',
+        Phi:    '#93f8d2',
+        Gamma1: '#3f1658',
+      };
+      for (const [label, hex] of Object.entries(_initialHex)) {
+        paletteState.setHex(label, hex);
+      }
+    }
     // Walker entry point. Level is unused — kept in the signature so that
     // multi-scale colour variation can later be reintroduced by perturbing
     // the base colour per substitution level.
@@ -869,7 +895,7 @@
     // the cell itself, positive values bias toward parents/grandparents
     // for a "zoomed-out" feel even at deep zoom. Mutated in place by the
     // controls cell; the walker re-reads on every walk().
-    const colorBlendState = { sigma: 4.0, offset: 0.0, leafNoise: 0.0 };
+    const colorBlendState = { sigma: 2.35, offset: 4.9 };
 
     // Aggregate-hexagon shape parameters. `dilation` scales each
     // hexagon's circumradius around its centroid; values > 1 grow the
@@ -887,7 +913,7 @@
     // larger values aggregate sooner (low quality, fast walk). The
     // worker reads `view.aggPx` per walk; main passes this value in
     // every view message.
-    const qualityState = { aggPx: 25 };
+    const qualityState = { aggPx: 50 };
   </script>
 
   <script id="worker-setup" type="text/x-typescript">
@@ -1025,14 +1051,13 @@
     }
     function sendColorBlendToWorker(): void {
       if (!workerStatus.ready) return;
-      const hash = colorBlendState.sigma + ',' + colorBlendState.offset + ',' + colorBlendState.leafNoise;
+      const hash = colorBlendState.sigma + ',' + colorBlendState.offset;
       if (hash === _lastSentColorBlend) return;
       _lastSentColorBlend = hash;
       walkerWorker.postMessage({
         type: 'colorBlend',
         sigma: colorBlendState.sigma,
         offset: colorBlendState.offset,
-        leafNoise: colorBlendState.leafNoise,
       });
     }
     let _viewSeq = 0;
@@ -1594,7 +1619,7 @@
     // rates without making walks visibly slower. Push it higher (via
     // the video-export slider) for smoother fast-zoom at the cost of
     // walk latency.
-    const cullState: { padPx: number } = { padPx: 200 };
+    const cullState: { padPx: number } = { padPx: 300 };
     function repackInstances(): void {
       if (viewerState.pixelWidth === 0) return;
       if (freezeState.frozen) {
@@ -1677,22 +1702,19 @@
       onViewChange: () => repackInstances(),
     });
 
-    // The initial fit needs the cluster's world-space bounds, which
-    // come asynchronously from the worker's `init` message. So the
-    // resize callback may run before the bounds are known; we just
-    // try the fit on every relevant trigger and let it succeed once
-    // both the canvas has pixels and the worker has handed off
-    // bounds.
+    // Snap the live view to a fixed initial pose (centered at the
+    // origin, pixelScale 20 — matches the saved-config keyframe 0
+    // baked in below). We still wait for the worker's init message
+    // because the first walk needs the worker handshake to have
+    // completed; the `b` (rootBounds) it brings is no longer used
+    // for fitting, just as the gate.
     function _tryInitialFit(): void {
       if (_initialFitDone) return;
       if (viewerState.pixelWidth === 0) return;
-      const b = workerStatus.rootBounds;
-      if (!b) return;
-      viewerState.centerX = (b.minX + b.maxX) / 2;
-      viewerState.centerY = (b.minY + b.maxY) / 2;
-      const fitX = viewerState.pixelWidth  / (b.maxX - b.minX);
-      const fitY = viewerState.pixelHeight / (b.maxY - b.minY);
-      viewerState.pixelScale = 0.95 * Math.min(fitX, fitY);
+      if (!workerStatus.rootBounds) return;
+      viewerState.centerX = 0;
+      viewerState.centerY = 0;
+      viewerState.pixelScale = 20;
       _initialFitDone = true;
       repackInstances();
     }
@@ -1705,6 +1727,7 @@
       width: 640,
       height: 640,
       wide: true,
+      controls: '#spectre-controls',
       onResize: (_el, w, h) => {
         viewerState.resize(w, h);
         _tryInitialFit();
@@ -1982,15 +2005,11 @@
       return w > 0 ? w : 1; // fallback while canvas not yet sized
     }
     const _kf: View[] = [
-      { centerX: 62.90020681398703,        centerY: -69.41475882293156,    pixelScale: 159.57638576360853 },
-      { centerX: -276309144.8722216,       centerY: 813097338.8738983,     pixelScale: 8.685921175201373e-8 },
-      { centerX: 52490654572.06181,        centerY: 31946543152.550705,    pixelScale: 8.685921175201373e-8 },
-      { centerX: 52651834944.69957,        centerY: 31501858022.634777,    pixelScale: 118.57227795600912 },
+      { centerX: 0,                  centerY: 0,                  pixelScale: 20 },
+      { centerX: -552442261.2357118, centerY: -1044150917.0082084, pixelScale: 20 },
     ];
     const _seg: SegConfig[] = [
-      { smooth: false, sec: 6, ease: 'quintic', speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
-      { smooth: false, sec: 4, ease: 'cubic',   speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
-      { smooth: false, sec: 6, ease: 'quintic', speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
+      { smooth: true, sec: 2, ease: 'sinusoidal', speed: 1.5, rho: 1.5 },
     ];
 
     // Optional per-render brightness ramp. When `autoBalance` is on,
@@ -2469,7 +2488,7 @@
       const head = document.createElement('div');
       head.className = 'spectre-section-head';
       const h = document.createElement('h4');
-      h.textContent = 'trajectory';
+      h.textContent = 'keyframes';
       head.append(h);
       _kfContainer.append(head);
 
@@ -2678,9 +2697,9 @@
 
     const _w    = _numInput('w',     1280, 'num-md');
     const _h    = _numInput('h',      720, 'num-md');
-    const _fps  = _numInput('fps',     30, 'num-sm');
-    const _qp   = _numInput('qp',      24, 'num-sm');
-    const _samp = _numInput('samples',  1, 'num-sm');
+    const _fps  = _numInput('fps',     60, 'num-sm');
+    const _qp   = _numInput('qp',      10, 'num-sm');
+    const _samp = _numInput('samples', 20, 'num-sm');
     for (const i of [_w, _h, _fps, _qp, _samp]) {
       i.inp.addEventListener('change', () => _saveLocal());
     }
@@ -2725,12 +2744,12 @@
     const _cullSlider = document.createElement('input');
     _cullSlider.type = 'range';
     _cullSlider.min = '0'; _cullSlider.max = '500'; _cullSlider.step = '5';
-    _cullSlider.value = '0';
+    _cullSlider.value = String(cullState.padPx);
     _cullSlider.className = 'spectre-cull-slider';
     const _cullVal = document.createElement('span');
     _cullVal.className = 'spectre-mono';
     _cullVal.style.minWidth = '44px';
-    _cullVal.textContent = '0 px';
+    _cullVal.textContent = `${cullState.padPx} px`;
     _cullSlider.addEventListener('input', () => {
       const v = +_cullSlider.value;
       cullState.padPx = v;
@@ -2983,6 +3002,22 @@
     });
     _loadBtn.addEventListener('click', () => _loadInput.click());
 
+    // Drop the auto-saved localStorage entry so the next page reload
+    // starts from the baked-in defaults instead of the last
+    // session's state. Disabled while a Save/Load is in flight so we
+    // don't race the debounced auto-save.
+    const _purgeSavedBtn = _btn(
+      'Purge saved', '',
+      'Delete the localStorage entry that auto-saves your config across reloads. ' +
+        'Page reload after this clicks restores the baked-in defaults.',
+    );
+    _purgeSavedBtn.addEventListener('click', () => {
+      // Cancel any pending auto-save so it can't write back over us.
+      if (_saveTimer != null) { clearTimeout(_saveTimer); _saveTimer = null; }
+      try { localStorage.removeItem(_LS_KEY); } catch (_e) { /* ignore */ }
+      _status.textContent = 'cleared saved state — reload page to start from defaults';
+    });
+
     // ─── Run (preview) ─────────────────────────────────────────────────
     // Animates the trajectory live in the viewport canvas using
     // requestAnimationFrame, ignoring `samples` (no supersampling) and
@@ -3079,7 +3114,7 @@
     const _renderActionsRow = document.createElement('div');
     _renderActionsRow.className = 'spectre-row';
     _renderActionsRow.append(
-      _saveBtn, _loadBtn, _loadInput,
+      _saveBtn, _loadBtn, _loadInput, _purgeSavedBtn,
       _runBtn, _renderBtn, _status,
     );
     const _cullRow = document.createElement('div');
@@ -3130,8 +3165,8 @@
       _refreshTotalLabel();
     };
 
-    display(_renderCard);
-    display(_kfContainer);
+    // Append ordering happens in the controls-display cell so the
+    // top-to-bottom layout is fixed regardless of cell execution order.
   </script>
 
   <script id="find-distant-match" type="text/x-typescript">
@@ -3514,7 +3549,21 @@
     };
 
     _loopRow.append(_loopControls, _loopStatusRow, _purgeRow, _treeInfoText);
-    display(_loopRow);
+    // Append happens in the controls-display cell.
+  </script>
+
+  <script id="controls-display" type="text/x-typescript">
+    // Append all cards to the controls container in EXPLICIT visual
+    // order, then display once. Doing the appends here (rather than
+    // each card cell appending itself) decouples DOM order from cell
+    // execution order — the dependency resolver may shuffle which
+    // card cell runs first, but this cell runs after all of them
+    // (it references each card) and stamps the canonical order.
+    controlsContainer.append(_paletteCard);
+    controlsContainer.append(_kfContainer);
+    controlsContainer.append(_renderCard);
+    controlsContainer.append(_loopRow);
+    display(controlsContainer);
   </script>
 
 </notebook>

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -135,7 +135,7 @@
     // covering all such sub-pixel mismatches. The overlap is invisible
     // because adjacent leaves' fill colors are picked by the walker to
     // be visually similar at the moment of rendering.
-    const _LEAF_DILATE = 8.0;
+    const _LEAF_DILATE = 1.05;
     const meshVertexData = (() => {
       let cx = 0, cy = 0;
       for (const v of spectreVertices) { cx += v[0]; cy += v[1]; }
@@ -787,12 +787,7 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      // DIAGNOSTIC: 5× aggregate-polygon dilation. If gaps persist with
-      // this much overdraw, they're not from chord-vs-chord mismatches
-      // between adjacent cells — there must be world-space regions
-      // where no cell of any kind is being emitted. Dial back once root
-      // cause is found.
-      const DILATE = 5.0;
+      const DILATE = 1.05;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -64,7 +64,7 @@
     // covering all such sub-pixel mismatches. The overlap is invisible
     // because adjacent leaves' fill colors are picked by the walker to
     // be visually similar at the moment of rendering.
-    const _LEAF_DILATE = 1.012;
+    const _LEAF_DILATE = 1.02;
     const meshVertexData = (() => {
       let cx = 0, cy = 0;
       for (const v of spectreVertices) { cx += v[0]; cy += v[1]; }
@@ -632,7 +632,7 @@
       let cx = 0, cy = 0;
       for (const p of simplified) { cx += p[0]; cy += p[1]; }
       cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.012;
+      const DILATE = 1.02;
       const polygon = new Float32Array(simplified.length * 2);
       const flat: number[] = new Array(simplified.length * 2);
       for (let i = 0; i < simplified.length; i++) {
@@ -1153,9 +1153,15 @@
       walkerState.extensionLevel += 1;
     }
 
-    // Extend while the current root's bounding circle doesn't cover the
-    // view-corner farthest from the root center. The 0.95 factor leaves
-    // a small margin so we extend before the user actually sees an edge.
+    // Extend while the current root's bounding circle isn't comfortably
+    // bigger than the viewport. _localRadius is measured from the spectre
+    // tile's corner origin (vertex 0), not the cluster's centroid, so in
+    // some directions the cluster covers as little as ~35% of that
+    // radius. To guarantee that every viewport pixel falls inside the
+    // cluster's actual shape (not just the bounding circle), we want
+    // distToCorner ≤ ~0.35 × r. Picking 0.3 gives a small safety margin.
+    // Each extension is O(1) and grows the cluster by ~2.5×, so the
+    // tighter threshold typically costs ~1 extra extension level.
     function maybeExtend(view: WalkView): void {
       let safety = 64;
       while (safety-- > 0) {
@@ -1167,7 +1173,7 @@
         const dx = Math.abs(view.centerX - cx) + halfW;
         const dy = Math.abs(view.centerY - cy) + halfH;
         const distToCorner = Math.hypot(dx, dy);
-        if (distToCorner <= 0.95 * r) return;
+        if (distToCorner <= 0.3 * r) return;
         extendRootUpward();
       }
     }

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -36,9 +36,26 @@
     _ctrlSeed.style.width = '80px';
     _ctrlSeed.style.fontSize = '12px';
     _ctrlSeed.style.padding = '2px 6px';
+    function _updateClearValue() {
+      // Average RGB across all 11 palette labels — used as the canvas's
+      // clear colour so any uncovered pixels (sub-pixel gaps between
+      // cells, viewport corners outside the root cluster's actual shape)
+      // blend with a muted version of the palette instead of an opaque
+      // dark grey. Premultiplied with alpha = 1 (the canvas is in
+      // 'premultiplied' alphaMode), so r/g/b are the colour values
+      // directly.
+      let r = 0, g = 0, b = 0;
+      for (const label of _ALL_LABELS) {
+        const c = paletteState.rgb[label];
+        r += c[0]; g += c[1]; b += c[2];
+      }
+      const n = _ALL_LABELS.length;
+      viewerState.clearValue = { r: r / n, g: g / n, b: b / n, a: 1 };
+    }
     function _applySeed(s: number) {
       paletteState.setSeed(s);
       _ctrlSeed.value = String(paletteState.seed);
+      _updateClearValue();
       // requestFrame just redraws the existing instance buffer with the
       // colours it already has. To pick up the new palette we need to
       // re-run the walker, which packs each instance's colour at emit
@@ -46,6 +63,8 @@
       viewerState.onViewChange?.(viewerState);
       viewerState.requestFrame();
     }
+    // Initial clear value at page load.
+    _updateClearValue();
     _ctrlBtn.addEventListener('click', () => {
       _applySeed(Math.floor(Math.random() * 99999));
     });
@@ -113,7 +132,7 @@
     // covering all such sub-pixel mismatches. The overlap is invisible
     // because adjacent leaves' fill colors are picked by the walker to
     // be visually similar at the moment of rendering.
-    const _LEAF_DILATE = 1.02;
+    const _LEAF_DILATE = 3.0;
     const meshVertexData = (() => {
       let cx = 0, cy = 0;
       for (const v of spectreVertices) { cx += v[0]; cy += v[1]; }
@@ -946,7 +965,7 @@
     // as the user zooms in) happens at the same threshold, so a smaller
     // AGG_PX pushes refinement to fire at a smaller on-screen size —
     // detail persists farther into zoom-out.
-    const AGG_PX = 22;
+    const AGG_PX = 20;
     // _localRadius is measured from the spectre's corner origin (vertex 0),
     // so for any supertile it's ~1.5× the cluster's true centered radius
     // (empirically 1.44 at sub-level 3, growing to 1.64 at sub-level 5).

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -218,6 +218,21 @@
       input.spectre-swatch::-webkit-color-swatch-wrapper { padding: 0; }
       input.spectre-swatch::-webkit-color-swatch { border: none; border-radius: 2px; }
       input.spectre-swatch::-moz-color-swatch { border: none; }
+      .spectre-slider-row {
+        display: flex; gap: 8px; align-items: center;
+      }
+      .spectre-slider-row > .spectre-label {
+        min-width: 78px;
+      }
+      .spectre-slider-row > input[type="range"] {
+        flex: 1 1 0;
+        min-width: 60px;
+      }
+      .spectre-slider-grid {
+        display: grid;
+        gap: 6px 16px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
     </style>
   </script>
 
@@ -330,6 +345,134 @@
     const _ctrlRow = document.createElement('div');
     _ctrlRow.className = 'spectre-row';
     _ctrlRow.append(_ctrlBtn, _ctrlSeedLabel);
+
+    // Slider + numeric input pair, bidirectionally bound. Each row uses
+    // a fixed-width label so all colour-parameter rows align vertically.
+    // Used for tonemap (contrast/saturation/brightness) and the
+    // multi-level Gaussian blend (detail/blend offset).
+    function _tmSlider(
+      label: string, min: number, max: number, step: number,
+      initial: number, onChange: (v: number) => void,
+    ) {
+      const wrap = document.createElement('div');
+      wrap.className = 'spectre-slider-row';
+      const lbl = document.createElement('span');
+      lbl.className = 'spectre-label';
+      lbl.textContent = label;
+      const inp = document.createElement('input');
+      inp.type = 'range';
+      inp.min = String(min); inp.max = String(max); inp.step = String(step);
+      inp.value = String(initial);
+      const num = document.createElement('input');
+      num.type = 'number';
+      num.min = String(min); num.max = String(max); num.step = String(step);
+      num.value = (+initial).toFixed(2);
+      num.className = 'spectre-input num-md';
+      const apply = (v: number) => {
+        onChange(v);
+        viewerState.requestFrame();
+        (window as any)._spectreSaveLocal?.();
+      };
+      inp.addEventListener('input', () => {
+        const v = +inp.value;
+        num.value = v.toFixed(2);
+        apply(v);
+      });
+      num.addEventListener('input', () => {
+        const raw = +num.value;
+        if (!Number.isFinite(raw)) return;
+        const v = Math.max(min, Math.min(max, raw));
+        inp.value = String(v);
+        apply(v);
+      });
+      wrap.append(lbl, inp, num);
+      return {
+        wrap,
+        set(v: number) {
+          inp.value = String(v);
+          num.value = (+v).toFixed(2);
+        },
+      };
+    }
+    const _tmContrast = _tmSlider('contrast', 0.5, 2.5, 0.01, viewerState.tonemap.contrast,
+      (v) => { viewerState.tonemap.contrast = v; });
+    const _tmSat = _tmSlider('saturation', 0.0, 2.5, 0.01, viewerState.tonemap.saturation,
+      (v) => { viewerState.tonemap.saturation = v; });
+    const _tmBright = _tmSlider('brightness', -0.5, 0.5, 0.01, viewerState.tonemap.brightness,
+      (v) => { viewerState.tonemap.brightness = v; });
+    function _syncTonemap() {
+      _tmContrast.set(viewerState.tonemap.contrast);
+      _tmSat.set(viewerState.tonemap.saturation);
+      _tmBright.set(viewerState.tonemap.brightness);
+    }
+    (window as any)._spectreSyncTonemap = _syncTonemap;
+
+    // Multi-level Gaussian blend controls. Mutating colorBlendState
+    // (defined in the palette cell) is enough — the walker re-reads on
+    // every walk(). We trigger onViewChange to repack instances with
+    // the new colours immediately.
+    //
+    // "blend width" is σ directly: larger σ pulls more ancestor levels
+    // into each cell's colour (smoother, more macro structure); smaller
+    // σ collapses the blend toward whichever level the offset peaks at,
+    // letting per-cell variation show through.
+    const _cbWidth = _tmSlider('blend width', 0.3, 8.0, 0.05, colorBlendState.sigma,
+      (v) => {
+        colorBlendState.sigma = v;
+        viewerState.onViewChange?.(viewerState);
+      });
+    const _cbOffset = _tmSlider('blend offset', -2.0, 12.0, 0.05, colorBlendState.offset,
+      (v) => {
+        colorBlendState.offset = v;
+        viewerState.onViewChange?.(viewerState);
+      });
+    const _cbLeafNoise = _tmSlider('leaf noise', 0.0, 0.25, 0.005, colorBlendState.leafNoise,
+      (v) => {
+        colorBlendState.leafNoise = v;
+        viewerState.onViewChange?.(viewerState);
+      });
+    // Hexagon dilation: scales each aggregate hexagon's circumradius
+    // around its centroid. Changing this only affects mesh geometry
+    // (not the worker's instance data), so we just rebuild the
+    // hexagon meshes and re-render — no walker round-trip needed.
+    const _aggDilation = _tmSlider('hex dilate', 0.5, 1.5, 0.01, aggHexState.dilation,
+      (v) => {
+        aggHexState.dilation = v;
+        refreshAggMeshes();
+      });
+    // Quality / aggregation threshold (px). Smaller = more cells
+    // visible (higher quality, slower walks); larger = aggregates
+    // sooner (lower quality, faster walks). Drives view.aggPx in
+    // every walk message — the worker recomputes its r-thresholds
+    // per walk, so changes take effect on the next walk with no
+    // worker-state churn. Display rounds to integer px since the
+    // worker uses it as a screen-pixel threshold.
+    const _qSlider = _tmSlider('agg px', 5, 100, 1, qualityState.aggPx,
+      (v) => {
+        qualityState.aggPx = Math.max(1, Math.round(v));
+        viewerState.onViewChange?.(viewerState);
+      });
+    // Per-leaf outline opacity. The renderer fades the outlines from
+    // 0 to this value as leaves grow above ~6 px on screen, so dialed
+    // in here is the *peak* outline strength. Setting to 0 disables
+    // outlines entirely.
+    const _outlineSlider = _tmSlider('outline', 0, 1, 0.01, viewerState.outline.opacity,
+      (v) => {
+        viewerState.outline.opacity = v;
+        viewerState.outline.enabled = v > 0;
+        viewerState.requestFrame();
+      });
+    function _syncColorBlend() {
+      _cbWidth.set(colorBlendState.sigma);
+      _cbOffset.set(colorBlendState.offset);
+      _cbLeafNoise.set(colorBlendState.leafNoise);
+      _aggDilation.set(aggHexState.dilation);
+      _qSlider.set(qualityState.aggPx);
+      _outlineSlider.set(viewerState.outline.opacity);
+    }
+    (window as any)._spectreSyncColorBlend = _syncColorBlend;
+    (window as any)._spectreSyncQuality = () => _qSlider.set(qualityState.aggPx);
+
     const _paletteCard = document.createElement('div');
     _paletteCard.className = 'spectre-card';
     const _paletteHead = document.createElement('div');
@@ -337,311 +480,19 @@
     const _paletteH = document.createElement('h4');
     _paletteH.textContent = 'palette';
     _paletteHead.append(_paletteH);
-    _paletteCard.append(_paletteHead, _swatchRow, _ctrlRow);
+    const _sliderGrid = document.createElement('div');
+    _sliderGrid.className = 'spectre-slider-grid';
+    _sliderGrid.append(
+      _tmContrast.wrap, _tmSat.wrap, _tmBright.wrap,
+      _cbWidth.wrap, _cbOffset.wrap, _cbLeafNoise.wrap,
+      _aggDilation.wrap, _qSlider.wrap, _outlineSlider.wrap,
+    );
+    _paletteCard.append(_paletteHead, _swatchRow, _ctrlRow, _sliderGrid);
     display(_paletteCard);
   </script>
 
   <script id="figure" type="text/x-typescript">
     display(viewerExpandable);
-  </script>
-
-  <script id="find-distant-match" type="text/x-typescript">
-    // ─── Find a distant pattern-matching view ─────────────────────────
-    // For a given source view (the current viewport), find another world
-    // position whose local pattern is identical to the source within a
-    // radius determined by the suffix length K. Two leaves with the same
-    // K-suffix (last K geometry indices in the substitution path, same
-    // type at level K) sit inside identically-substituted level-K
-    // supertiles, so their local environments are byte-identical out to
-    // ~(2.45)^K world units.
-    type LeafAddress = {
-      path: number[];        // geom indices, root → leaf
-      types: TileName[];     // type at each meta level
-      rots: number[];        // accumulated world rot at each meta level
-      mirs: number[];        // accumulated world mirror at each meta level
-      leafCx: number;        // world X of the located leaf's centroid
-      leafCy: number;        // world Y of the located leaf's centroid
-    };
-    // Closest-child descent: always reaches a leaf (the one whose
-    // centroid is nearest to the target). Robust to floating-point
-    // precision at deep extension levels and to the case where the
-    // target is on a polygon boundary.
-    function _findLeafNear(targetX: number, targetY: number): LeafAddress | null {
-      let mt: any = walkerState.currentRoot;
-      let tx: any = walkerState.currentRootTransform;
-      if (mt.kind !== 'meta') return null;
-      const path: number[] = [];
-      const types: TileName[] = [mt.name];
-      const rots: number[] = [tx.rot];
-      const mirs: number[] = [tx.mirror];
-      while (mt.kind === 'meta') {
-        let bestI = -1, bestD = Infinity;
-        for (let i = 0; i < mt.geometries.length; i++) {
-          const geom = mt.geometries[i];
-          const child = geom.child;
-          const childTx = txCompose(tx, geom.transform);
-          const cx = (child as any)._cCx ?? 0;
-          const cy = (child as any)._cCy ?? 0;
-          const wc = txApply(childTx, [cx, cy]);
-          const d = Math.hypot(wc[0] - targetX, wc[1] - targetY);
-          if (d < bestD) { bestD = d; bestI = i; }
-        }
-        if (bestI < 0) break;
-        path.push(bestI);
-        const geom = mt.geometries[bestI];
-        tx = txCompose(tx, geom.transform);
-        mt = geom.child;
-        if (mt.kind === 'meta') {
-          types.push(mt.name as TileName);
-          rots.push(tx.rot);
-          mirs.push(tx.mirror);
-        }
-      }
-      // mt is the leaf — compute its world centroid for offset
-      // preservation in the caller.
-      const lcx = (mt as any)._cCx ?? 0;
-      const lcy = (mt as any)._cCy ?? 0;
-      const wc = txApply(tx, [lcx, lcy]);
-      return { path, types, rots, mirs, leafCx: wc[0], leafCy: wc[1] };
-    }
-
-    interface FindMatchResult { centerX: number; centerY: number; attempts: number }
-    function _findMatchingLeaf(args: {
-      sourceX: number; sourceY: number;
-      parentType: TileName;
-      parentRot: number;     // world rotation of source's level-K ancestor
-      parentMir: number;     // world mirror of source's level-K ancestor
-      parentSubLevel: number;
-      suffix: number[];
-      minDistance: number;
-      maxAttempts?: number;
-    }): FindMatchResult | null {
-      const root = walkerState.currentRoot;
-      const rootTransform = walkerState.currentRootTransform;
-      if (root.kind !== 'meta') return null;
-      const rootSubLevel = (root as any)._subLevel as number;
-      const stepsToParent = rootSubLevel - args.parentSubLevel;
-      if (stepsToParent < 0) return null;
-      const seed = ((Math.floor(args.sourceX) ^ Math.floor(args.sourceY)) >>> 0) || 1;
-      const rng = _makeSeededRng(seed);
-      const max = args.maxAttempts ?? 200000;
-      for (let attempt = 0; attempt < max; attempt++) {
-        let mt: any = root;
-        let tx: any = rootTransform;
-        let ok = true;
-        for (let d = 0; d < stepsToParent; d++) {
-          if (mt.kind !== 'meta') { ok = false; break; }
-          const i = Math.floor(rng() * mt.geometries.length);
-          const geom = mt.geometries[i];
-          tx = txCompose(tx, geom.transform);
-          mt = geom.child;
-        }
-        if (!ok || mt.kind !== 'meta' || mt.name !== args.parentType) continue;
-        // Match world orientation: same rot and mirror means the
-        // candidate's local pattern is in the same on-screen orientation
-        // as the source, not just congruent up to a rotation.
-        if (tx.rot !== args.parentRot || tx.mirror !== args.parentMir) continue;
-        // Apply suffix.
-        let suffOk = true;
-        for (const i of args.suffix) {
-          if (mt.kind !== 'meta' || i >= mt.geometries.length) { suffOk = false; break; }
-          const geom = mt.geometries[i];
-          tx = txCompose(tx, geom.transform);
-          mt = geom.child;
-        }
-        if (!suffOk || mt.kind !== 'leaf') continue;
-        const lcx = (mt as any)._cCx ?? 0;
-        const lcy = (mt as any)._cCy ?? 0;
-        const c = txApply(tx, [lcx, lcy]);
-        const dx = c[0] - args.sourceX, dy = c[1] - args.sourceY;
-        if (Math.hypot(dx, dy) < args.minDistance) continue;
-        return { centerX: c[0], centerY: c[1], attempts: attempt + 1 };
-      }
-      return null;
-    }
-
-    function _findDistantMatchForCurrentView(K: number, minDistance: number):
-      { result: FindMatchResult | null; sourceLeaf: LeafAddress | null } {
-      const v = viewerState.getView();
-      const sourceLeaf = _findLeafNear(v.centerX, v.centerY);
-      if (!sourceLeaf) return { result: null, sourceLeaf: null };
-      const D = sourceLeaf.path.length;
-      if (D < K) return { result: null, sourceLeaf };
-      const suffix = sourceLeaf.path.slice(D - K);
-      const idx = D - K;
-      const parentType = sourceLeaf.types[idx];
-      const parentRot = sourceLeaf.rots[idx];
-      const parentMir = sourceLeaf.mirs[idx];
-      const root = walkerState.currentRoot;
-      const rootSubLevel = (root as any)._subLevel as number;
-      const parentSubLevel = rootSubLevel - idx;
-      const result = _findMatchingLeaf({
-        sourceX: v.centerX, sourceY: v.centerY,
-        parentType, parentRot, parentMir, parentSubLevel,
-        suffix, minDistance,
-      });
-      return { result, sourceLeaf };
-    }
-
-    // Local button helper (keeps this cell self-contained — the
-    // video-export cell has its own _btn, but cross-cell helper sharing
-    // is brittle and this is two lines.)
-    function _fdmBtn(text: string, classes = '', title?: string): HTMLButtonElement {
-      const b = document.createElement('button');
-      b.textContent = text;
-      b.className = `spectre-btn ${classes}`.trim();
-      if (title) b.title = title;
-      return b;
-    }
-
-    const _loopRow = document.createElement('div');
-    _loopRow.className = 'spectre-card';
-    const _loopHead = document.createElement('div');
-    _loopHead.className = 'spectre-section-head';
-    const _loopH = document.createElement('h4');
-    _loopH.textContent = 'find distant match';
-    _loopHead.append(_loopH);
-    _loopRow.append(_loopHead);
-    const _loopHelp = document.createElement('details');
-    _loopHelp.className = 'spectre-help';
-    const _loopHelpSummary = document.createElement('summary');
-    _loopHelpSummary.textContent = 'how this works';
-    const _loopHelpBody = document.createElement('p');
-    _loopHelpBody.textContent =
-      'Locates a far-away spot whose local pattern matches the current view exactly, ' +
-      'useful for building a seamless looping zoom. Frame a view, click Find, then Go ' +
-      'to jump there; paste the output into a keyframe to use it as an endpoint. ' +
-      'Match depth is bounded by the supertile levels currently loaded around the view, ' +
-      'so if it fails, zoom out slightly (to extend the tree) or reduce depth / min dist.';
-    _loopHelp.append(_loopHelpSummary, _loopHelpBody);
-    _loopRow.append(_loopHelp);
-    const _loopControls = document.createElement('div');
-    _loopControls.className = 'spectre-row';
-
-    function _labeledInput(
-      label: string, type: string, value: string, cls: string, title: string,
-    ) {
-      const wrap = document.createElement('label');
-      wrap.className = 'spectre-checkbox';
-      const span = document.createElement('span');
-      span.className = 'spectre-label';
-      span.textContent = label;
-      const inp = document.createElement('input');
-      inp.type = type;
-      inp.value = value;
-      inp.className = `spectre-input ${cls}`.trim();
-      inp.title = title;
-      wrap.append(span, inp);
-      return { wrap, inp };
-    }
-    // K can be left as 'auto' (or 0/empty) to be derived from the current
-    // viewport's world extent. Match radius is ~2.45^K world units, so K
-    // needs to scale with how zoomed-out the user is.
-    const _kInput = _labeledInput(
-      'match depth', 'text', 'auto', 'num-sm',
-      'How many substitution levels of context the match must reproduce. ' +
-        'Match radius ≈ 2.45^depth world units. "auto" picks the smallest depth ' +
-        'whose radius comfortably exceeds the current viewport. ' +
-        'Capped by the supertile levels currently loaded around the view — ' +
-        'if no match is found, zoom out a bit (to load more levels) or lower the depth.',
-    );
-    const _minDistInput = _labeledInput(
-      'min dist', 'text', 'auto', 'num-md',
-      'Minimum world-units distance from current view to candidate. "auto" = current viewport diameter.',
-    );
-
-    const _matchBtn = _fdmBtn('Find distant match', 'primary');
-    const _matchOut = document.createElement('input');
-    _matchOut.type = 'text';
-    _matchOut.readOnly = true;
-    _matchOut.className = 'spectre-input grow';
-    _matchOut.placeholder = 'paste output into a keyframe';
-
-    const _matchGoBtn = _fdmBtn('Go', '', 'Jump the live view to the matched coordinates.');
-    _matchGoBtn.disabled = true;
-
-    // Separate status line so the output box stays cleanly copy-able.
-    const _matchStatus = document.createElement('span');
-    _matchStatus.className = 'spectre-mono';
-
-    function _autoK(viewPxW: number, pixelScale: number): number {
-      // Want 2.45^K >> viewport world diameter so the entire visible
-      // area is well inside the matching radius — and so a small
-      // offset drift after Go can't push the next-iteration source
-      // onto a *different* leaf with a different K-suffix. +2 gives
-      // ~6× headroom over the viewport extent.
-      const worldExtent = Math.max(1, viewPxW) / Math.max(1e-30, pixelScale);
-      return Math.max(2, Math.ceil(Math.log(worldExtent) / Math.log(2.45)) + 2);
-    }
-
-    type _FdmView = { centerX: number; centerY: number; pixelScale: number };
-    let _matchedView: _FdmView | null = null;
-    _matchBtn.addEventListener('click', () => {
-      const v = viewerState.getView();
-      const liveW = viewerState.pixelWidth || 1280;
-      // Resolve K: 'auto' / 0 / empty → derive from viewport.
-      let K = parseInt(_kInput.inp.value, 10);
-      if (!Number.isFinite(K) || K < 1) K = _autoK(liveW, v.pixelScale);
-      // Resolve min distance: 'auto' / empty → viewport world diameter.
-      let minDist = Number(_minDistInput.inp.value);
-      if (!Number.isFinite(minDist) || minDist < 0) {
-        minDist = liveW / Math.max(1e-30, v.pixelScale);
-      }
-      const t0 = performance.now();
-      const { result, sourceLeaf } = _findDistantMatchForCurrentView(K, minDist);
-      const ms = (performance.now() - t0).toFixed(0);
-      if (!sourceLeaf) {
-        _matchOut.value = '';
-        _matchStatus.textContent = 'could not locate source leaf at view center';
-        _matchedView = null;
-        _matchGoBtn.disabled = true;
-        return;
-      }
-      if (!result) {
-        _matchOut.value = '';
-        _matchStatus.textContent = `no match · depth=${K} · min dist=${minDist.toExponential(2)} · try lower depth, smaller min dist, or zoom out to load more levels`;
-        _matchedView = null;
-        _matchGoBtn.disabled = true;
-        return;
-      }
-      // Preserve the source view's offset from its own leaf's centroid:
-      // both source and matched leaves are at the same K-suffix path
-      // and share the same level-K ancestor world rotation, so their
-      // local environments are byte-identical. Setting the new view to
-      // (matchedLeaf.centroid + sourceOffset) reproduces what the user
-      // was looking at, just at the matched coordinates — instead of
-      // shifting the framing to the matched leaf's centroid.
-      const offX = v.centerX - sourceLeaf.leafCx;
-      const offY = v.centerY - sourceLeaf.leafCy;
-      _matchedView = {
-        centerX: result.centerX + offX,
-        centerY: result.centerY + offY,
-        pixelScale: v.pixelScale,
-      };
-      const radius = Math.pow(2.45, K);
-      _matchOut.value = `${_matchedView.pixelScale}/${_matchedView.centerX}/${_matchedView.centerY}`;
-      _matchStatus.textContent = `depth=${K} · r≈${radius.toExponential(1)} · ${result.attempts} attempts · ${ms}ms`;
-      _matchGoBtn.disabled = false;
-      // No auto-go: clicking "Find" again with the same view re-runs
-      // deterministically (same seeded RNG → same result). Click "Go"
-      // to inspect the match and use it as the next source.
-      // eslint-disable-next-line no-console
-      console.log('match found:', {
-        ...(_matchedView as any),
-        K, attempts: result.attempts, ms: +ms, matchRadius: radius,
-      });
-    });
-
-    _matchGoBtn.addEventListener('click', () => {
-      if (_matchedView) viewerState.setView(_matchedView);
-    });
-
-    _loopControls.append(_kInput.wrap, _minDistInput.wrap, _matchBtn, _matchOut, _matchGoBtn);
-    const _loopStatusRow = document.createElement('div');
-    _loopStatusRow.className = 'spectre-row';
-    _loopStatusRow.append(_matchStatus);
-    _loopRow.append(_loopControls, _loopStatusRow);
-    display(_loopRow);
   </script>
 
   <script id="gpu-context" type="text/x-typescript">
@@ -1008,6 +859,442 @@
           ?? paletteState.rgb[_typeForLabel(label)]
           ?? [0.5, 0.5, 0.5];
     }
+
+    // Multi-level Gaussian colour blend parameters. The walker fills a
+    // weight table keyed by ancestor level distance d:
+    //   weight[d] = exp(-(d - offset)² / (2σ²))
+    // sigma controls how many ancestor levels contribute to each cell's
+    // colour (small σ → sharper per-cell detail; large σ → smoother
+    // macro structure). offset shifts the peak: 0 puts peak weight on
+    // the cell itself, positive values bias toward parents/grandparents
+    // for a "zoomed-out" feel even at deep zoom. Mutated in place by the
+    // controls cell; the walker re-reads on every walk().
+    const colorBlendState = { sigma: 4.0, offset: 0.0, leafNoise: 0.0 };
+
+    // Aggregate-hexagon shape parameters. `dilation` scales each
+    // hexagon's circumradius around its centroid; values > 1 grow the
+    // hexagons (more overlap with neighbours, eats edge gaps), values
+    // < 1 shrink them (cleaner per-cell silhouettes but visible gaps
+    // between neighbours). Mutated by the palette-controls slider;
+    // boundary-cache reads on every mesh build, so changing it
+    // requires invalidating the GpuMesh cache.
+    const aggHexState = { dilation: 0.86 };
+
+    // Aggregation threshold in CSS pixels — cells whose on-screen
+    // extent shrinks below this size are emitted as a hexagon
+    // aggregate instead of recursing into individual leaves. Smaller
+    // values produce more leaves on screen (high quality, slow walk);
+    // larger values aggregate sooner (low quality, fast walk). The
+    // worker reads `view.aggPx` per walk; main passes this value in
+    // every view message.
+    const qualityState = { aggPx: 25 };
+  </script>
+
+  <script id="worker-setup" type="text/x-typescript">
+    // The walker, the metatile DAG, and tree-extension state all live
+    // in `infinite-walker-worker.js`. Main thread: send view +
+    // palette + colorBlend updates; receive instance buffers (with
+    // ArrayBuffers transferred zero-copy) and forward them to the
+    // renderer. While the worker is computing, the renderer keeps
+    // drawing the *previous* result, with the offset uniform shifting
+    // it to the current view (same mechanism the freeze toggle uses).
+    // So pan/zoom stays smooth even when each individual walk takes
+    // hundreds of milliseconds.
+    type WorkerGroup = {
+      key: string | null;
+      cCx?: number; cCy?: number; cBound?: number;
+      instanceOffset: number;
+      instanceCount: number;
+    };
+    type WorkerResult = {
+      type: 'result';
+      data: ArrayBuffer;
+      totalCount: number;
+      groups: WorkerGroup[];
+      instanceCenterX: number;
+      instanceCenterY: number;
+      pixelScale: number;
+      extensionLevel: number;
+      rootName: string;
+      rootSubLevel: number;
+      rootCBound: number;
+      rootTxRot: number;
+      rootTxMirror: number;
+      rootTxTx: number;
+      rootTxTy: number;
+    };
+    type WorkerInit = {
+      type: 'init';
+      rootBounds: { minX: number; minY: number; maxX: number; maxY: number };
+      extensionLevel: number;
+    };
+
+    // Mutable status object the rest of the notebook can poll. Other
+    // cells must guard on `ready` before pushing view messages because
+    // they can construct before the worker handshake completes.
+    const workerStatus: {
+      ready: boolean;
+      rootBounds: { minX: number; minY: number; maxX: number; maxY: number } | null;
+      extensionLevel: number;
+      lastResult: WorkerResult | null;
+      onResult: ((result: WorkerResult) => void) | null;
+      onInit:   ((init: WorkerInit) => void) | null;
+      // True while the video-export loop is in flight. Interactive
+      // view changes (mouse/wheel handlers) call sendViewToWorker
+      // through repackInstances, which would race the export's
+      // walkAndAwait by overwriting the worker's pendingView and
+      // dropping our seq. Setting this flag blocks repackInstances
+      // from posting; the export drives walks itself via walkAndAwait.
+      captureMode: boolean;
+    } = {
+      ready: false,
+      rootBounds: null,
+      extensionLevel: 0,
+      lastResult: null,
+      onResult: null,
+      onInit: null,
+      captureMode: false,
+    };
+
+    const walkerWorker = new Worker(
+      new URL('./infinite-walker-worker.js', import.meta.url),
+      { type: 'module' },
+    );
+
+    // Resolvers awaiting a specific view's result, keyed by view seq.
+    // Used by the video-export path (and any other "I need this exact
+    // view's output" caller) to synchronously block on the worker.
+    const _pendingSeqResolvers = new Map<number, (m: WorkerResult) => void>();
+    // Resolvers for ack-style messages on the live worker (currently
+    // just findDistantMatchDone). Same Map-keyed-by-ackId pattern as
+    // the pool's _pending; lives here because the live worker has
+    // its own message channel.
+    const _pendingAckResolvers = new Map<number, (m: any) => void>();
+    let _liveAckSeq = 0;
+
+    walkerWorker.onmessage = (e: MessageEvent) => {
+      const m = e.data;
+      if (m.type === 'init') {
+        workerStatus.ready = true;
+        workerStatus.rootBounds = m.rootBounds;
+        workerStatus.extensionLevel = m.extensionLevel;
+        // Push the current palette + colorBlend state immediately
+        // so the worker's first walk uses up-to-date colours.
+        sendPaletteToWorker();
+        sendColorBlendToWorker();
+        workerStatus.onInit?.(m);
+      } else if (m.type === 'result') {
+        workerStatus.lastResult = m;
+        workerStatus.extensionLevel = m.extensionLevel;
+        workerStatus.onResult?.(m);
+        const seq = (m as any).viewSeq;
+        if (typeof seq === 'number') {
+          const r = _pendingSeqResolvers.get(seq);
+          if (r) {
+            _pendingSeqResolvers.delete(seq);
+            r(m);
+          }
+        }
+      } else if (m.type === 'findDistantMatchDone' || m.type === 'resetDone') {
+        const r = _pendingAckResolvers.get(m.ackId);
+        if (r) { _pendingAckResolvers.delete(m.ackId); r(m); }
+        if (m.type === 'resetDone') {
+          workerStatus.rootBounds = m.rootBounds;
+          workerStatus.extensionLevel = m.extensionLevel;
+        }
+      }
+    };
+
+    // Push state helpers. Each one diffs against the last-sent payload
+    // and no-ops if nothing has changed, so repackInstances can call
+    // all three on every view update without paying for redundant
+    // postMessages. Both palette and colorBlend land in the worker
+    // *before* the view message that follows, so the next walk uses
+    // up-to-date state.
+    let _lastSentPalette = '';
+    let _lastSentColorBlend = '';
+    function sendPaletteToWorker(): void {
+      if (!workerStatus.ready) return;
+      const hash = JSON.stringify(paletteState.hex);
+      if (hash === _lastSentPalette) return;
+      _lastSentPalette = hash;
+      walkerWorker.postMessage({
+        type: 'palette',
+        rgb: { ...paletteState.rgb },
+      });
+    }
+    function sendColorBlendToWorker(): void {
+      if (!workerStatus.ready) return;
+      const hash = colorBlendState.sigma + ',' + colorBlendState.offset + ',' + colorBlendState.leafNoise;
+      if (hash === _lastSentColorBlend) return;
+      _lastSentColorBlend = hash;
+      walkerWorker.postMessage({
+        type: 'colorBlend',
+        sigma: colorBlendState.sigma,
+        offset: colorBlendState.offset,
+        leafNoise: colorBlendState.leafNoise,
+      });
+    }
+    let _viewSeq = 0;
+    function sendViewToWorker(view: {
+      centerX: number; centerY: number;
+      pixelScale: number;
+      pixelWidth: number; pixelHeight: number;
+      aggPixelScale?: number; cullPadPx?: number;
+    }): number {
+      if (!workerStatus.ready) return -1;
+      sendPaletteToWorker();
+      sendColorBlendToWorker();
+      const seq = ++_viewSeq;
+      walkerWorker.postMessage({ type: 'view', view: { ...view, seq } });
+      return seq;
+    }
+    // Block until the worker has processed a *specific* view (identified
+    // by the seq returned from sendViewToWorker). Used by the video
+    // export so each frame's drawList matches the frame's intended view
+    // exactly, instead of whatever the most-recent walk happens to have
+    // produced. The worker drops *pending* views but never drops one
+    // it has begun processing, so as long as nothing else posts a view
+    // before our walk completes, the seq we requested will come back.
+    function awaitWorkerResultForSeq(seq: number): Promise<WorkerResult> {
+      return new Promise((resolve) => _pendingSeqResolvers.set(seq, resolve));
+    }
+    // Convenience: send a view AND wait for its result. Use this from
+    // synchronous capture loops (video export, screenshot rendering)
+    // that need a deterministic frame-for-frame correspondence.
+    async function walkAndAwait(view: {
+      centerX: number; centerY: number;
+      pixelScale: number;
+      pixelWidth: number; pixelHeight: number;
+      aggPixelScale?: number; cullPadPx?: number;
+    }): Promise<WorkerResult> {
+      const seq = sendViewToWorker(view);
+      if (seq < 0) throw new Error('worker not ready');
+      return awaitWorkerResultForSeq(seq);
+    }
+
+    // Clear the live worker's accumulated extension state. Returns
+    // when the worker reports the reset is done.
+    async function resetWorkerTree(): Promise<void> {
+      if (!workerStatus.ready) return;
+      const ackId = ++_liveAckSeq;
+      await new Promise<void>((resolve) => {
+        _pendingAckResolvers.set(ackId, () => resolve());
+        walkerWorker.postMessage({ type: 'reset', ackId });
+      });
+      // Force palette/colorBlend to be re-broadcast on next view —
+      // the worker's mirrors aren't touched by reset, but tagging
+      // them dirty is the easiest way to ensure consistency.
+      _lastSentPalette = '';
+      _lastSentColorBlend = '';
+    }
+
+    // DAG-driven find-distant-match (replaces the old synchronous
+    // helpers in the find-distant-match cell that used to walk
+    // walkerState directly on main). The live worker hosts the
+    // metatile DAG, so we send a request and await the response.
+    async function findDistantMatchOnWorker(
+      sourceX: number, sourceY: number, K: number, minDistance: number,
+    ): Promise<{
+      sourceLeaf: { leafCx: number; leafCy: number; path: number[] } | null;
+      result: { centerX: number; centerY: number; attempts: number } | null;
+    }> {
+      if (!workerStatus.ready) throw new Error('worker not ready');
+      const ackId = ++_liveAckSeq;
+      const m: any = await new Promise((resolve) => {
+        _pendingAckResolvers.set(ackId, resolve);
+        walkerWorker.postMessage({
+          type: 'findDistantMatch',
+          ackId, sourceX, sourceY, K, minDistance,
+        });
+      });
+      return { sourceLeaf: m.sourceLeaf, result: m.result };
+    }
+
+    // ─── Worker pool for video-export parallelism ──────────────────
+    //
+    // Spawns a fresh set of workers for the duration of an export.
+    // Each pool worker is an independent copy of the same module and
+    // is initialised to identical state via:
+    //   broadcast palette + colorBlend
+    //   broadcast extendToLevel(K)  (K is precomputed by main from
+    //                                the trajectory's most zoomed-out
+    //                                view, so every worker reaches the
+    //                                exact same cluster shape before
+    //                                any walk runs)
+    // After init, walk(view) picks an idle worker and posts the view.
+    // Resolves when that worker's result with the matching seq comes
+    // back. Workers are released back to the idle pool on completion.
+    type _PoolPending<T> = Map<string, (val: T) => void>;
+    // Top-level helper so Vite's worker plugin sees the literal
+    // `new Worker(new URL(...), { type: 'module' })` pattern at AST
+    // root — the static-analysis heuristic doesn't always look inside
+    // class constructors. This matches what the live walkerWorker
+    // construction does above.
+    function _spawnWalkerWorker(): Worker {
+      return new Worker(
+        new URL('./infinite-walker-worker.js', import.meta.url),
+        { type: 'module' },
+      );
+    }
+    let _poolWalkCount = 0;
+    class WalkerWorkerPool {
+      readonly size: number;
+      readonly workers: Worker[];
+      private readonly _seq: number[];
+      private readonly _pending: _PoolPending<any>[];
+      private readonly _idle: number[];
+      private readonly _waiters: Array<(idx: number) => void>;
+      readonly ready: Promise<void>;
+
+      constructor(size: number) {
+        this.size = size;
+        this.workers = [];
+        this._seq = [];
+        this._pending = [];
+        this._idle = [];
+        this._waiters = [];
+        const initPromises: Array<Promise<void>> = [];
+        for (let i = 0; i < size; i++) {
+          const w = _spawnWalkerWorker();
+          // Surface any spawn / module-load / runtime error so we
+          // don't silently hang on `pool.ready` waiting for an init
+          // message that's never coming.
+          w.addEventListener('error', (e) => {
+            // eslint-disable-next-line no-console
+            console.error('[pool worker', i, 'error]', e.message, e.filename, e.lineno);
+          });
+          w.addEventListener('messageerror', (e) => {
+            // eslint-disable-next-line no-console
+            console.error('[pool worker', i, 'messageerror]', e);
+          });
+          this.workers.push(w);
+          this._seq.push(0);
+          const pending: _PoolPending<any> = new Map();
+          this._pending.push(pending);
+          this._idle.push(i);
+          const initP = new Promise<void>((resolve) => {
+            const onInit = (e: MessageEvent) => {
+              if (e.data?.type === 'init') {
+                w.removeEventListener('message', onInit);
+                // eslint-disable-next-line no-console
+                console.log('[pool worker', i, 'ready]');
+                resolve();
+              }
+            };
+            w.addEventListener('message', onInit);
+          });
+          w.addEventListener('message', (e) => {
+            const m = e.data;
+            if (m?.type === 'result') {
+              const r = pending.get('v:' + m.viewSeq);
+              if (r) { pending.delete('v:' + m.viewSeq); r(m); }
+            } else if (m?.type === 'extendDone') {
+              const r = pending.get('a:' + m.ackId);
+              if (r) { pending.delete('a:' + m.ackId); r(m); }
+            }
+          });
+          initPromises.push(initP);
+        }
+        this.ready = Promise.all(initPromises).then(() => undefined);
+      }
+
+      // Send `msg` to every worker without waiting for an ack.
+      async broadcast(msg: any): Promise<void> {
+        await this.ready;
+        for (const w of this.workers) w.postMessage(msg);
+      }
+
+      // Send an extend* message to every worker and wait for each
+      // worker's `extendDone` ack. Returns each worker's reported
+      // extensionLevel (useful for verifying they all reached the same
+      // state).
+      async broadcastExtend(msg: any): Promise<number[]> {
+        await this.ready;
+        const results: number[] = new Array(this.size);
+        const ps: Array<Promise<void>> = [];
+        for (let i = 0; i < this.size; i++) {
+          const ackId = ++this._seq[i];
+          const p = new Promise<void>((resolve) => {
+            this._pending[i].set('a:' + ackId, (m: any) => {
+              results[i] = m.extensionLevel;
+              resolve();
+            });
+          });
+          this.workers[i].postMessage({ ...msg, ackId });
+          ps.push(p);
+        }
+        await Promise.all(ps);
+        return results;
+      }
+
+      // Send `msg` to one specific worker and await its extendDone.
+      async sendExtend(workerIdx: number, msg: any): Promise<number> {
+        await this.ready;
+        const ackId = ++this._seq[workerIdx];
+        const m: any = await new Promise((resolve) => {
+          this._pending[workerIdx].set('a:' + ackId, resolve);
+          this.workers[workerIdx].postMessage({ ...msg, ackId });
+        });
+        return m.extensionLevel;
+      }
+
+      private _acquire(): Promise<number> {
+        if (this._idle.length > 0) return Promise.resolve(this._idle.shift()!);
+        return new Promise((resolve) => this._waiters.push(resolve));
+      }
+
+      private _release(workerIdx: number): void {
+        if (this._waiters.length > 0) {
+          const r = this._waiters.shift()!;
+          r(workerIdx);
+        } else {
+          this._idle.push(workerIdx);
+        }
+      }
+
+      // Pick an idle worker, post `view`, await its result. The
+      // pool's concurrency = N walks in flight at once (one per
+      // worker); calls beyond N queue up.
+      async walk(view: {
+        centerX: number; centerY: number;
+        pixelScale: number;
+        pixelWidth: number; pixelHeight: number;
+        aggPixelScale?: number; cullPadPx?: number;
+      }): Promise<WorkerResult> {
+        await this.ready;
+        const callNum = ++_poolWalkCount;
+        const idx = await this._acquire();
+        const startMs = performance.now();
+        try {
+          const seq = ++this._seq[idx];
+          const _logFirst = callNum <= 10 || callNum % 100 === 0;
+          if (_logFirst) {
+            // eslint-disable-next-line no-console
+            console.log('[pool] dispatch #', callNum, 'worker=', idx, 'seq=', seq);
+          }
+          const result: WorkerResult = await new Promise((resolve) => {
+            this._pending[idx].set('v:' + seq, resolve);
+            this.workers[idx].postMessage({ type: 'view', view: { ...view, seq } });
+          });
+          const dt = performance.now() - startMs;
+          if (_logFirst || dt > 1000) {
+            // eslint-disable-next-line no-console
+            console.log('[pool] return   #', callNum, 'worker=', idx, 'seq=', seq, 'count=', result.totalCount, 'in', dt.toFixed(0), 'ms');
+          }
+          return result;
+        } finally {
+          this._release(idx);
+        }
+      }
+
+      destroy(): void {
+        for (const w of this.workers) w.terminate();
+        this.workers.length = 0;
+        this._idle.length = 0;
+        this._waiters.length = 0;
+      }
+    }
   </script>
 
   <script id="cluster" type="text/x-typescript">
@@ -1195,207 +1482,21 @@
   </script>
 
   <script id="boundary-cache" type="text/x-typescript">
-    // Extract a metatile's outer boundary: walk its leaves, build an edge
-    // multiplicity map, the multiplicity-1 edges are exterior, stitch them
-    // into a closed loop, earcut for triangle indices.
+    // Aggregated cells render as a circumscribing regular hexagon
+    // centered on the cell's centroid (`_cCx`, `_cCy`) with radius
+    // `_cBound`. At the few-pixel scale where aggregation kicks in,
+    // anything more elaborate is wasted: 6 verts conveys the cell's
+    // position and footprint just as well as 50 verts of fractal
+    // boundary. Adjacent cells' hexagons overlap by ~30–60% at the
+    // shared edge (concave Spectre bumps interlock tighter than
+    // circumscribing hexagons), which guarantees coverage with no
+    // gap-finding logic. Overlap is visually quiet because adjacent
+    // cells get near-identical colours from the multi-level Gaussian
+    // blend.
     //
-    // Skip extraction (return null) if the metatile has more than
-    // MAX_BOUNDARY_LEAVES leaves — at deep substitution levels this would
-    // be untenably slow without simplification. The walker falls back to
-    // treating those metatiles as "recurse normally" rather than aggregate.
-    const MAX_BOUNDARY_LEAVES = 200_000;
-    // No vertex budget — keep every spectre edge that's on the cluster
-    // boundary. Adjacent clusters' shared edges are *the same* sequence
-    // of leaf-spectre edges traversed from each side, so two adjacent
-    // clusters' polygons share the entire vertex sequence on the shared
-    // boundary by construction. Any simplification breaks that invariant
-    // (each cluster picks a different chord approximation, leaving gaps).
-    // Without simplification, gaps reduce to f32 precision drift in the
-    // GPU shader, which the small DILATE below covers. Sub-level 5
-    // boundary is ~3200 verts → ~3200 triangles per aggregate × ~5K
-    // visible = ~16M triangles, well within GPU fill rate at 1.8M pixels.
-    // Above this sub-level, skip raw extraction and use a scaled donor
-    // polygon. The donor's shape is the cap-level cluster boundary;
-    // higher sub-levels' actual boundaries have additional fractal
-    // detail that the donor smooths over, which causes adjacent
-    // donor-scaled polygons to leave visible chord-mismatch slivers.
-    // Bumping the cap to 6 means a sub-level 6 cluster is extracted
-    // from real leaves (~530K leaves max per shape) — its boundary is
-    // exact, so adjacent same-shape sub-level 6 cells tile properly.
-    // Above 6 we still use the donor (now the sub-level 6 polygon).
-    const EXTRACT_CAP = 5;
-
-    type BoundaryMesh = {
-      polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
-      indices: Uint32Array;
-    };
-    const _boundaryCache = new WeakMap<MetaTile, BoundaryMesh | null>();
-
-    function _collectLeafTransforms(mt: MetaTile, accum: Transform, out: Transform[]) {
-      if (mt.kind === "leaf") { out.push(accum); return; }
-      for (const { child, transform: T2 } of mt.geometries) {
-        _collectLeafTransforms(child, txCompose(accum, T2), out);
-      }
-    }
-
-    // Decimate the boundary by keeping anchors (the metatile's 4 superQuad
-    // corners) plus a fixed number of evenly-spaced intermediate vertices
-    // on each side between consecutive anchors.
-    //
-    // Cross-cluster consistency: two adjacent clusters share a side
-    // between the same two anchors C1 and C2, traversed in opposite
-    // directions but covering the same L vertices. Both compute m =
-    // min(maxExtraPerSide, L − 1) intermediate samples and keep verts at
-    // index offsets {round(k · L / (m + 1)) : k = 1..m}. That offset set
-    // is symmetric under k → m + 1 − k, so reversing the traversal
-    // direction picks the same world-space vertices. The polygons agree
-    // exactly along every shared side; the anchors pin the side
-    // endpoints so even sub-pixel index-rounding asymmetries can't open
-    // a corner gap.
-    function _decimateBetweenAnchors(
-      pts: Vec2[],
-      anchorIndices: number[],
-      maxExtraPerSide: number,
-    ): Vec2[] {
-      const n = pts.length;
-      if (anchorIndices.length < 2) {
-        // No usable anchors: just keep every k-th vertex around the loop.
-        const target = Math.min(48, n);
-        if (target >= n) return pts.slice();
-        const out: Vec2[] = [];
-        const step = n / target;
-        for (let i = 0; i < target; i++) out.push(pts[Math.round(i * step) % n]);
-        return out;
-      }
-      const sorted = [...anchorIndices].sort((a, b) => a - b);
-      const out: Vec2[] = [];
-      for (let a = 0; a < sorted.length; a++) {
-        const start = sorted[a];
-        const end = sorted[(a + 1) % sorted.length];
-        out.push(pts[start]);
-        const sideLen = (end - start + n) % n;
-        if (sideLen <= 1) continue;
-        const m = Math.min(maxExtraPerSide, sideLen - 1);
-        for (let k = 1; k <= m; k++) {
-          const offset = Math.round((k * sideLen) / (m + 1));
-          if (offset > 0 && offset < sideLen) {
-            out.push(pts[(start + offset) % n]);
-          }
-        }
-      }
-      return out.length >= 3 ? out : pts;
-    }
-
-    function extractBoundary(mt: MetaTile): BoundaryMesh | null {
-      if (mt.kind === "leaf") return null;
-      const cached = _boundaryCache.get(mt);
-      if (cached !== undefined) return cached;
-      const leafCount = countLeaves(mt);
-      if (leafCount > MAX_BOUNDARY_LEAVES) {
-        _boundaryCache.set(mt, null);
-        return null;
-      }
-
-      const xforms: Transform[] = [];
-      _collectLeafTransforms(mt, txIdentity, xforms);
-
-      const Q = 1e7;
-      const vertMap = new Map<string, number>();
-      const vertList: Vec2[] = [];
-      function vertId(p: Vec2): number {
-        const qx = Math.round(p[0] * Q);
-        const qy = Math.round(p[1] * Q);
-        const key = qx + "," + qy;
-        let id = vertMap.get(key);
-        if (id === undefined) { id = vertList.length; vertMap.set(key, id); vertList.push([p[0], p[1]]); }
-        return id;
-      }
-
-      const edgeMult = new Map<number, number>();
-      for (const T of xforms) {
-        const ids: number[] = new Array(14);
-        for (let i = 0; i < 14; i++) ids[i] = vertId(txApply(T, spectreVertices[i]));
-        for (let i = 0; i < 14; i++) {
-          const a = ids[i], b = ids[(i + 1) % 14];
-          const lo = a < b ? a : b;
-          const hi = a < b ? b : a;
-          const key = lo * 0x100000 + hi;
-          edgeMult.set(key, (edgeMult.get(key) ?? 0) + 1);
-        }
-      }
-
-      const adj = new Map<number, number[]>();
-      for (const [key, mult] of edgeMult) {
-        if (mult !== 1) continue;
-        const lo = Math.floor(key / 0x100000);
-        const hi = key % 0x100000;
-        let la = adj.get(lo); if (!la) { la = []; adj.set(lo, la); } la.push(hi);
-        let lb = adj.get(hi); if (!lb) { lb = []; adj.set(hi, lb); } lb.push(lo);
-      }
-
-      const visited = new Set<number>();
-      const loops: number[][] = [];
-      for (const start of adj.keys()) {
-        if (visited.has(start)) continue;
-        const loop: number[] = [];
-        let prev = -1;
-        let cur = start;
-        while (true) {
-          loop.push(cur);
-          visited.add(cur);
-          const ns = adj.get(cur)!;
-          let next = -1;
-          for (const n of ns) { if (n !== prev) { next = n; break; } }
-          if (next === -1 || next === start) break;
-          prev = cur;
-          cur = next;
-        }
-        loops.push(loop);
-      }
-      if (loops.length === 0) { _boundaryCache.set(mt, null); return null; }
-      loops.sort((a, b) => b.length - a.length);
-      const outer = loops[0];
-
-      const anchorVertIds = new Set<number>();
-      if (mt.kind === "meta") {
-        for (const corner of mt.quad) {
-          const qx = Math.round(corner[0] * Q);
-          const qy = Math.round(corner[1] * Q);
-          const id = vertMap.get(qx + "," + qy);
-          if (id !== undefined) anchorVertIds.add(id);
-        }
-      }
-      const outerPts: Vec2[] = outer.map((id) => vertList[id]);
-      const anchorIndices: number[] = [];
-      for (let i = 0; i < outer.length; i++) {
-        if (anchorVertIds.has(outer[i])) anchorIndices.push(i);
-      }
-
-      const simplified = _decimateBetweenAnchors(outerPts, anchorIndices, 12);
-      let cx = 0, cy = 0;
-      for (const p of simplified) { cx += p[0]; cy += p[1]; }
-      cx /= simplified.length; cy /= simplified.length;
-      const DILATE = 1.05;
-      const polygon = new Float32Array(simplified.length * 2);
-      const flat: number[] = new Array(simplified.length * 2);
-      for (let i = 0; i < simplified.length; i++) {
-        const x = cx + (simplified[i][0] - cx) * DILATE;
-        const y = cy + (simplified[i][1] - cy) * DILATE;
-        polygon[i * 2 + 0] = x;
-        polygon[i * 2 + 1] = y;
-        flat[i * 2 + 0] = x;
-        flat[i * 2 + 1] = y;
-      }
-      const indices = new Uint32Array(earcut(flat));
-      const built: BoundaryMesh = { polygon, indices };
-      _boundaryCache.set(mt, built);
-      return built;
-    }
-
-    // ─── GPU mesh handles ──────────────────────────────────────────────
-    // Per-metatile lazily-created vertex+index buffers. Memory is bounded
-    // by the number of unique metatiles encountered as aggregation
-    // candidates — at most ~9 metatypes × the deepest aggregation level.
+    // Cache key is `(subLevel, name)` — same-type same-sub-level cells
+    // share a centroid offset and bound radius (DAG-shared mt object),
+    // so one cached hexagon mesh fits every visible instance.
     import {
       createVertexBuffer as _createVB,
       createIndexBuffer as _createIB,
@@ -1407,599 +1508,64 @@
       indexCount: number;
       indexFormat: 'uint32';
     };
-    // Per-metatile-object cache (avoids re-checking the shape map every
-    // visit) and a shape-keyed cache that all 8 non-Γ types at the same
-    // substitution level point at, so we extract one boundary and create
-    // one pair of GPU buffers per (level, isGamma) instead of per type.
-    const _gpuMeshCache = new WeakMap<MetaTile, GpuMesh | null>();
     const _gpuMeshByShape = new Map<string, GpuMesh | null>();
 
-    // Donor metatiles for boundary extraction, one per shape (Γ vs non-Γ),
-    // at sub-level EXTRACT_CAP. Their polygons are extracted on first
-    // demand and reused (scaled) for any same-shape metatile with
-    // subLevel > EXTRACT_CAP. The donor's _localRadius is captured so we
-    // can compute the scale factor without needing the inflation constant
-    // analytically.
-    //
-    // baseCluster has subLevel = BASE_DEPTH + 1 = 5 metatiles. We need
-    // donors at EXTRACT_CAP = 6, so we inflate once to get sub-level 6
-    // metatiles.
-    const _donors = (() => {
-      const inflated = buildSupertiles(baseCluster);
-      attachRadii(inflated.Delta);
-      attachSubLevels(inflated.Delta);
-      attachCentroidBounds(inflated.Delta);
-      attachRadii(inflated.Gamma);
-      attachSubLevels(inflated.Gamma);
-      attachCentroidBounds(inflated.Gamma);
-      return { nonGamma: inflated.Delta, gamma: inflated.Gamma };
-    })();
+    // Triangle fan from vertex 0: (0,1,2), (0,2,3), (0,3,4), (0,4,5).
+    const _hexIndices = new Uint32Array([0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 5]);
 
-    function _getDonorBoundary(isGamma: boolean): { mesh: BoundaryMesh; radius: number } | null {
-      const donor = isGamma ? _donors.gamma : _donors.nonGamma;
-      const mesh = extractBoundary(donor);
-      if (mesh === null) return null;
-      return { mesh, radius: (donor as any)._localRadius };
-    }
-
-    function getGpuMesh(mt: MetaTile): GpuMesh | null {
-      const cached = _gpuMeshCache.get(mt);
-      if (cached !== undefined) return cached;
-      const subLevel = (mt as any)._subLevel as number;
-      const isGamma = mt.kind === "meta" && mt.name === "Gamma";
-      const shapeKey = subLevel + (isGamma ? "g" : "n");
-      const shared = _gpuMeshByShape.get(shapeKey);
-      if (shared !== undefined) {
-        _gpuMeshCache.set(mt, shared);
-        return shared;
+    // The walker (in the worker) sends each aggregate group with a
+    // string key `"subLevel:name"` plus the cell's centroid offset
+    // (`cCx`, `cCy`) and bounding-ball radius (`cBound`) — everything
+    // needed to materialise a hexagon mesh on first sight without
+    // round-tripping back to the worker. Cache hits skip the GPU
+    // buffer creation.
+    function getGpuMesh(
+      shapeKey: string,
+      cCx: number,
+      cCy: number,
+      cBound: number,
+    ): GpuMesh {
+      const cached = _gpuMeshByShape.get(shapeKey);
+      if (cached !== undefined && cached !== null) return cached;
+      const r = cBound * aggHexState.dilation;
+      const polygon = new Float32Array(12);
+      for (let i = 0; i < 6; i++) {
+        const t = i * Math.PI / 3;
+        polygon[2 * i + 0] = cCx + r * Math.cos(t);
+        polygon[2 * i + 1] = cCy + r * Math.sin(t);
       }
-      let polygon: Float32Array;
-      let indices: Uint32Array;
-      if (subLevel <= EXTRACT_CAP) {
-        const boundary = extractBoundary(mt);
-        if (boundary === null) {
-          _gpuMeshByShape.set(shapeKey, null);
-          _gpuMeshCache.set(mt, null);
-          return null;
-        }
-        polygon = boundary.polygon;
-        indices = boundary.indices;
-      } else {
-        const donor = _getDonorBoundary(isGamma);
-        if (donor === null) {
-          _gpuMeshByShape.set(shapeKey, null);
-          _gpuMeshCache.set(mt, null);
-          return null;
-        }
-        const scale = ((mt as any)._localRadius as number) / donor.radius;
-        polygon = new Float32Array(donor.mesh.polygon.length);
-        for (let i = 0; i < polygon.length; i++) polygon[i] = donor.mesh.polygon[i] * scale;
-        indices = donor.mesh.indices;
-      }
-      const vb = _createVB(device, 'agg-poly-verts', polygon);
-      const ib = _createIB(device, 'agg-poly-indices', indices);
+      const vb = _createVB(device, 'agg-hex-verts', polygon);
+      const ib = _createIB(device, 'agg-hex-indices', _hexIndices);
       const mesh: GpuMesh = {
         vertexBuffer: vb, indexBuffer: ib,
-        indexCount: indices.length, indexFormat: 'uint32',
+        indexCount: _hexIndices.length, indexFormat: 'uint32',
       };
       _gpuMeshByShape.set(shapeKey, mesh);
-      _gpuMeshCache.set(mt, mesh);
       return mesh;
     }
 
-    // Pre-extract every aggregate-polygon shape we'll use during normal
-    // interaction. Without this, the first time the user zooms out far
-    // enough to cross a substitution-level boundary, the walker calls
-    // `extractBoundary` cold for that level — at sub-level 5 (the donor)
-    // that walks ~4400 leaves and hashes ~62K edges synchronously,
-    // which shows up as a 30+ ms hitch on the main thread. Pre-warming
-    // moves all that work into module init time, where it's spent
-    // before the first frame.
-    //
-    (function _prewarmAggregatePolygons() {
-      const seen = new Set<string>();
-      const visited = new WeakSet<MetaTile>();
-      function rec(mt: MetaTile) {
-        if (mt.kind === "leaf" || visited.has(mt)) return;
-        visited.add(mt);
-        const sl = (mt as any)._subLevel as number | undefined;
-        if (sl != null && sl >= 1 && sl <= EXTRACT_CAP) {
-          const isG = mt.name === "Gamma";
-          const key = sl + (isG ? "g" : "n");
-          if (!seen.has(key)) {
-            seen.add(key);
-            getGpuMesh(mt);
-          }
-        }
-        for (const { child } of mt.geometries) rec(child);
-      }
-      rec(walkerState.currentRoot);
-      rec(_donors.nonGamma);
-      rec(_donors.gamma);
-      _getDonorBoundary(false);
-      _getDonorBoundary(true);
-    })();
-  </script>
-
-  <script id="walker" type="text/x-typescript">
-    // View-driven walker: traverse the metatile DAG with a per-frame view
-    // rect, cull subtrees whose bounding circle is outside the rect, and
-    // emit one 16-byte instance per visible leaf:
-    //   offset  0 (8 B): float32x2 (tx, ty)
-    //   offset  8 (4 B): snorm16x2 (cos θ, sin θ)
-    //   offset 12 (4 B): unorm8x4  (r, g, b, mirror)
-    //
-    // Scratch state (the data buffer, the transform stack) is allocated
-    // once and reused; only the visible-leaf prefix changes per frame.
-    type WalkView = {
-      centerX: number; centerY: number;
-      pixelScale: number;
-      pixelWidth: number; pixelHeight: number;
-      // Optional: if set, used for AGG threshold instead of pixelScale.
-      // Lets the user "freeze" the aggregation level while still zooming
-      // the actual rendering in/out.
-      aggPixelScale?: number;
-      // Optional extra cull-pad in CSS pixels. The walker pads the
-      // viewport AABB outward by this many pixels (converted to world
-      // units) before testing each cell's bounding ball. Pure safety
-      // margin — set higher to reduce the chance of background
-      // peeking through at the viewport edges.
-      cullPadPx?: number;
-    };
-
-    // Aggregate at this on-screen pixel extent: a metatile whose actual
-    // diameter shrinks below AGG_PX is rendered as its outline polygon
-    // instead of recursing into individual leaves.
-    //
-    // The walker descends until the first cell falls under the threshold
-    // and aggregates there, so cell sizes after aggregation land in
-    // (AGG_PX/inflation, AGG_PX] = (~AGG_PX/2.8, AGG_PX]. Refinement
-    // (the transition from aggregate polygon back to individual leaves
-    // as the user zooms in) happens at the same threshold, so a smaller
-    // AGG_PX pushes refinement to fire at a smaller on-screen size —
-    // detail persists farther into zoom-out.
-    const AGG_PX = 25;
-    // _localRadius is measured from the spectre's corner origin (vertex 0),
-    // so for any supertile it's ~1.5× the cluster's true centered radius
-    // (empirically 1.44 at sub-level 3, growing to 1.64 at sub-level 5).
-    // Multiplying the threshold by this factor lets aggregates trigger at
-    // the cell's actual on-screen extent rather than a smaller fraction.
-    // Without it, the walker recurses one extra level on average and emits
-    // ~5× more cells than necessary.
-    const _LOOSE_RADIUS_FACTOR = 1.55;
-
-    // Zoom-dependent color via Gaussian-weighted ancestor blend. Each
-    // visible cell has a precomputed RGB at every ancestor level (cell
-    // color at its own subLevel, plus one RGB per ancestor on the stack).
-    // viewLevel — derived from pixelScale so viewLevel = 0 places leaves
-    // exactly at the AGG_PX threshold, and each unit grows by one
-    // substitution step's worth of zoom-out — picks the *base* of the
-    // Gaussian. We then shift the actual center up by COLOR_SHIFT, so a
-    // cell about to aggregate (at AGG_PX, where S = viewLevel) is biased
-    // toward its parent's color rather than its own. Result: tiny tiles
-    // fade toward their parent (so the leaf-to-aggregate handoff is
-    // visually continuous, and the new aggregate's color matches the
-    // children that just merged into it), mid-size tiles (~2.5× AGG)
-    // pick up most of their own color, and large tiles render with full
-    // own-color saturation. Texture and contrast come from the mid and
-    // large scale objects, not the about-to-disappear small ones.
-    //
-    // σ ≈ 3.0 blends ~8 levels of ancestry into each cell's color:
-    // self ~23%, parent ~22%, gp ~18%, ggp ~14%, gggp ~9%, ggggp ~6%,
-    // and a long tail. Cell-centered, so this multi-scale blend is
-    // intrinsic to the substitution hierarchy and stays consistent
-    // across zooms. Adjacent cells differ at ~6 visible scales at once
-    // — per-cell, per-parent, per-grandparent, per-great-grandparent,
-    // etc. — instead of just one or two.
-    const SIGMA = 4.0;
-    const _TWO_SIGMA_SQ = 2 * SIGMA * SIGMA;
-    // Offset of the Gaussian center from viewLevel. With the alpha-fade
-    // band handling the visual smoothness at the aggregate-to-children
-    // crossover, the Gaussian center can sit on viewLevel itself — each
-    // cell reads at peak weight on its own color, so adjacent cells of
-    // different metatypes look distinct rather than averaging into their
-    // shared parent's color. That keeps smaller-scale structure visible
-    // alongside larger-scale, instead of the level-(K+1) ancestor's
-    // fractal boundary dominating the entire deep-zoom view.
-    const _COLOR_SHIFT = 0.0;
-    // Spectre supertile inflation factor — each substitution level's
-    // bounding circle scales by ~(1 + √3) ≈ 2.73 versus the previous;
-    // I'm using 2.5 here as a tuning compromise.
-    const _INFLATION = 2.5;
-    const _LEVEL0_PIXEL_SCALE = AGG_PX / (2 * _spectreBoundRadius);
-    function viewLevelFor(pixelScale: number): number {
-      if (pixelScale <= 0) return 0;
-      return -Math.log(pixelScale / _LEVEL0_PIXEL_SCALE) / Math.log(_INFLATION);
-    }
-
-    type WalkBucket = {
-      // null key = leaves drawn with the spectre mesh; otherwise the
-      // metatile whose outline polygon owns this bucket.
-      key: MetaTile | null;
-      data: ArrayBuffer;
-      f32: Float32Array;
-      i16: Int16Array;
-      u8: Uint8Array;
-      count: number;
-      capacity: number;
-    };
-
-    function _newBucket(key: MetaTile | null, initCap: number): WalkBucket {
-      const capacity = Math.max(16, initCap);
-      const data = new ArrayBuffer(capacity * 16);
-      return {
-        key,
-        data,
-        f32: new Float32Array(data),
-        i16: new Int16Array(data),
-        u8:  new Uint8Array(data),
-        count: 0,
-        capacity,
-      };
-    }
-
-    function _growBucket(b: WalkBucket, needed: number) {
-      if (needed <= b.capacity) return;
-      const newCap = Math.max(needed, b.capacity * 2);
-      const newData = new ArrayBuffer(newCap * 16);
-      new Uint8Array(newData).set(b.u8.subarray(0, b.count * 16));
-      b.data = newData;
-      b.f32 = new Float32Array(newData);
-      b.i16 = new Int16Array(newData);
-      b.u8  = new Uint8Array(newData);
-      b.capacity = newCap;
-    }
-
-    function makeWalker(initialLeafCap: number) {
-      // Generous depth budget — depth grows by 1 per upward-extension level.
-      const STK = 64;
-      const stRot = new Uint8Array(STK);
-      const stMir = new Uint8Array(STK);
-      const stTx  = new Float64Array(STK);
-      const stTy  = new Float64Array(STK);
-      // Ancestry color stack: each entered meta pushes its (subLevel, RGB).
-      // emit() blends the cell's own RGB with these ancestor RGBs using a
-      // Gaussian weight on (subLevel − viewLevel). Stack is ordered with
-      // index 0 = root (highest subLevel) and index ancDepth−1 = immediate
-      // parent (lowest subLevel).
-      const stColR = new Float64Array(STK);
-      const stColG = new Float64Array(STK);
-      const stColB = new Float64Array(STK);
-      const stSubL = new Float64Array(STK);
-      let ancDepth = 0;
-
-      let vMnX = -Infinity, vMxX = Infinity, vMnY = -Infinity, vMxY = Infinity;
-      let pixelScale = 1;
-      let aggPixelScale = 1; // used for AGG threshold; can be frozen
-      let viewLevel = 0;
-      // Per-frame precomputed Gaussian weight table: weight[L] =
-      // exp(-(L − viewLevel)² / 2σ²). 64 entries cover any plausible
-      // substitution level, replacing per-emit Math.exp calls with array
-      // lookups. Filled at the start of each walk().
-      const weightTable = new Float64Array(64);
-      const buckets = new Map<MetaTile | null, WalkBucket>();
-      // Pre-seed the leaf bucket at the requested size; it reuses across
-      // frames. Aggregate buckets are created lazily and reset each frame.
-      buckets.set(null, _newBucket(null, initialLeafCap));
-
-      function emit(bucketKey: MetaTile | null, label: string, d: number, cellSubLevel: number, alpha: number) {
-        if (alpha <= 0) return;
-        let b = buckets.get(bucketKey);
-        if (!b) { b = _newBucket(bucketKey, 64); buckets.set(bucketKey, b); }
-        if (b.count >= b.capacity) _growBucket(b, b.count + 1);
-        const i = b.count;
-        b.f32[i * 4 + 0] = stTx[d];
-        b.f32[i * 4 + 1] = stTy[d];
-        const c = _COS[stRot[d]], s = _SIN[stRot[d]];
-        b.i16[i * 8 + 4] = Math.max(-32768, Math.min(32767, Math.round(c * 32767)));
-        b.i16[i * 8 + 5] = Math.max(-32768, Math.min(32767, Math.round(s * 32767)));
-
-        // Cell-centered Gaussian-weighted RGB blend over the ancestry chain.
-        // weightTable[d] = exp(-d² / 2σ²) is indexed by level-distance from
-        // the cell. The cell itself gets weight[0] = 1 (peak), each
-        // ancestor d levels up gets weight[d]. This way every cell reads
-        // dominantly its own type color regardless of zoom; the visual
-        // character is consistent across substitution levels because the
-        // blend is intrinsic to the cell's position in the substitution
-        // hierarchy, not to the global zoom state.
-        const cellCol = colorForLevelType(cellSubLevel, label);
-        let w = weightTable[0];
-        let total = w, R = w * cellCol[0], G = w * cellCol[1], B = w * cellCol[2];
-        for (let k = 0; k < ancDepth; k++) {
-          const d = (stSubL[k] - cellSubLevel) | 0;
-          w = weightTable[d < 0 ? -d : d];
-          total += w;
-          R += w * stColR[k]; G += w * stColG[k]; B += w * stColB[k];
-        }
-        const inv = 1 / total;
-
-        // Pack mirror flag (high bit) and alpha (low 7 bits) into byte 15.
-        // 0..127 = non-mirrored, alpha 0..1; 128..255 = mirrored, alpha 0..1.
-        // Shader decodes via select() on byte >= 128 and divides by 127.
-        const a127 = Math.max(0, Math.min(127, Math.round(alpha * 127)));
-        const off = i * 16;
-        b.u8[off + 12] = Math.max(0, Math.min(255, Math.round(R * inv * 255)));
-        b.u8[off + 13] = Math.max(0, Math.min(255, Math.round(G * inv * 255)));
-        b.u8[off + 14] = Math.max(0, Math.min(255, Math.round(B * inv * 255)));
-        b.u8[off + 15] = (stMir[d] ? 128 : 0) | a127;
-        b.count = i + 1;
-      }
-
-      function recurse(mt: MetaTile, d: number, alphaIn: number, allowFadeOut: boolean = true) {
-        if (alphaIn <= 0) return;
-        const cx = stTx[d], cy = stTy[d];
-        const r = (mt as any)._localRadius ?? 0;
-        if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
-        if (mt.kind === "leaf") { emit(null, mt.label, d, 0, alphaIn); return; }
-
-        // We crossfade the parent's self-emit against its children's
-        // recursion so neither pops. The parent fades in across an upper
-        // band [aggThresh, upperFadeBound] (at α=0 above, α=1 at and
-        // below aggThresh) while children render at full alpha. Below
-        // aggThresh the parent stays at α=1 and children fade out across
-        // [lowerFadeBound, aggThresh]. Below lowerFadeBound only the
-        // parent renders.
-        //
-        // allowFadeOut limits cascade: a child reached via fade-out
-        // doesn't itself get a fade-out band, so we render at most two
-        // levels (parent + one fade-out children level) in the
-        // sub-aggThresh region instead of cascading down to leaves.
-        const pixelExtent = 2 * r * aggPixelScale;
-        const aggThresh = AGG_PX * _LOOSE_RADIUS_FACTOR;
-        const upperFadeBound = aggThresh * 1.5;
-        const mySubLevel = (mt as any)._subLevel as number;
-        // At and below sub-level EXTRACT_CAP+1, children are real-extracted
-        // (or leaves) and tile correctly, so a wider fade band lets them
-        // smoothly disappear without revealing structural gaps. At higher
-        // sub-levels the children are also donor-scaled (gaps remain), so
-        // we use a narrower band: enough to smooth the level-transition
-        // pop without paying full-band cell counts.
-        const lowerFadeBound = mySubLevel <= EXTRACT_CAP + 1
-          ? aggThresh / 3
-          : aggThresh * 0.65;
-
-        // Parent self-emit alpha factor: 1 in the lower band, smooth
-        // fade-in across the upper band, 0 above the upper band.
-        let parentFactor = 0;
-        if (pixelExtent < aggThresh) {
-          parentFactor = 1;
-        } else if (pixelExtent < upperFadeBound) {
-          const u = (upperFadeBound - pixelExtent) / (upperFadeBound - aggThresh);
-          parentFactor = u * u * (3 - 2 * u);
-        }
-
-        if (parentFactor > 0) {
-          const mesh = getGpuMesh(mt);
-          if (mesh) {
-            emit(mt, mt.name, d, mySubLevel, alphaIn * parentFactor);
-          } else if (pixelExtent < aggThresh) {
-            // No mesh available and we're in the lower band where the
-            // parent must carry coverage; abort before recursing into
-            // children we can't fall back on.
-            return;
-          }
-        }
-
-        let childAlpha: number;
-        let childAllowFadeOut: boolean;
-        if (pixelExtent < aggThresh) {
-          // Lower band: only recurse children if a fade-out applies.
-          if (pixelExtent < lowerFadeBound || !allowFadeOut) return;
-          const u = (pixelExtent - lowerFadeBound) / (aggThresh - lowerFadeBound);
-          const t = u * u * (3 - 2 * u);
-          childAlpha = alphaIn * t;
-          childAllowFadeOut = false;
-        } else {
-          // Upper fade band or beyond: children recurse at full alpha.
-          childAlpha = alphaIn;
-          childAllowFadeOut = allowFadeOut;
-        }
-
-        // Push this meta's RGB onto the ancestry stack, recurse, pop.
-        const mySL = (mt as any)._subLevel as number;
-        const myCol = colorForLevelType(mySL, mt.name);
-        stColR[ancDepth] = myCol[0];
-        stColG[ancDepth] = myCol[1];
-        stColB[ancDepth] = myCol[2];
-        stSubL[ancDepth] = mySL;
-        ancDepth++;
-
-        const pRot = stRot[d], pMir = stMir[d];
-        const pTx = stTx[d], pTy = stTy[d];
-        const pc = _COS[pRot], ps = _SIN[pRot];
-        const d1 = d + 1;
-        for (const { child, transform: T2 } of mt.geometries) {
-          let ccx = T2.t[0], ccy = T2.t[1];
-          if (pMir) ccy = -ccy;
-          stTx[d1] = pc * ccx - ps * ccy + pTx;
-          stTy[d1] = ps * ccx + pc * ccy + pTy;
-          const rDiff = pMir ? -T2.rot : T2.rot;
-          stRot[d1] = (pRot + rDiff + 12) % 12;
-          stMir[d1] = (pMir ^ T2.mirror) as 0 | 1;
-          recurse(child, d1, childAlpha, childAllowFadeOut);
-        }
-        ancDepth--;
-      }
-
-      // Single shared buffer, populated by concatenating bucket data
-      // post-walk. Re-used across frames; grows on demand.
-      let outData = new ArrayBuffer(initialLeafCap * 16);
-      let outU8 = new Uint8Array(outData);
-
-      return function walk(rootMeta: MetaTile, rootTransform: Transform, view: WalkView): {
-        data: ArrayBuffer; totalCount: number;
-        groups: Array<{ key: MetaTile | null; instanceOffset: number; instanceCount: number }>;
-      } {
-        const halfW = view.pixelWidth / (2 * view.pixelScale);
-        const halfH = view.pixelHeight / (2 * view.pixelScale);
-        const m = _spectreBoundRadius;
-        const padPx = view.cullPadPx ?? 0;
-        const padWorld = padPx / view.pixelScale;
-        // Walker accumulates positions in *view-relative* world units: every
-        // stTx/stTy is "world coordinate minus viewCenter", computed in Float64
-        // throughout the recursion. The instance buffer's iWorld is then a
-        // small-magnitude Float32 (bounded by the viewport radius), and the
-        // GPU shader doesn't have to subtract two large numbers to project to
-        // clip space. Without this trick, the cancellation of (world - center)
-        // inside `world * view.scale + view.offset` chews through Float32
-        // precision once world coordinates pass ~1e6, and shared edges
-        // between adjacent cells crack open. (Standard "Relative-To-Center"
-        // / RTC trick used by web maps and 3D engines.)
-        vMnX = -halfW - m - padWorld;
-        vMxX =  halfW + m + padWorld;
-        vMnY = -halfH - m - padWorld;
-        vMxY =  halfH + m + padWorld;
-        pixelScale = view.pixelScale;
-        // aggPixelScale defaults to view.pixelScale, but can be overridden
-        // (e.g., by the freeze toggle) so the AGG threshold is computed
-        // against a frozen pixelScale even though the actual rendering
-        // uses view.pixelScale. That lets the user zoom in on a captured
-        // structure without it re-aggregating.
-        aggPixelScale = (view as any).aggPixelScale ?? view.pixelScale;
-        viewLevel = viewLevelFor(aggPixelScale);
-        // The weight table is now indexed by ABSOLUTE LEVEL DISTANCE from
-        // the cell being emitted, not by absolute level number. weight[d]
-        // is the weight applied to an ancestor d substitution levels up
-        // from the cell. So the cell's own color always gets weight[0] = 1
-        // (peak) regardless of zoom. Without this, when viewLevel sits
-        // between two integer levels, neither the cell nor its parent
-        // gets peak weight, and the dominant contribution comes from
-        // averaging across many ancestors — at deep zoom that converges
-        // toward the palette mean (a bluish-grey), erasing the per-cell
-        // color variation.
-        for (let d = 0; d < weightTable.length; d++) {
-          weightTable[d] = Math.exp(-(d * d) / _TWO_SIGMA_SQ);
-        }
-        ancDepth = 0;
-
-        // Reset all buckets.
-        for (const b of buckets.values()) b.count = 0;
-
-        stRot[0] = rootTransform.rot;
-        stMir[0] = rootTransform.mirror;
-        stTx[0]  = rootTransform.t[0] - view.centerX;
-        stTy[0]  = rootTransform.t[1] - view.centerY;
-        recurse(rootMeta, 0, 1.0);
-
-        // Concatenate buckets into outData. Aggregates first (so the
-        // fading-in next level draws on top of them with alpha blending),
-        // then leaves last on top of all aggregates.
-        let totalCount = 0;
-        for (const b of buckets.values()) totalCount += b.count;
-        if (totalCount * 16 > outData.byteLength) {
-          const newCap = Math.max(totalCount, (outData.byteLength / 16) * 2);
-          outData = new ArrayBuffer(newCap * 16);
-          outU8 = new Uint8Array(outData);
-        }
-        const groups: Array<{ key: MetaTile | null; instanceOffset: number; instanceCount: number }> = [];
-        let off = 0;
-        // Sort aggregate buckets coarsest-first (highest subLevel first) so
-        // a parent aggregate draws under its child sub-aggregates during
-        // the fade-band overlap. Leaves (subLevel 0) come last.
-        const aggBuckets: WalkBucket[] = [];
-        for (const b of buckets.values()) {
-          if (b.key === null) continue;
-          if (b.count === 0) continue;
-          aggBuckets.push(b);
-        }
-        aggBuckets.sort((a, b) =>
-          ((b.key as any)._subLevel ?? 0) - ((a.key as any)._subLevel ?? 0)
-        );
-        for (const b of aggBuckets) {
-          outU8.set(b.u8.subarray(0, b.count * 16), off * 16);
-          groups.push({ key: b.key, instanceOffset: off, instanceCount: b.count });
-          off += b.count;
-        }
-        const leafBucket = buckets.get(null)!;
-        if (leafBucket.count > 0) {
-          outU8.set(leafBucket.u8.subarray(0, leafBucket.count * 16), off * 16);
-          groups.push({ key: null, instanceOffset: off, instanceCount: leafBucket.count });
-          off += leafBucket.count;
-        }
-        return { data: outData, totalCount, groups };
-      };
-    }
-
-    const walker = makeWalker(countLeaves(rootMeta));
-
-    // ─── Upward extension ───────────────────────────────────────────────
-    // Wrap the current root in a level-up parent. The new root's pose is
-    // chosen so the slot containing the existing root keeps the existing
-    // root's accumulated transform — visible tiles do not move.
-    //
-    // To avoid the "same surroundings at every zoom-out" effect, we walk
-    // through different (parent_type, slot) options at each extension
-    // rather than always wrapping as slot-1 of Δ. The substitution rules
-    // form a constrained graph: child type C can only sit at the
-    // specific (parent, slot) pairs where superRules[parent][slot] === C.
-    // Some types are bottlenecks (e.g., Θ only fits at slot 3 of Γ, Λ
-    // only at slot 6 of Σ); others have many options.
-    const _PARENT_OPTIONS: Record<TileName, Array<[TileName, number]>> = (() => {
-      const out = {} as Record<TileName, Array<[TileName, number]>>;
-      for (const t of TILE_NAMES) out[t] = [];
-      for (const parent of TILE_NAMES) {
-        const subs = superRules[parent];
-        for (let slot = 0; slot < subs.length; slot++) {
-          const c = subs[slot];
-          if (c !== null) out[c].push([parent, slot]);
+    // Drop every cached hexagon mesh and re-resolve the last
+    // worker-delivered draw list with freshly-built meshes. Called
+    // when aggHexState.dilation changes — the cached vertex buffers
+    // bake the previous dilation into their positions, so the cache
+    // must be invalidated for the new dilation to take visual effect.
+    // Re-running `workerStatus.onResult` on `lastResult` does the
+    // re-resolve and re-uploads the (unchanged) instance buffer; the
+    // onResult handler also calls requestFrame.
+    function refreshAggMeshes(): void {
+      for (const m of _gpuMeshByShape.values()) {
+        if (m) {
+          m.vertexBuffer.destroy?.();
+          m.indexBuffer.destroy?.();
         }
       }
-      return out;
-    })();
-    function extendRootUpward() {
-      const nextRecord = buildSupertiles(walkerState.currentBaseRecord);
-      const root = walkerState.currentRoot;
-      if (root.kind !== 'meta') throw new Error('root must be a meta tile');
-      const currentType = root.name;
-      const opts = _PARENT_OPTIONS[currentType];
-      // Cycle through options. The simple modulo is good enough; for
-      // bottleneck types (Θ, Λ) opts.length === 1 and we always pick it.
-      const [parentType, slot] = opts[walkerState.extensionLevel % opts.length];
-      const newRoot = nextRecord[parentType];
-      attachRadii(newRoot);
-      attachSubLevels(newRoot);
-      attachCentroidBounds(newRoot);
-      // Find geometry index for slot, accounting for null entries that
-      // buildSupertiles filters out (only Γ has a null, at slot 2).
-      const subs = superRules[parentType];
-      let geomIdx = 0;
-      for (let s = 0; s < slot; s++) if (subs[s] !== null) geomIdx++;
-      const slot1Transform = newRoot.geometries[geomIdx].transform;
-      walkerState.currentRootTransform = txCompose(
-        walkerState.currentRootTransform,
-        txInverse(slot1Transform),
-      );
-      walkerState.currentRoot = newRoot;
-      walkerState.currentBaseRecord = nextRecord;
-      walkerState.extensionLevel += 1;
-    }
-
-    // Extend while the current root's bounding circle isn't comfortably
-    // bigger than the viewport. _localRadius is measured from the spectre
-    // tile's corner origin (vertex 0), not the cluster's centroid, so in
-    // some directions the cluster covers as little as ~35% of that
-    // radius. To guarantee that every viewport pixel falls inside the
-    // cluster's actual shape (not just the bounding circle), we want
-    // distToCorner ≤ ~0.35 × r. Picking 0.3 gives a small safety margin.
-    // Each extension is O(1) and grows the cluster by ~2.5×, so the
-    // tighter threshold typically costs ~1 extra extension level.
-    function maybeExtend(view: WalkView): void {
-      let safety = 64;
-      while (safety-- > 0) {
-        const r = (walkerState.currentRoot as any)._localRadius;
-        const cx = walkerState.currentRootTransform.t[0];
-        const cy = walkerState.currentRootTransform.t[1];
-        const halfW = view.pixelWidth / (2 * view.pixelScale);
-        const halfH = view.pixelHeight / (2 * view.pixelScale);
-        const padW = (view.cullPadPx ?? 0) / view.pixelScale;
-        const dx = Math.abs(view.centerX - cx) + halfW + padW;
-        const dy = Math.abs(view.centerY - cy) + halfH + padW;
-        const distToCorner = Math.hypot(dx, dy);
-        if (distToCorner <= 0.3 * r) return;
-        extendRootUpward();
+      _gpuMeshByShape.clear();
+      if (workerStatus.lastResult && workerStatus.onResult) {
+        workerStatus.onResult(workerStatus.lastResult);
       }
     }
   </script>
+
 
   <script id="renderer-setup" type="text/x-typescript">
     import { expandable } from './lib/expandable.js';
@@ -2008,18 +1574,48 @@
     // Rebuilt on every view change; the walker's scratch buffer is
     // reused so this call is allocation-free in the hot path.
     let _initialFitDone = false;
-    // Mutable freeze state: when non-null, the aggregation threshold is
-    // computed against this pixelScale instead of the live one, so the
-    // structure stays at its captured aggregation level while the user
-    // zooms the camera in/out for inspection.
-    const freezeState: { aggPixelScale: number | null } = { aggPixelScale: null };
+    // Mutable freeze state. When `frozen` is true the walker is bypassed
+    // entirely: the captured instance buffer keeps drawing, and pan/zoom
+    // is absorbed by the renderer's offset uniform via instanceCenterX/Y.
+    // `aggPixelScale` is the freeze-time pixel scale, exposed to the
+    // walker (when not bypassed) so the AGG threshold uses the captured
+    // scale instead of the live one.
+    const freezeState: { frozen: boolean; aggPixelScale: number | null } = {
+      frozen: false, aggPixelScale: null,
+    };
     // Cull-padding (CSS pixels) applied around the viewport before
-    // per-cell cull tests. Mutated by the video-export slider; defaults
-    // to 0 so live interaction is unchanged.
-    const cullState: { padPx: number } = { padPx: 0 };
+    // per-cell cull tests in the worker. Each walk takes ~viewport-area
+    // time, so increasing the pad makes individual walks slower (more
+    // cells visited) — but since the renderer keeps drawing the cached
+    // result while the worker computes the next one, a larger pad lets
+    // pan/zoom drift further before blank space appears at the edges.
+    // 200 px on a 1280-wide viewport is ~16% extra coverage in each
+    // direction (~33% margin total), which absorbs typical wheel-zoom
+    // rates without making walks visibly slower. Push it higher (via
+    // the video-export slider) for smoother fast-zoom at the cost of
+    // walk latency.
+    const cullState: { padPx: number } = { padPx: 200 };
     function repackInstances(): void {
       if (viewerState.pixelWidth === 0) return;
-      const view = {
+      if (freezeState.frozen) {
+        // Skip the worker entirely. The cached instance buffer keeps
+        // drawing, and pan/zoom shifts the offset uniform via the
+        // (instanceCenter − center) term in _renderTo.
+        viewerState.requestFrame();
+        return;
+      }
+      if (workerStatus.captureMode) {
+        // Video export is driving walks via walkAndAwait. An
+        // interactive sendViewToWorker here would overwrite the
+        // export's pending view and cause its await to hang.
+        return;
+      }
+      // Push the latest view to the worker. The renderer keeps
+      // drawing the *previous* result (with the offset uniform
+      // compensating for the view delta) until a fresh result
+      // arrives. The worker drops stale views, so a flurry of pan
+      // events between frames coalesces into a single re-walk.
+      sendViewToWorker({
         centerX: viewerState.centerX,
         centerY: viewerState.centerY,
         pixelScale: viewerState.pixelScale,
@@ -2027,16 +1623,26 @@
         pixelHeight: viewerState.pixelHeight,
         aggPixelScale: freezeState.aggPixelScale ?? undefined,
         cullPadPx: cullState.padPx,
-      };
-      maybeExtend(view);
-      const result = walker(walkerState.currentRoot, walkerState.currentRootTransform, view);
+        aggPx: qualityState.aggPx,
+      });
+      viewerState.requestFrame();
+    }
 
-      // Resolve bucket keys → renderer meshes. The leaf bucket uses the
-      // renderer's default spectre mesh; aggregates use per-metatile
-      // boundary meshes. getGpuMesh is memoized so repeats are cheap.
+    // Forward worker results to the renderer. Each group's mesh is
+    // looked up (or built and cached) from its `(subLevel, name)` key
+    // plus the centroid + bound that came with it; leaves use the
+    // renderer's default spectre mesh.
+    // Resolve a worker result's bucket-key groups to renderer mesh
+    // references (looking up — and lazily building — the per-(subLevel,
+    // name) hexagon meshes), upload its instance buffer, and pin the
+    // renderer's instanceCenter to the view that produced it. Used by
+    // both the live onResult handler and the video-export pool path.
+    function applyWorkerResult(m: WorkerResult): void {
       const renderGroups = [];
-      for (const g of result.groups) {
-        const mesh = g.key === null ? viewerState.defaultMesh : getGpuMesh(g.key);
+      for (const g of m.groups) {
+        const mesh = g.key === null
+          ? viewerState.defaultMesh
+          : getGpuMesh(g.key, g.cCx!, g.cCy!, g.cBound!);
         if (!mesh) continue;
         renderGroups.push({
           mesh,
@@ -2044,8 +1650,23 @@
           instanceCount: g.instanceCount,
         });
       }
-      viewerState.setDrawList({ data: result.data, totalCount: result.totalCount, groups: renderGroups });
+      viewerState.instanceCenterX = m.instanceCenterX;
+      viewerState.instanceCenterY = m.instanceCenterY;
+      viewerState.setDrawList({
+        data: m.data,
+        totalCount: m.totalCount,
+        groups: renderGroups,
+      });
     }
+    workerStatus.onResult = (m) => {
+      applyWorkerResult(m);
+      // setDrawList only uploads to the GPU buffer — it doesn't
+      // schedule a frame. Without this, a result that arrives between
+      // user interactions (e.g., after clicking Go on a keyframe)
+      // never paints, and the canvas stays blank until the next pan
+      // or resize triggers requestFrame.
+      viewerState.requestFrame();
+    };
 
     const { canvas: viewerCanvas, state: viewerState } = createInfiniteRenderer({
       device,
@@ -2056,6 +1677,29 @@
       onViewChange: () => repackInstances(),
     });
 
+    // The initial fit needs the cluster's world-space bounds, which
+    // come asynchronously from the worker's `init` message. So the
+    // resize callback may run before the bounds are known; we just
+    // try the fit on every relevant trigger and let it succeed once
+    // both the canvas has pixels and the worker has handed off
+    // bounds.
+    function _tryInitialFit(): void {
+      if (_initialFitDone) return;
+      if (viewerState.pixelWidth === 0) return;
+      const b = workerStatus.rootBounds;
+      if (!b) return;
+      viewerState.centerX = (b.minX + b.maxX) / 2;
+      viewerState.centerY = (b.minY + b.maxY) / 2;
+      const fitX = viewerState.pixelWidth  / (b.maxX - b.minX);
+      const fitY = viewerState.pixelHeight / (b.maxY - b.minY);
+      viewerState.pixelScale = 0.95 * Math.min(fitX, fitY);
+      _initialFitDone = true;
+      repackInstances();
+    }
+    // If the worker handshake completes after the renderer has
+    // already sized itself, do the fit then.
+    workerStatus.onInit = () => _tryInitialFit();
+
     const viewerExpandable = expandable(viewerCanvas, {
       id: 'spectre-infinite',
       width: 640,
@@ -2063,18 +1707,7 @@
       wide: true,
       onResize: (_el, w, h) => {
         viewerState.resize(w, h);
-        if (!_initialFitDone && viewerState.pixelWidth > 0) {
-          // First valid pixel size: center on the cluster centroid and
-          // pick the largest pixelScale that keeps the cluster inside
-          // the viewport with a 5% margin.
-          const b = rootBounds;
-          viewerState.centerX = (b.minX + b.maxX) / 2;
-          viewerState.centerY = (b.minY + b.maxY) / 2;
-          const fitX = viewerState.pixelWidth  / (b.maxX - b.minX);
-          const fitY = viewerState.pixelHeight / (b.maxY - b.minY);
-          viewerState.pixelScale = 0.95 * Math.min(fitX, fitY);
-          _initialFitDone = true;
-        }
+        _tryInitialFit();
         repackInstances();
         viewerState.requestFrame();
       },
@@ -2086,48 +1719,69 @@
     // current zoom/pan state out of the page (to share, screenshot,
     // reproduce a bug report) and paste it back later to return to the
     // exact same view.
-    const _viewOutput = document.createElement('input');
-    _viewOutput.type = 'text';
-    _viewOutput.readOnly = true;
-    _viewOutput.className = 'spectre-input grow';
-    _viewOutput.title = 'Current view as pixelScale/centerX/centerY.';
+    // Single editable view box: shows the current pixelScale/centerX/centerY,
+    // editable in place. Click Go (or press Enter) to jump. Auto-refresh
+    // pauses while the input is focused so an interactive pan/zoom doesn't
+    // wipe the user's mid-edit text.
+    const _viewInput = document.createElement('input');
+    _viewInput.type = 'text';
+    _viewInput.className = 'spectre-input grow';
+    _viewInput.title = 'pixelScale/centerX/centerY — edit and press Enter (or click Go) to jump.';
+    let _viewInputFocused = false;
     function _formatView(): string {
       const v = viewerState.getView();
       return `${v.pixelScale}/${v.centerX}/${v.centerY}`;
     }
-    function _refreshViewOutput() { _viewOutput.value = _formatView(); }
+    function _refreshViewInput() {
+      if (_viewInputFocused) return;
+      _viewInput.value = _formatView();
+    }
+    _viewInput.addEventListener('focus', () => { _viewInputFocused = true; });
+    _viewInput.addEventListener('blur',  () => {
+      _viewInputFocused = false;
+      _refreshViewInput();
+    });
     // Wrap the existing onViewChange so each view update also refreshes
-    // the read-out. Done here (not in renderer.js) so the display logic
-    // stays a notebook-level concern.
+    // the displayed value. Done here (not in renderer.js) so the display
+    // logic stays a notebook-level concern.
     const _origOnViewChange = viewerState.onViewChange;
     viewerState.onViewChange = function (...args: any[]) {
       _origOnViewChange?.apply(this, args);
-      _refreshViewOutput();
+      _refreshViewInput();
     };
-    _refreshViewOutput();
+    _refreshViewInput();
 
-    const _viewInput = document.createElement('input');
-    _viewInput.type = 'text';
-    _viewInput.placeholder = 'pixelScale/centerX/centerY';
-    _viewInput.className = 'spectre-input grow';
-    _viewInput.addEventListener('change', () => {
+    function _applyView() {
       const parts = _viewInput.value.split('/');
       const ps = parts.length === 3 ? Number(parts[0]) : NaN;
       const cx = parts.length === 3 ? Number(parts[1]) : NaN;
       const cy = parts.length === 3 ? Number(parts[2]) : NaN;
       if (Number.isFinite(ps) && Number.isFinite(cx) && Number.isFinite(cy)) {
+        _viewInput.style.outline = '';
         viewerState.setView({ pixelScale: ps, centerX: cx, centerY: cy });
-        _viewInput.value = '';
+        _viewInput.blur();
       } else {
-        _viewInput.style.outline = '1px solid red';
+        _viewInput.style.outline = '1px solid #d04848';
         setTimeout(() => { _viewInput.style.outline = ''; }, 600);
       }
+    }
+    _viewInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); _applyView(); }
     });
+    const _goBtn = document.createElement('button');
+    _goBtn.type = 'button';
+    _goBtn.className = 'spectre-btn';
+    _goBtn.textContent = 'Go';
+    _goBtn.addEventListener('click', _applyView);
 
-    // Freeze checkbox: locks the aggregation level to whatever it was at
-    // the moment the box was checked, so zooming in past the threshold
-    // doesn't trigger refinement. Useful for inspecting a specific
-    // aggregation level's geometry up close.
+    // Freeze checkbox: pins the *exact* draw list (and its
+    // accompanying view center / aggregation pixelScale) at the
+    // moment the box is checked. While checked the walker is
+    // bypassed entirely — pan and zoom shift the renderer's offset
+    // uniform but the instance buffer doesn't change. This is a
+    // debugging tool: it lets you zoom out far enough to see what
+    // would otherwise have been culled, without the walker grinding
+    // through an ever-growing tree.
     const _freezeWrap = document.createElement('label');
     _freezeWrap.className = 'spectre-checkbox';
     _freezeWrap.htmlFor = 'spectre-freeze';
@@ -2138,8 +1792,19 @@
     _freezeText.textContent = 'freeze structure';
     _freezeWrap.append(_freezeCb, _freezeText);
     _freezeCb.addEventListener('change', () => {
-      freezeState.aggPixelScale = _freezeCb.checked ? viewerState.pixelScale : null;
-      viewerState.onViewChange?.(viewerState);
+      if (_freezeCb.checked) {
+        // Take a fresh walk at the current view, then lock everything
+        // — the walker call seeds instanceCenterX/Y to the freeze-time
+        // center, and `frozen = true` blocks subsequent re-walks.
+        freezeState.frozen = false;
+        freezeState.aggPixelScale = viewerState.pixelScale;
+        repackInstances();
+        freezeState.frozen = true;
+      } else {
+        freezeState.frozen = false;
+        freezeState.aggPixelScale = null;
+        repackInstances();
+      }
       viewerState.requestFrame();
     });
 
@@ -2148,11 +1813,8 @@
     _viewRow.style.margin = '8px 0';
     const _viewLabel1 = document.createElement('span');
     _viewLabel1.className = 'spectre-label';
-    _viewLabel1.textContent = 'view';
-    const _viewLabel2 = document.createElement('span');
-    _viewLabel2.className = 'spectre-label';
-    _viewLabel2.textContent = 'set';
-    _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput, _freezeWrap);
+    _viewLabel1.textContent = 'scale/x/y';
+    _viewRow.append(_viewLabel1, _viewInput, _goBtn, _freezeWrap);
     display(_viewRow);
   </script>
 
@@ -2331,6 +1993,17 @@
       { smooth: false, sec: 6, ease: 'quintic', speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
     ];
 
+    // Optional per-render brightness ramp. When `autoBalance` is on,
+    // the exporter pre-renders frame 0 and the last frame, measures
+    // their average luma, and biases viewerState.tonemap.brightness
+    // by ±(L_end − L_start) / 2 so frame 0 looks one half-step
+    // brighter (or dimmer) than nominal and the last frame looks one
+    // half-step the other way. The two halves "meet at the midpoint"
+    // (zero adjustment), and a loop video transitions smoothly
+    // because the visual brightness of the first and last frames
+    // both converge to (L_start + L_end) / 2.
+    const _brightnessRamp: { autoBalance: boolean } = { autoBalance: true };
+
     // For each segment, return its evaluated form: a duration in seconds
     // and a sample(localT) function mapping local time ∈ [0, 1] → View.
     // Smooth segments compute the van Wijk geodesic and scale by S/V;
@@ -2419,6 +2092,8 @@
     }
 
     async function _recordVideo(opts: RecordOpts): Promise<Uint8Array> {
+      // eslint-disable-next-line no-console
+      console.log('[mp4] _recordVideo called', opts);
       const w = opts.width  - (opts.width  & 1);
       const h = opts.height - (opts.height & 1);
       if (w < 16 || h < 16) throw new Error('width/height too small');
@@ -2462,53 +2137,294 @@
       enc.initialize();
 
       // Temporal supersampling: per output frame, render N sub-frames at
-      // fractional times spanning the output frame's interval, then
-      // average. Only the time parameter varies between sub-samples;
-      // palette, cull pad, etc. stay fixed. N=1 is plain (no blur).
+      // fractional times spanning the output frame's interval. With N>1
+      // we accumulate the sub-frames in a linear HDR buffer on the GPU
+      // and run the tonemap curve once on the average — this preserves
+      // bright streaks that the per-sub-frame tonemap path would clip
+      // and then dilute via post-tonemap averaging. With N=1 we use the
+      // direct fill+tonemap path. Only the time parameter varies between
+      // sub-samples; palette, cull pad, etc. stay fixed.
       const N = Math.max(1, Math.floor(opts.samples) | 0);
       const dFrac = 1 / Math.max(1, totalFrames - 1);
-      const accLen = w * h * 4;
-      const acc = N > 1 ? new Float64Array(accLen) : null;
+      const useAccumulator = N > 1;
 
-      (viewerState as any).beginCapture(w, h);
+      // ─── Worker pool setup ───────────────────────────────────────
+      // Spawn N independent walker workers, initialise each with the
+      // current palette + colorBlend, and pre-extend them all to the
+      // same DAG state. Walks for individual frames then run in
+      // parallel without further extension, so per-frame cluster
+      // shape is identical across pool workers (no cross-worker
+      // visual inconsistency from divergent extension histories).
+      const poolSize = Math.max(1, Math.min(8, navigator.hardwareConcurrency || 4));
+      // eslint-disable-next-line no-console
+      console.log('[mp4] _recordVideo enter — totalFrames =', totalFrames, ', poolSize =', poolSize);
+      const pool = new WalkerWorkerPool(poolSize);
+      // Block interactive sendViewToWorker calls (mouse/wheel handlers
+      // that fire during our awaits) so the live worker doesn't churn
+      // on stale views while the export runs. The pool drives its own
+      // walks; the live worker is left idle.
+      workerStatus.captureMode = true;
+      // Disable mouse interactions on the live canvas — mid-export
+      // pan/zoom mutations would race the per-frame view we set on
+      // viewerState, putting the encoder out of sync with what the
+      // walker computed.
+      const _savedPointerEvents = viewerCanvas.style.pointerEvents;
+      viewerCanvas.style.pointerEvents = 'none';
+      // Preview canvas: a sibling 2D-context canvas that shows each
+      // captured frame as it's encoded. We can't multiplex WebGPU
+      // and 2D contexts on the same canvas, so we hide the live
+      // canvas and put a 2D canvas in its slot for the duration of
+      // the export.
+      const _previewCanvas = document.createElement('canvas');
+      _previewCanvas.width = w;
+      _previewCanvas.height = h;
+      _previewCanvas.style.display = 'block';
+      _previewCanvas.style.width = '100%';
+      _previewCanvas.style.height = '100%';
+      _previewCanvas.style.objectFit = 'contain';
+      const _previewCtx = _previewCanvas.getContext('2d');
+      const _viewerSavedDisplay = viewerCanvas.style.display;
+      viewerCanvas.style.display = 'none';
+      viewerCanvas.parentElement?.insertBefore(_previewCanvas, viewerCanvas);
+      // Per-channel ramp setup. We compute the bias values after the
+      // worker pool is up (the auto path renders two preview frames
+      // first); for now save the live tonemap state so finally can
+      // restore it.
+      const _tmSaved = {
+        biasR: viewerState.tonemap.biasR ?? 0,
+        biasG: viewerState.tonemap.biasG ?? 0,
+        biasB: viewerState.tonemap.biasB ?? 0,
+      };
+      let _brightActive = false;
+      let _biasStartR = 0, _biasStartG = 0, _biasStartB = 0;
+      let _biasEndR   = 0, _biasEndG   = 0, _biasEndB   = 0;
+      (viewerState as any).beginCapture(w, h, { accumulator: useAccumulator });
       const t0 = performance.now();
       try {
-        for (let i = 0; i < totalFrames; i++) {
-          const fracI = i / Math.max(1, totalFrames - 1);
-          let frame: Uint8Array | null = null;
-          if (acc) acc.fill(0);
-          for (let k = 0; k < N; k++) {
-            const subOff = ((k + 0.5) / N - 0.5) * dFrac;
-            const subFrac = Math.max(0, Math.min(1, fracI + subOff));
-            const v = _viewAt(subFrac);
-            viewerState.setView({
+        // eslint-disable-next-line no-console
+        console.log('[mp4] waiting for pool of', poolSize, 'workers to spawn...');
+        await pool.ready;
+        // eslint-disable-next-line no-console
+        console.log('[mp4] pool ready; broadcasting palette + colorBlend');
+        await pool.broadcast({ type: 'palette', rgb: { ...paletteState.rgb } });
+        await pool.broadcast({
+          type: 'colorBlend',
+          sigma:     colorBlendState.sigma,
+          offset:    colorBlendState.offset,
+          leafNoise: colorBlendState.leafNoise,
+        });
+        // Walk every sampled trajectory point through maybeExtend on
+        // pool worker 0 to find the cumulative extensionLevel needed
+        // to cover the entire trajectory (centroid drift means the
+        // single most-zoomed-out view is not always sufficient — a
+        // far-flung view at modest zoom can still extend the
+        // cluster). Then broadcast the resulting target level to the
+        // rest of the pool. extendRootUpward is deterministic from
+        // baseCluster, so every worker reaching the same level via
+        // sequential extensions ends up in byte-identical state.
+        const samples = Math.max(60, Math.min(totalFrames, 200));
+        let targetLevel = 0;
+        // eslint-disable-next-line no-console
+        console.log('[mp4] computing extension level over', samples, 'samples...');
+        for (let i = 0; i <= samples; i++) {
+          const v = _viewAt(i / samples);
+          targetLevel = await pool.sendExtend(0, {
+            type: 'extendForView',
+            view: {
               centerX: v.centerX,
               centerY: v.centerY,
               pixelScale: v.pixelScale * psScale,
+              pixelWidth: w, pixelHeight: h,
+              aggPixelScale: freezeState.aggPixelScale ?? undefined,
+              cullPadPx: cullState.padPx,
+              aggPx: qualityState.aggPx,
+            },
+          });
+        }
+        // eslint-disable-next-line no-console
+        console.log('[mp4] target extension level =', targetLevel, '— broadcasting');
+        await pool.broadcastExtend({ type: 'extendToLevel', level: targetLevel });
+        // eslint-disable-next-line no-console
+        console.log('[mp4] all workers extended; starting frame walks');
+
+        // ─── Per-channel auto-balance ───────────────────────────────
+        // Render frame 0 and the last frame as quick singles (one
+        // sub-frame each, no accumulator), measure their average
+        // R/G/B, and derive a per-channel bias ramp that pulls both
+        // ends toward their midpoint colour. Per-channel rather than
+        // luma-only because the multi-level colour blend's ancestor-
+        // chain truncation at the trajectory endpoints often shifts
+        // hue — not just brightness — between matched start and end
+        // views. Loop endpoints converge on the SAME average colour
+        // (not just the same average luma), so the seam is invisible.
+        if (_brightnessRamp.autoBalance && totalFrames >= 2) {
+          const measure = async (frac: number): Promise<[number, number, number]> => {
+            const v = _viewAt(frac);
+            const m = await pool.walk({
+              centerX: v.centerX, centerY: v.centerY,
+              pixelScale: v.pixelScale * psScale,
+              pixelWidth: w, pixelHeight: h,
+              aggPixelScale: freezeState.aggPixelScale ?? undefined,
+              cullPadPx: cullState.padPx,
+              aggPx: qualityState.aggPx,
             });
-            const rgba = await (viewerState as any).captureFrame();
-            if (acc) {
-              for (let j = 0; j < accLen; j++) acc[j] += rgba[j];
-            } else {
-              frame = rgba;
+            applyWorkerResult(m);
+            viewerState.centerX = m.instanceCenterX;
+            viewerState.centerY = m.instanceCenterY;
+            viewerState.pixelScale = m.pixelScale;
+            // Disable any existing bias for the measurement so we
+            // measure the un-shifted colour. (Should already be 0
+            // unless a previous export crashed before the finally.)
+            viewerState.tonemap.biasR = 0;
+            viewerState.tonemap.biasG = 0;
+            viewerState.tonemap.biasB = 0;
+            const px = await (viewerState as any).captureFrame() as Uint8Array;
+            // Stride-sample every 4th pixel for speed (~230k samples
+            // at 1280×720, plenty for a stable average).
+            let sR = 0, sG = 0, sB = 0, n = 0;
+            for (let p = 0; p < px.length; p += 16) {
+              sR += px[p];
+              sG += px[p + 1];
+              sB += px[p + 2];
+              n++;
             }
-          }
-          if (acc) {
-            frame = new Uint8Array(accLen);
-            const inv = 1 / N;
-            for (let j = 0; j < accLen; j++) {
-              frame[j] = Math.round(acc[j] * inv);
+            return [sR / n / 255, sG / n / 255, sB / n / 255];
+          };
+          // Serialize: captureFrame uses a single _capture.readback
+          // buffer, so two concurrent measure() calls would race on
+          // the same GPU map → corrupted pixels → eventual encoder
+          // abort. The walk dispatches can still go to the pool in
+          // parallel under the hood, but the readback half must run
+          // one at a time.
+          const aStart = await measure(0);
+          const aEnd   = await measure(1);
+          const dR = (aEnd[0] - aStart[0]) / 2;
+          const dG = (aEnd[1] - aStart[1]) / 2;
+          const dB = (aEnd[2] - aStart[2]) / 2;
+          _biasStartR = +dR; _biasStartG = +dG; _biasStartB = +dB;
+          _biasEndR   = -dR; _biasEndG   = -dG; _biasEndB   = -dB;
+          const mag = Math.max(Math.abs(dR), Math.abs(dG), Math.abs(dB));
+          _brightActive = mag > 1e-4;
+          // eslint-disable-next-line no-console
+          console.log('[mp4] colour auto-balance: start=[',
+                      aStart.map(x => x.toFixed(3)).join(', '),
+                      '] end=[', aEnd.map(x => x.toFixed(3)).join(', '),
+                      '] delta=[', dR.toFixed(3), dG.toFixed(3), dB.toFixed(3), ']',
+                      _brightActive ? '(applied)' : '(skipped, near-identical)');
+        }
+
+        // ─── Walk + encode pipeline ───────────────────────────────
+        // Per-frame, dispatch N sub-frame walks to the pool. Pool
+        // schedules them across its workers; concurrency ≈ poolSize.
+        // Encoding (sequential GPU work on main thread) overlaps with
+        // walks for upcoming frames via an in-flight bound: at most
+        // 2*poolSize frames' walks are in flight at any time, so
+        // memory stays bounded and the encoder isn't throttled.
+        const buildFrameView = (frac: number) => {
+          const v = _viewAt(frac);
+          return {
+            centerX: v.centerX,
+            centerY: v.centerY,
+            pixelScale: v.pixelScale * psScale,
+            pixelWidth: w,
+            pixelHeight: h,
+            aggPixelScale: freezeState.aggPixelScale ?? undefined,
+            cullPadPx: cullState.padPx,
+            aggPx: qualityState.aggPx,
+          };
+        };
+        const walkOneFrame = (frameIdx: number): Promise<WorkerResult[]> => {
+          const fracI = frameIdx / Math.max(1, totalFrames - 1);
+          if (useAccumulator) {
+            const ps: Array<Promise<WorkerResult>> = [];
+            for (let k = 0; k < N; k++) {
+              const subOff = ((k + 0.5) / N - 0.5) * dFrac;
+              const subFrac = Math.max(0, Math.min(1, fracI + subOff));
+              ps.push(pool.walk(buildFrameView(subFrac)));
             }
+            return Promise.all(ps);
           }
-          enc.addFrameRgba(frame!);
+          return Promise.all([pool.walk(buildFrameView(fracI))]);
+        };
+
+        const inFlight = poolSize * 2;
+        const slots: Array<Promise<WorkerResult[]> | null> = new Array(totalFrames).fill(null);
+        let nextDispatch = 0;
+        const dispatchUpTo = (limit: number) => {
+          while (nextDispatch < limit && nextDispatch < totalFrames) {
+            slots[nextDispatch] = walkOneFrame(nextDispatch);
+            nextDispatch++;
+          }
+        };
+        // eslint-disable-next-line no-console
+        console.log('[mp4] dispatching first', Math.min(inFlight, totalFrames), 'frames worth of walks (', N, 'sub-frames each)');
+        dispatchUpTo(Math.min(inFlight, totalFrames));
+        // eslint-disable-next-line no-console
+        console.log('[mp4] entering encode loop, awaiting frame 0...');
+
+        const weight = 1 / N;
+        for (let i = 0; i < totalFrames; i++) {
+          const tWaitStart = performance.now();
+          const subResults = await slots[i]!;
+          if (i < 5 || i % 25 === 0) {
+            // eslint-disable-next-line no-console
+            console.log('[mp4] frame', i, 'walks done after', (performance.now() - tWaitStart).toFixed(0), 'ms wait');
+          }
+          slots[i] = null;
+          if (_brightActive) {
+            const t = totalFrames > 1 ? i / (totalFrames - 1) : 0;
+            viewerState.tonemap.biasR = _biasStartR + (_biasEndR - _biasStartR) * t;
+            viewerState.tonemap.biasG = _biasStartG + (_biasEndG - _biasStartG) * t;
+            viewerState.tonemap.biasB = _biasStartB + (_biasEndB - _biasStartB) * t;
+          }
+          let frame: Uint8Array;
+          if (useAccumulator) {
+            (viewerState as any).clearAccumulator();
+            for (let k = 0; k < N; k++) {
+              applyWorkerResult(subResults[k]);
+              // Mirror the renderer's view to match the sub-frame so
+              // the offset uniform stays at zero AND the GPU's NDC
+              // scale (sx, sy) matches the walker's view — without
+              // this, the renderer would draw at the wrong size.
+              viewerState.centerX = subResults[k].instanceCenterX;
+              viewerState.centerY = subResults[k].instanceCenterY;
+              viewerState.pixelScale = subResults[k].pixelScale;
+              (viewerState as any).accumulateSubFrame(weight);
+            }
+            frame = await (viewerState as any).captureAccumulated();
+          } else {
+            applyWorkerResult(subResults[0]);
+            viewerState.centerX = subResults[0].instanceCenterX;
+            viewerState.centerY = subResults[0].instanceCenterY;
+            viewerState.pixelScale = subResults[0].pixelScale;
+            frame = await (viewerState as any).captureFrame();
+          }
+          enc.addFrameRgba(frame);
+          // Echo to the preview canvas. ImageData wants a Uint8ClampedArray
+          // view over the same bytes — the renderer's RGBA frame is
+          // already in the right pixel order.
+          if (_previewCtx) {
+            const clamped = new Uint8ClampedArray(frame.buffer, frame.byteOffset, frame.byteLength);
+            _previewCtx.putImageData(new ImageData(clamped, w, h), 0, 0);
+          }
+          // Top up the dispatch queue now that one slot freed.
+          dispatchUpTo(i + 1 + inFlight);
           opts.progress?.(i + 1, totalFrames, performance.now() - t0);
         }
         enc.finalize();
         return enc.FS.readFile(enc.outputFilename) as Uint8Array;
       } finally {
+        pool.destroy();
         enc.delete();
         (viewerState as any).endCapture();
+        workerStatus.captureMode = false;
+        viewerCanvas.style.pointerEvents = _savedPointerEvents;
+        _previewCanvas.remove();
+        viewerCanvas.style.display = _viewerSavedDisplay;
         viewerState.setView(savedView);
+        viewerState.tonemap.biasR = _tmSaved.biasR;
+        viewerState.tonemap.biasG = _tmSaved.biasG;
+        viewerState.tonemap.biasB = _tmSaved.biasB;
         _vwRefWidthOverride = null;
       }
     }
@@ -2830,6 +2746,23 @@
       return {
         version: 3,
         palette: { seed: paletteState.seed, hex: { ...paletteState.hex } },
+        tonemap: {
+          contrast:   viewerState.tonemap.contrast,
+          saturation: viewerState.tonemap.saturation,
+          midpoint:   viewerState.tonemap.midpoint,
+          brightness: viewerState.tonemap.brightness,
+        },
+        outline: {
+          opacity: viewerState.outline.opacity,
+        },
+        colorBlend: {
+          sigma:     colorBlendState.sigma,
+          offset:    colorBlendState.offset,
+          leafNoise: colorBlendState.leafNoise,
+        },
+        aggHex: {
+          dilation: aggHexState.dilation,
+        },
         keyframes: _kf.map((k) => ({
           centerX: k.centerX, centerY: k.centerY, pixelScale: k.pixelScale,
         })),
@@ -2845,6 +2778,8 @@
           samples:  +_samp.inp.value,
           fitMode:  _fitSel.value,
           cullPadPx: cullState.padPx,
+          autoBalance: _brightnessRamp.autoBalance,
+          aggPx: qualityState.aggPx,
         },
       };
     }
@@ -2868,6 +2803,39 @@
         (window as any)._spectreSyncSwatches?.();
         // Trigger a fresh repack so the new colours land.
         viewerState.onViewChange?.(viewerState);
+      }
+      if (cfg.tonemap && typeof cfg.tonemap === 'object') {
+        const t = cfg.tonemap;
+        if (Number.isFinite(+t.contrast))   viewerState.tonemap.contrast   = +t.contrast;
+        if (Number.isFinite(+t.saturation)) viewerState.tonemap.saturation = +t.saturation;
+        if (Number.isFinite(+t.midpoint))   viewerState.tonemap.midpoint   = +t.midpoint;
+        if (Number.isFinite(+t.brightness)) viewerState.tonemap.brightness = +t.brightness;
+        (window as any)._spectreSyncTonemap?.();
+        viewerState.requestFrame();
+      }
+      if (cfg.outline && typeof cfg.outline === 'object') {
+        if (Number.isFinite(+cfg.outline.opacity)) {
+          viewerState.outline.opacity = Math.max(0, Math.min(1, +cfg.outline.opacity));
+          viewerState.outline.enabled = viewerState.outline.opacity > 0;
+          (window as any)._spectreSyncColorBlend?.();
+          viewerState.requestFrame();
+        }
+      }
+      if (cfg.colorBlend && typeof cfg.colorBlend === 'object') {
+        const cb = cfg.colorBlend;
+        if (Number.isFinite(+cb.sigma)  && +cb.sigma > 0)   colorBlendState.sigma     = +cb.sigma;
+        if (Number.isFinite(+cb.offset))                    colorBlendState.offset    = +cb.offset;
+        if (Number.isFinite(+cb.leafNoise) && +cb.leafNoise >= 0) colorBlendState.leafNoise = +cb.leafNoise;
+        (window as any)._spectreSyncColorBlend?.();
+        viewerState.onViewChange?.(viewerState);
+      }
+      if (cfg.aggHex && typeof cfg.aggHex === 'object') {
+        const ah = cfg.aggHex;
+        if (Number.isFinite(+ah.dilation) && +ah.dilation > 0) {
+          aggHexState.dilation = +ah.dilation;
+          (window as any)._spectreSyncColorBlend?.();
+          refreshAggMeshes();
+        }
       }
       if (Array.isArray(cfg.keyframes) && cfg.keyframes.length >= 2) {
         _kf.length = 0;
@@ -2937,6 +2905,14 @@
           cullState.padPx = +cfg.video.cullPadPx;
           _cullSlider.value = String(cullState.padPx);
           _cullVal.textContent = `${cullState.padPx} px`;
+        }
+        if (typeof cfg.video.autoBalance === 'boolean') {
+          _brightnessRamp.autoBalance = cfg.video.autoBalance;
+          (window as any)._spectreSyncBrightnessRamp?.();
+        }
+        if (Number.isFinite(+cfg.video.aggPx) && +cfg.video.aggPx > 0) {
+          qualityState.aggPx = +cfg.video.aggPx;
+          (window as any)._spectreSyncQuality?.();
         }
       }
       _rebuildKfWidget();
@@ -3098,7 +3074,7 @@
     _renderConfigRow.className = 'spectre-row';
     _renderConfigRow.append(
       _w.wrap, _h.wrap, _fps.wrap, _qp.wrap, _samp.wrap,
-      _fitWrap, _cullWrap,
+      _fitWrap,
     );
     const _renderActionsRow = document.createElement('div');
     _renderActionsRow.className = 'spectre-row';
@@ -3106,7 +3082,40 @@
       _saveBtn, _loadBtn, _loadInput,
       _runBtn, _renderBtn, _status,
     );
-    _renderCard.append(_renderHead, _renderConfigRow, _renderActionsRow);
+    const _cullRow = document.createElement('div');
+    _cullRow.className = 'spectre-row';
+    _cullRow.append(_cullWrap);
+
+    // Auto-balance brightness checkbox. When on, the exporter renders
+    // the first and last output frames as quick singles before the
+    // main encode loop, measures their luma, and biases brightness
+    // ±half the difference across the trajectory. Loop endpoints
+    // converge to the same average brightness so a looped playback
+    // doesn't flash at the seam.
+    const _autoBalanceWrap = document.createElement('label');
+    _autoBalanceWrap.className = 'spectre-checkbox';
+    const _autoBalanceCb = document.createElement('input');
+    _autoBalanceCb.type = 'checkbox';
+    _autoBalanceCb.checked = _brightnessRamp.autoBalance;
+    const _autoBalanceTxt = document.createElement('span');
+    _autoBalanceTxt.textContent = 'auto-balance brightness';
+    _autoBalanceTxt.title =
+      'Render frame 0 and the last frame, measure their average brightness, ' +
+      'and ramp tonemap brightness across all frames so both ends meet at the midpoint. ' +
+      'Useful for seamless loops.';
+    _autoBalanceWrap.append(_autoBalanceCb, _autoBalanceTxt);
+    _autoBalanceCb.addEventListener('change', () => {
+      _brightnessRamp.autoBalance = _autoBalanceCb.checked;
+      _saveLocal();
+    });
+    (window as any)._spectreSyncBrightnessRamp = () => {
+      _autoBalanceCb.checked = _brightnessRamp.autoBalance;
+    };
+    const _brightnessRow = document.createElement('div');
+    _brightnessRow.className = 'spectre-row';
+    _brightnessRow.append(_autoBalanceWrap);
+
+    _renderCard.append(_renderHead, _renderConfigRow, _renderActionsRow, _cullRow, _brightnessRow);
     // Restore previous session if present. This calls _applyConfig
     // which rebuilds the keyframe widget and refreshes the total label.
     _loadLocal();
@@ -3124,4 +3133,388 @@
     display(_renderCard);
     display(_kfContainer);
   </script>
+
+  <script id="find-distant-match" type="text/x-typescript">
+    // ─── Find a distant pattern-matching view ─────────────────────────
+    // For a given source view (the current viewport), find another world
+    // position whose local pattern is identical to the source within a
+    // radius determined by the suffix length K. Two leaves with the same
+    // K-suffix (last K geometry indices in the substitution path, same
+    // type at level K) sit inside identically-substituted level-K
+    // supertiles, so their local environments are byte-identical out to
+    // ~(2.45)^K world units.
+    type LeafAddress = {
+      path: number[];        // geom indices, root → leaf
+      types: TileName[];     // type at each meta level
+      rots: number[];        // accumulated world rot at each meta level
+      mirs: number[];        // accumulated world mirror at each meta level
+      leafCx: number;        // world X of the located leaf's centroid
+      leafCy: number;        // world Y of the located leaf's centroid
+    };
+    // Closest-child descent: always reaches a leaf (the one whose
+    // centroid is nearest to the target). Robust to floating-point
+    // precision at deep extension levels and to the case where the
+    // target is on a polygon boundary.
+    function _findLeafNear(targetX: number, targetY: number): LeafAddress | null {
+      let mt: any = walkerState.currentRoot;
+      let tx: any = walkerState.currentRootTransform;
+      if (mt.kind !== 'meta') return null;
+      const path: number[] = [];
+      const types: TileName[] = [mt.name];
+      const rots: number[] = [tx.rot];
+      const mirs: number[] = [tx.mirror];
+      while (mt.kind === 'meta') {
+        let bestI = -1, bestD = Infinity;
+        for (let i = 0; i < mt.geometries.length; i++) {
+          const geom = mt.geometries[i];
+          const child = geom.child;
+          const childTx = txCompose(tx, geom.transform);
+          const cx = (child as any)._cCx ?? 0;
+          const cy = (child as any)._cCy ?? 0;
+          const wc = txApply(childTx, [cx, cy]);
+          const d = Math.hypot(wc[0] - targetX, wc[1] - targetY);
+          if (d < bestD) { bestD = d; bestI = i; }
+        }
+        if (bestI < 0) break;
+        path.push(bestI);
+        const geom = mt.geometries[bestI];
+        tx = txCompose(tx, geom.transform);
+        mt = geom.child;
+        if (mt.kind === 'meta') {
+          types.push(mt.name as TileName);
+          rots.push(tx.rot);
+          mirs.push(tx.mirror);
+        }
+      }
+      // mt is the leaf — compute its world centroid for offset
+      // preservation in the caller.
+      const lcx = (mt as any)._cCx ?? 0;
+      const lcy = (mt as any)._cCy ?? 0;
+      const wc = txApply(tx, [lcx, lcy]);
+      return { path, types, rots, mirs, leafCx: wc[0], leafCy: wc[1] };
+    }
+
+    interface FindMatchResult { centerX: number; centerY: number; attempts: number }
+    function _findMatchingLeaf(args: {
+      sourceX: number; sourceY: number;
+      parentType: TileName;
+      parentRot: number;     // world rotation of source's level-K ancestor
+      parentMir: number;     // world mirror of source's level-K ancestor
+      parentSubLevel: number;
+      suffix: number[];
+      minDistance: number;
+      maxAttempts?: number;
+    }): FindMatchResult | null {
+      const root = walkerState.currentRoot;
+      const rootTransform = walkerState.currentRootTransform;
+      if (root.kind !== 'meta') return null;
+      const rootSubLevel = (root as any)._subLevel as number;
+      const stepsToParent = rootSubLevel - args.parentSubLevel;
+      if (stepsToParent < 0) return null;
+      const seed = ((Math.floor(args.sourceX) ^ Math.floor(args.sourceY)) >>> 0) || 1;
+      const rng = _makeSeededRng(seed);
+      const max = args.maxAttempts ?? 200000;
+      for (let attempt = 0; attempt < max; attempt++) {
+        let mt: any = root;
+        let tx: any = rootTransform;
+        let ok = true;
+        for (let d = 0; d < stepsToParent; d++) {
+          if (mt.kind !== 'meta') { ok = false; break; }
+          const i = Math.floor(rng() * mt.geometries.length);
+          const geom = mt.geometries[i];
+          tx = txCompose(tx, geom.transform);
+          mt = geom.child;
+        }
+        if (!ok || mt.kind !== 'meta' || mt.name !== args.parentType) continue;
+        // Match world orientation: same rot and mirror means the
+        // candidate's local pattern is in the same on-screen orientation
+        // as the source, not just congruent up to a rotation.
+        if (tx.rot !== args.parentRot || tx.mirror !== args.parentMir) continue;
+        // Apply suffix.
+        let suffOk = true;
+        for (const i of args.suffix) {
+          if (mt.kind !== 'meta' || i >= mt.geometries.length) { suffOk = false; break; }
+          const geom = mt.geometries[i];
+          tx = txCompose(tx, geom.transform);
+          mt = geom.child;
+        }
+        if (!suffOk || mt.kind !== 'leaf') continue;
+        const lcx = (mt as any)._cCx ?? 0;
+        const lcy = (mt as any)._cCy ?? 0;
+        const c = txApply(tx, [lcx, lcy]);
+        const dx = c[0] - args.sourceX, dy = c[1] - args.sourceY;
+        if (Math.hypot(dx, dy) < args.minDistance) continue;
+        return { centerX: c[0], centerY: c[1], attempts: attempt + 1 };
+      }
+      return null;
+    }
+
+    function _findDistantMatchForCurrentView(K: number, minDistance: number):
+      { result: FindMatchResult | null; sourceLeaf: LeafAddress | null } {
+      const v = viewerState.getView();
+      const sourceLeaf = _findLeafNear(v.centerX, v.centerY);
+      if (!sourceLeaf) return { result: null, sourceLeaf: null };
+      const D = sourceLeaf.path.length;
+      if (D < K) return { result: null, sourceLeaf };
+      const suffix = sourceLeaf.path.slice(D - K);
+      const idx = D - K;
+      const parentType = sourceLeaf.types[idx];
+      const parentRot = sourceLeaf.rots[idx];
+      const parentMir = sourceLeaf.mirs[idx];
+      const root = walkerState.currentRoot;
+      const rootSubLevel = (root as any)._subLevel as number;
+      const parentSubLevel = rootSubLevel - idx;
+      const result = _findMatchingLeaf({
+        sourceX: v.centerX, sourceY: v.centerY,
+        parentType, parentRot, parentMir, parentSubLevel,
+        suffix, minDistance,
+      });
+      return { result, sourceLeaf };
+    }
+
+    // Local button helper (keeps this cell self-contained — the
+    // video-export cell has its own _btn, but cross-cell helper sharing
+    // is brittle and this is two lines.)
+    function _fdmBtn(text: string, classes = '', title?: string): HTMLButtonElement {
+      const b = document.createElement('button');
+      b.textContent = text;
+      b.className = `spectre-btn ${classes}`.trim();
+      if (title) b.title = title;
+      return b;
+    }
+
+    const _loopRow = document.createElement('div');
+    _loopRow.className = 'spectre-card';
+    const _loopHead = document.createElement('div');
+    _loopHead.className = 'spectre-section-head';
+    const _loopH = document.createElement('h4');
+    _loopH.textContent = 'find distant match';
+    _loopHead.append(_loopH);
+    _loopRow.append(_loopHead);
+    const _loopHelp = document.createElement('details');
+    _loopHelp.className = 'spectre-help';
+    const _loopHelpSummary = document.createElement('summary');
+    _loopHelpSummary.textContent = 'how this works';
+    const _loopHelpBody = document.createElement('p');
+    _loopHelpBody.textContent =
+      'Locates a far-away spot whose local pattern matches the current view exactly, ' +
+      'useful for building a seamless looping zoom. Frame a view, click Find, then Go ' +
+      'to jump there; paste the output into a keyframe to use it as an endpoint. ' +
+      'Match depth is bounded by the supertile levels currently loaded around the view, ' +
+      'so if it fails, zoom out slightly (to extend the tree) or reduce depth / min dist.';
+    _loopHelp.append(_loopHelpSummary, _loopHelpBody);
+    _loopRow.append(_loopHelp);
+    const _loopControls = document.createElement('div');
+    _loopControls.className = 'spectre-row';
+
+    function _labeledInput(
+      label: string, type: string, value: string, cls: string, title: string,
+    ) {
+      const wrap = document.createElement('label');
+      wrap.className = 'spectre-checkbox';
+      const span = document.createElement('span');
+      span.className = 'spectre-label';
+      span.textContent = label;
+      const inp = document.createElement('input');
+      inp.type = type;
+      inp.value = value;
+      inp.className = `spectre-input ${cls}`.trim();
+      inp.title = title;
+      wrap.append(span, inp);
+      return { wrap, inp };
+    }
+    // K can be left as 'auto' (or 0/empty) to be derived from the current
+    // viewport's world extent. Match radius is ~2.45^K world units, so K
+    // needs to scale with how zoomed-out the user is.
+    const _kInput = _labeledInput(
+      'match depth', 'text', 'auto', 'num-sm',
+      'How many substitution levels of context the match must reproduce. ' +
+        'Match radius ≈ 2.45^depth world units. "auto" picks the smallest depth ' +
+        'whose radius comfortably exceeds the current viewport. ' +
+        'Capped by the supertile levels currently loaded around the view — ' +
+        'if no match is found, zoom out a bit (to load more levels) or lower the depth.',
+    );
+    const _minDistInput = _labeledInput(
+      'min dist', 'text', 'auto', 'num-md',
+      'Minimum world-units distance from current view to candidate. "auto" = current viewport diameter.',
+    );
+
+    const _matchBtn = _fdmBtn('Find distant match', 'primary');
+    const _matchOut = document.createElement('input');
+    _matchOut.type = 'text';
+    _matchOut.readOnly = true;
+    _matchOut.className = 'spectre-input grow';
+    _matchOut.placeholder = 'paste output into a keyframe';
+
+    const _matchGoBtn = _fdmBtn('Go', '', 'Jump the live view to the matched coordinates.');
+    _matchGoBtn.disabled = true;
+
+    // Separate status line so the output box stays cleanly copy-able.
+    const _matchStatus = document.createElement('span');
+    _matchStatus.className = 'spectre-mono';
+
+    function _autoK(viewPxW: number, pixelScale: number): number {
+      // Want 2.45^K >> viewport world diameter so the entire visible
+      // area is well inside the matching radius — and so a small
+      // offset drift after Go can't push the next-iteration source
+      // onto a *different* leaf with a different K-suffix. +2 gives
+      // ~6× headroom over the viewport extent.
+      const worldExtent = Math.max(1, viewPxW) / Math.max(1e-30, pixelScale);
+      return Math.max(2, Math.ceil(Math.log(worldExtent) / Math.log(2.45)) + 2);
+    }
+
+    type _FdmView = { centerX: number; centerY: number; pixelScale: number };
+    let _matchedView: _FdmView | null = null;
+    _matchBtn.addEventListener('click', async () => {
+      const v = viewerState.getView();
+      const liveW = viewerState.pixelWidth || 1280;
+      // Resolve K: 'auto' / 0 / empty → derive from viewport.
+      let K = parseInt(_kInput.inp.value, 10);
+      if (!Number.isFinite(K) || K < 1) K = _autoK(liveW, v.pixelScale);
+      // Resolve min distance: 'auto' / empty → viewport world diameter.
+      let minDist = Number(_minDistInput.inp.value);
+      if (!Number.isFinite(minDist) || minDist < 0) {
+        minDist = liveW / Math.max(1e-30, v.pixelScale);
+      }
+      _matchBtn.disabled = true;
+      _matchStatus.textContent = 'searching...';
+      const t0 = performance.now();
+      let result, sourceLeaf;
+      try {
+        ({ result, sourceLeaf } = await findDistantMatchOnWorker(
+          v.centerX, v.centerY, K, minDist,
+        ));
+      } catch (err) {
+        _matchStatus.textContent = 'error: ' + (err as Error).message;
+        _matchBtn.disabled = false;
+        return;
+      } finally {
+        _matchBtn.disabled = false;
+      }
+      const ms = (performance.now() - t0).toFixed(0);
+      if (!sourceLeaf) {
+        _matchOut.value = '';
+        _matchStatus.textContent = 'could not locate source leaf at view center';
+        _matchedView = null;
+        _matchGoBtn.disabled = true;
+        return;
+      }
+      if (!result) {
+        _matchOut.value = '';
+        _matchStatus.textContent = `no match · depth=${K} · min dist=${minDist.toExponential(2)} · try lower depth, smaller min dist, or zoom out to load more levels`;
+        _matchedView = null;
+        _matchGoBtn.disabled = true;
+        return;
+      }
+      // Preserve the source view's offset from its own leaf's centroid:
+      // both source and matched leaves are at the same K-suffix path
+      // and share the same level-K ancestor world rotation, so their
+      // local environments are byte-identical. Setting the new view to
+      // (matchedLeaf.centroid + sourceOffset) reproduces what the user
+      // was looking at, just at the matched coordinates — instead of
+      // shifting the framing to the matched leaf's centroid.
+      const offX = v.centerX - sourceLeaf.leafCx;
+      const offY = v.centerY - sourceLeaf.leafCy;
+      _matchedView = {
+        centerX: result.centerX + offX,
+        centerY: result.centerY + offY,
+        pixelScale: v.pixelScale,
+      };
+      const radius = Math.pow(2.45, K);
+      _matchOut.value = `${_matchedView.pixelScale}/${_matchedView.centerX}/${_matchedView.centerY}`;
+      _matchStatus.textContent = `depth=${K} · r≈${radius.toExponential(1)} · ${result.attempts} attempts · ${ms}ms`;
+      _matchGoBtn.disabled = false;
+      // No auto-go: clicking "Find" again with the same view re-runs
+      // deterministically (same seeded RNG → same result). Click "Go"
+      // to inspect the match and use it as the next source.
+      // eslint-disable-next-line no-console
+      console.log('match found:', {
+        ...(_matchedView as any),
+        K, attempts: result.attempts, ms: +ms, matchRadius: radius,
+      });
+    });
+
+    _matchGoBtn.addEventListener('click', () => {
+      if (_matchedView) viewerState.setView(_matchedView);
+    });
+
+    _loopControls.append(_kInput.wrap, _minDistInput.wrap, _matchBtn, _matchOut, _matchGoBtn);
+    const _loopStatusRow = document.createElement('div');
+    _loopStatusRow.className = 'spectre-row';
+    _loopStatusRow.append(_matchStatus);
+
+    // Tree state: hidden internal state that drifts with extension —
+    // not user-visible inputs (palette, keyframes, view) but the
+    // accumulated side-effects of how the user has been zooming.
+    // Affects: multi-level Gaussian colour blend (deeper ancestor
+    // chains shift ancestor averages), find-distant-match (root
+    // sub-level bounds the reachable K-suffix levels), and
+    // float-precision (very large root translations eat decimal
+    // digits in world coords).
+    //
+    // The button row sits ABOVE the info text so the button isn't
+    // vertically centred on a multi-line info block.
+    const _purgeBtn = _fdmBtn(
+      'purge tree', '',
+      'Reset the worker\'s metatile DAG to the freshly-built base cluster (extension level 0). ' +
+        'Clears accumulated extensions and the hexagon mesh cache.',
+    );
+    const _purgeRow = document.createElement('div');
+    _purgeRow.className = 'spectre-row';
+    _purgeRow.append(_purgeBtn);
+    const _treeInfoText = document.createElement('pre');
+    _treeInfoText.className = 'spectre-mono';
+    _treeInfoText.style.margin = '4px 0 0 0';
+    _treeInfoText.style.whiteSpace = 'pre';
+    _treeInfoText.style.fontSize = '11px';
+    _treeInfoText.textContent = '(no walks yet)';
+    _purgeBtn.addEventListener('click', async () => {
+      _purgeBtn.disabled = true;
+      const prev = _treeInfoText.textContent;
+      _treeInfoText.textContent = 'purging…';
+      try {
+        await resetWorkerTree();
+        refreshAggMeshes();
+        repackInstances();
+      } finally {
+        _purgeBtn.disabled = false;
+        // Info refreshes on the next worker result message via
+        // workerStatus.onResult; the prev text is fine until then.
+      }
+    });
+    function _refreshTreeInfo(): void {
+      const m = workerStatus.lastResult;
+      if (!m) { _treeInfoText.textContent = '(no walks yet)'; return; }
+      // Float-precision headroom: f32 has ~7 decimal digits of
+      // mantissa, f64 has ~15. log10(|root.t|) tells us how many
+      // are eaten by the world-coord magnitude alone. We show f64
+      // digits since the worker walks in Float64 — this is the
+      // headroom *available*, not the headroom remaining after the
+      // GPU's relative-to-centre trick (which is much better).
+      const txMag = Math.hypot(m.rootTxTx, m.rootTxTy);
+      const f64Headroom = 15 - Math.max(0, Math.log10(Math.max(1, txMag)));
+      const lines = [
+        `extension level ${m.extensionLevel}`,
+        `root type       ${m.rootName}`,
+        `root sub-level  ${m.rootSubLevel}`,
+        `root tx rot     ${m.rootTxRot} (× 30°)`,
+        `root tx mirror  ${m.rootTxMirror}`,
+        `root tx |t|     ${txMag.toExponential(3)}`,
+        `root cBound     ${m.rootCBound.toExponential(3)}`,
+        `f64 digits left ${f64Headroom.toFixed(1)}`,
+      ];
+      _treeInfoText.textContent = lines.join('\n');
+    }
+    // Refresh whenever a fresh worker result lands. We chain the
+    // existing onResult so we don't clobber the renderer's hookup.
+    const _origOnResult = workerStatus.onResult;
+    workerStatus.onResult = (m) => {
+      _origOnResult?.(m);
+      _refreshTreeInfo();
+    };
+
+    _loopRow.append(_loopControls, _loopStatusRow, _purgeRow, _treeInfoText);
+    display(_loopRow);
+  </script>
+
 </notebook>

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -1,0 +1,1126 @@
+<!doctype html>
+<notebook theme="air">
+  <title>Aperiodic Monotile, Infinite Zoom</title>
+
+  <script id="title" type="text/markdown">
+    # Aperiodic monotile, infinite zoom
+
+    A pared-down Spectre viewer that lets you zoom out arbitrarily. Supertiles are generated on demand, and tiles that shrink below a few pixels collapse into earcut polygon meshes. This first cut is a plain viewer at fixed depth; the walker, upward extension, aggregation, and zoom-driven coloring are layered in afterwards.
+  </script>
+
+  <script id="figure" type="text/x-typescript">
+    display(viewerExpandable);
+  </script>
+
+  <script id="figure-caption" type="text/x-typescript">
+    const _totalLeaves = countLeaves(rootMeta);
+    display(html`<figcaption>
+      Depth-${BASE_DEPTH} Δ supertile, Cartesian coordinates only (no morph). ${_totalLeaves.toLocaleString()} spectres total; only the visible subset is uploaded each frame.
+    </figcaption>`);
+  </script>
+
+  <script id="gpu-context" type="text/x-typescript">
+    import { createWebGPUContext } from './lib/webgpu-canvas.js';
+    const _gpuCtx = await createWebGPUContext();
+    const { device, canvasFormat } = _gpuCtx;
+  </script>
+
+  <script id="spectre-data" type="text/x-typescript">
+    import earcut from 'npm:earcut';
+
+    // 14 cartesian spectre vertices — each edge is unit length.
+    const _SQ3_2 = Math.sqrt(3) / 2;
+    const spectreVertices: [number, number][] = [
+      [0,           0           ],
+      [1,           0           ],
+      [1.5,        -_SQ3_2      ],
+      [1.5 + _SQ3_2, 0.5 - _SQ3_2],
+      [1.5 + _SQ3_2, 1.5 - _SQ3_2],
+      [2.5 + _SQ3_2, 1.5 - _SQ3_2],
+      [3 + _SQ3_2,  1.5         ],
+      [3,           2           ],
+      [3 - _SQ3_2,  1.5         ],
+      [2.5 - _SQ3_2, 1.5 + _SQ3_2],
+      [1.5 - _SQ3_2, 1.5 + _SQ3_2],
+      [0.5 - _SQ3_2, 1.5 + _SQ3_2],
+      [-_SQ3_2,     1.5         ],
+      [0,           1           ],
+    ];
+
+    // The four spectre vertices that act as a metatile's "quad" handles.
+    const QUAD_INDICES = [3, 5, 7, 11] as const;
+    const baseQuad: [number, number][] = QUAD_INDICES.map((i) => spectreVertices[i]);
+
+    // Earcut-triangulated 14-gon: 12 triangles, 36 indices. The spectre is
+    // non-convex (vertex 2 sits below the v0–v1 baseline, vertex 7 makes a
+    // pocket), so a fan won't work — earcut produces a proper triangulation.
+    const meshVertexData = new Float32Array(spectreVertices.flat());
+    const meshFillIndices = new Uint16Array(earcut(spectreVertices.flat()));
+  </script>
+
+  <script id="transform-math" type="text/x-typescript">
+    type Vec2 = [number, number];
+
+    // Pre-computed cos/sin for the 12 multiples of 30°. Substitution math
+    // only ever rotates by integer multiples, so a 12-entry table is exact.
+    const _COS = new Float64Array(12);
+    const _SIN = new Float64Array(12);
+    for (let k = 0; k < 12; k++) {
+      _COS[k] = Math.cos(k * Math.PI / 6);
+      _SIN[k] = Math.sin(k * Math.PI / 6);
+    }
+
+    type Transform = { rot: number; mirror: 0 | 1; t: Vec2 };
+    const txIdentity: Transform = { rot: 0, mirror: 0, t: [0, 0] };
+
+    // p ↦ R(rot · 30°) · M^mirror(p) + t, where M reflects across x-axis.
+    function txApply(T: Transform, p: Vec2): Vec2 {
+      const x = p[0];
+      const y = T.mirror ? -p[1] : p[1];
+      const c = _COS[T.rot], s = _SIN[T.rot];
+      return [c * x - s * y + T.t[0], s * x + c * y + T.t[1]];
+    }
+
+    function txApplyLinear(T: Transform, p: Vec2): Vec2 {
+      const x = p[0];
+      const y = T.mirror ? -p[1] : p[1];
+      const c = _COS[T.rot], s = _SIN[T.rot];
+      return [c * x - s * y, s * x + c * y];
+    }
+
+    // (T1 ∘ T2)(p) = T1(T2(p)). Composition rule for rot/mirror/t in the
+    // group <rotation, x-axis reflection, translation>.
+    function txCompose(T1: Transform, T2: Transform): Transform {
+      const sign = T1.mirror ? -1 : 1;
+      const rot = (((T1.rot + sign * T2.rot) % 12) + 12) % 12;
+      const mirror = (T1.mirror ^ T2.mirror) as 0 | 1;
+      const lin = txApplyLinear(T1, T2.t);
+      return { rot, mirror, t: [lin[0] + T1.t[0], lin[1] + T1.t[1]] };
+    }
+
+    const txTranslate = (t: Vec2): Transform => ({ rot: 0, mirror: 0, t });
+    const txRotate = (k: number): Transform =>
+      ({ rot: ((k % 12) + 12) % 12, mirror: 0, t: [0, 0] });
+
+    // Inverse, derived from T(p) = R M p + t:
+    //   q = T(p)  ⇒  p = M^{-1} R^{-1} (q - t)
+    // Using R(α) M = M R(-α):
+    //   mirror = 0:  T^-1 = { rot: -rot, mirror: 0, t: -R(-rot)·t }
+    //   mirror = 1:  T^-1 = { rot:  rot, mirror: 1, t: -R(rot)·M·t }
+    function txInverse(T: Transform): Transform {
+      if (T.mirror) {
+        const c = _COS[T.rot], s = _SIN[T.rot];
+        const tx = T.t[0], ty = -T.t[1]; // M·t
+        const rx = c * tx - s * ty;
+        const ry = s * tx + c * ty;
+        return { rot: T.rot, mirror: 1, t: [-rx, -ry] };
+      } else {
+        const invRot = ((-T.rot % 12) + 12) % 12;
+        const ic = _COS[invRot], is = _SIN[invRot];
+        const rx = ic * T.t[0] - is * T.t[1];
+        const ry = is * T.t[0] + ic * T.t[1];
+        return { rot: invRot, mirror: 0, t: [-rx, -ry] };
+      }
+    }
+  </script>
+
+  <script id="substitution-data" type="text/x-typescript">
+    // Nine metatile types. Γ is the "mystic" pair of two overlapping
+    // spectres glued at vertex 8 with a 30° rotation; the other eight are
+    // bare spectres at substitution depth 0. Both rule tables are taken
+    // verbatim from Kaplan's spectre.js.
+    const TILE_NAMES = ["Gamma", "Delta", "Theta", "Lambda", "Xi", "Pi", "Sigma", "Phi", "Psi"] as const;
+    type TileName = typeof TILE_NAMES[number];
+
+    // [rotation in units of 30°, from-quad index, to-quad index]
+    const transformationRules: [number, number, number][] = [
+      [ 2, 3, 1],
+      [ 0, 2, 0],
+      [ 2, 3, 1],
+      [ 2, 3, 1],
+      [ 0, 2, 0],
+      [ 2, 3, 1],
+      [-4, 3, 3],
+    ];
+
+    const superRules: Record<TileName, (TileName | null)[]> = {
+      Gamma:  ["Pi",  "Delta", null,  "Theta", "Sigma", "Xi",  "Phi",    "Gamma"],
+      Delta:  ["Xi",  "Delta", "Xi",  "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+      Theta:  ["Psi", "Delta", "Pi",  "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+      Lambda: ["Psi", "Delta", "Xi",  "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+      Xi:     ["Psi", "Delta", "Pi",  "Phi",   "Sigma", "Psi", "Phi",    "Gamma"],
+      Pi:     ["Psi", "Delta", "Xi",  "Phi",   "Sigma", "Psi", "Phi",    "Gamma"],
+      Sigma:  ["Xi",  "Delta", "Xi",  "Phi",   "Sigma", "Pi",  "Lambda", "Gamma"],
+      Phi:    ["Psi", "Delta", "Psi", "Phi",   "Sigma", "Pi",  "Phi",    "Gamma"],
+      Psi:    ["Psi", "Delta", "Psi", "Phi",   "Sigma", "Psi", "Phi",    "Gamma"],
+    };
+  </script>
+
+  <script id="metatile-build" type="text/x-typescript">
+    type LeafLabel = TileName | "Gamma1" | "Gamma2";
+    type MetaTile =
+      | { kind: "leaf"; label: LeafLabel; quad: Vec2[] }
+      | { kind: "meta"; name: TileName; geometries: { child: MetaTile; transform: Transform }[]; quad: Vec2[] };
+
+    function buildSpectreBase(): Record<TileName, MetaTile> {
+      const cluster = {} as Record<TileName, MetaTile>;
+      for (const label of TILE_NAMES) {
+        if (label !== "Gamma") {
+          cluster[label] = { kind: "leaf", label, quad: baseQuad };
+        }
+      }
+      // Mystic Γ: two spectres glued at v8 with a 30° rotation.
+      cluster.Gamma = {
+        kind: "meta",
+        name: "Gamma",
+        quad: baseQuad,
+        geometries: [
+          { child: { kind: "leaf", label: "Gamma1", quad: baseQuad }, transform: txIdentity },
+          { child: { kind: "leaf", label: "Gamma2", quad: baseQuad },
+            transform: txCompose(txTranslate(spectreVertices[8]), txRotate(1)) },
+        ],
+      };
+      return cluster;
+    }
+
+    // Inflate one full record of nine metatiles to the next level.
+    function buildSupertiles(prev: Record<TileName, MetaTile>): Record<TileName, MetaTile> {
+      const quad = prev.Delta.quad;
+
+      // Build the seven non-identity transforms by walking the rule table.
+      const transformations: Transform[] = [txIdentity];
+      let totalRot = 0;
+      let rotation: Transform = txIdentity;
+      let rotatedQuad: Vec2[] = quad;
+      for (const [deltaRot, fromIdx, toIdx] of transformationRules) {
+        if (deltaRot !== 0) {
+          totalRot = (((totalRot + deltaRot) % 12) + 12) % 12;
+          rotation = txRotate(totalRot);
+          rotatedQuad = quad.map((p) => txApplyLinear(rotation, p));
+        }
+        const target = txApply(transformations[transformations.length - 1], quad[fromIdx]);
+        const source = rotatedQuad[toIdx];
+        const delta: Vec2 = [target[0] - source[0], target[1] - source[1]];
+        transformations.push({ rot: rotation.rot, mirror: 0, t: delta });
+      }
+
+      // Reflect across the y-axis: (x, y) ↦ (-x, y) ≡ rot 6 + mirror.
+      const R: Transform = { rot: 6, mirror: 1, t: [0, 0] };
+      const finalTransforms = transformations.map((T) => txCompose(R, T));
+
+      const superQuad: Vec2[] = [
+        txApply(finalTransforms[6], quad[2]),
+        txApply(finalTransforms[5], quad[1]),
+        txApply(finalTransforms[3], quad[2]),
+        txApply(finalTransforms[0], quad[1]),
+      ];
+
+      const next = {} as Record<TileName, MetaTile>;
+      for (const label of TILE_NAMES) {
+        const subs = superRules[label];
+        const geometries: { child: MetaTile; transform: Transform }[] = [];
+        for (let i = 0; i < subs.length; i++) {
+          const sub = subs[i];
+          if (sub === null) continue;
+          geometries.push({ child: prev[sub], transform: finalTransforms[i] });
+        }
+        next[label] = { kind: "meta", name: label, quad: superQuad, geometries };
+      }
+      return next;
+    }
+  </script>
+
+  <script id="palette" type="text/x-typescript">
+    // Per-(level, type) coloring. Each metatile type has a distinct base
+    // hue; each substitution level rotates the whole palette by 47°. So
+    // at any single dominant zoom level, the 9 types take 9 well-separated
+    // hues, and as zoom shifts by one substitution level, the palette
+    // rotates as a whole — enough to make supertile structure pop without
+    // making colors confusing across zoom changes.
+    // Hues spread evenly 40° apart across the wheel so any two types at
+    // the same substitution level read as clearly distinct, regardless of
+    // the level rotation. Order is arbitrary — just makes the 9 metatypes
+    // span the full color wheel without clustering.
+    const _TYPE_BASE_HUE: Record<string, number> = {
+      Gamma:  320, Delta:  200, Theta:    0, Lambda: 120,
+      Xi:     280, Pi:      80, Sigma:  240, Phi:     40, Psi: 160,
+    };
+    const _LEVEL_HUE_STEP = 47; // per substitution level
+    // Per-type saturation and lightness modulators in [-1, 1]. Used by the
+    // walker for HSL-channel hierarchical encoding: a cell's hue comes from
+    // the ancestor at viewLevel, its saturation from the ancestor +1 level
+    // up, its lightness from the ancestor +2 levels up. Each scale's
+    // structure becomes simultaneously visible because each scale drives
+    // a different perceptual channel. Modulators are arbitrary deterministic
+    // values in [-1, 1] picked to give 9 reasonably-distinct points along
+    // each axis. Γ takes the largest deltas so it reads as the strongest
+    // highlight at whichever level it dominates.
+    const _TYPE_SAT_MOD: Record<string, number> = {
+      Gamma:   1.0, Delta: -0.6, Theta:  0.4, Lambda: -0.2,
+      Xi:      0.7, Pi:    -0.8, Sigma:  0.2, Phi:    -0.4, Psi: 0.0,
+    };
+    const _TYPE_LIGHT_MOD: Record<string, number> = {
+      Gamma:   0.7, Delta:  0.5, Theta: -0.5, Lambda:  0.8,
+      Xi:     -0.3, Pi:    -0.8, Sigma:  0.2, Phi:    -0.1, Psi: 0.0,
+    };
+    function _hslToRgb(h: number, s: number, l: number): [number, number, number] {
+      h = ((h % 360) + 360) % 360;
+      const c = (1 - Math.abs(2 * l - 1)) * s;
+      const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+      const m = l - c / 2;
+      let r = 0, g = 0, b = 0;
+      if      (h <  60) { r = c; g = x; }
+      else if (h < 120) { r = x; g = c; }
+      else if (h < 180) { g = c; b = x; }
+      else if (h < 240) { g = x; b = c; }
+      else if (h < 300) { r = x; b = c; }
+      else              { r = c; b = x; }
+      return [r + m, g + m, b + m];
+    }
+    function _typeForLabel(label: string): string {
+      return label === "Gamma1" || label === "Gamma2" ? "Gamma" : label;
+    }
+  </script>
+
+  <script id="cluster" type="text/x-typescript">
+    function countLeaves(mt: MetaTile): number {
+      if (mt.kind === "leaf") return 1;
+      let n = 0;
+      for (const { child } of mt.geometries) n += countLeaves(child);
+      return n;
+    }
+
+    const BASE_DEPTH = 4;
+    const baseCluster = (() => {
+      let c = buildSpectreBase();
+      for (let i = 0; i < BASE_DEPTH; i++) c = buildSupertiles(c);
+      return c;
+    })();
+
+    // Mutable state shared across cells: as the user zooms out we wrap
+    // the current root in a new Δ parent at slot 1 (Δ→Δ self-similar
+    // chain via superRules.Delta[1]). currentRootTransform encodes the
+    // pose of the current root in absolute world coordinates so that
+    // tiles previously visible stay byte-identical after extension.
+    const walkerState = {
+      currentRoot: baseCluster.Delta,
+      currentRootTransform: txIdentity,
+      currentBaseRecord: baseCluster,
+      // Number of upward extensions on top of BASE_DEPTH.
+      extensionLevel: 0,
+    };
+    const rootMeta = baseCluster.Delta;
+
+    // ─── Bounding radius per metatile (for view-frustum culling) ────────
+    // A metatile's bounding circle in its own local frame: centered at the
+    // local origin (0, 0), large enough to cover every leaf vertex once
+    // children are placed. Conservative — only used to cull entire
+    // subtrees that are definitely off-screen.
+    const _spectreBoundRadius = (() => {
+      let r = 0;
+      for (const v of spectreVertices) {
+        const d = Math.hypot(v[0], v[1]);
+        if (d > r) r = d;
+      }
+      return r;
+    })();
+
+    function attachRadii(mt: MetaTile): number {
+      if ((mt as any)._localRadius != null) return (mt as any)._localRadius;
+      if (mt.kind === "leaf") {
+        (mt as any)._localRadius = _spectreBoundRadius;
+        return _spectreBoundRadius;
+      }
+      let r = 0;
+      for (const { child, transform } of mt.geometries) {
+        const cr = attachRadii(child);
+        const d = Math.hypot(transform.t[0], transform.t[1]);
+        if (d + cr > r) r = d + cr;
+      }
+      (mt as any)._localRadius = r;
+      return r;
+    }
+    // The DAG shares child metatiles across types; attachRadii is
+    // memoized on _localRadius, so walking just the root covers the rest.
+    attachRadii(rootMeta);
+
+    // ─── Substitution level (for zoom-dependent color blending) ────────
+    // _subLevel = how many substitution steps away from a leaf this
+    // metatile sits. Leaves are level 0; Γ at base depth is level 1
+    // (it's a meta of 2 leaves); non-Γ at depth N is level N; Γ at
+    // depth N is level N+1. The Gaussian color blend in the walker
+    // centers a window over (subLevel − viewLevel), where viewLevel
+    // grows with zoom-out.
+    function attachSubLevels(mt: MetaTile): number {
+      if ((mt as any)._subLevel != null) return (mt as any)._subLevel;
+      if (mt.kind === "leaf") { (mt as any)._subLevel = 0; return 0; }
+      let max = 0;
+      for (const { child } of mt.geometries) {
+        const cl = attachSubLevels(child);
+        if (cl > max) max = cl;
+      }
+      (mt as any)._subLevel = max + 1;
+      return max + 1;
+    }
+    attachSubLevels(rootMeta);
+
+    // ─── Initial-fit bounds (one-time bbox of the root cluster) ────────
+    // _localRadius from the local origin is loose — the spectre's
+    // origin is at one corner of its bbox, not the centroid, so for
+    // deep substitution the conservative radius is several × the
+    // cluster's actual extent. Compute an exact world-space AABB by
+    // walking once at construction time.
+    const rootBounds = (() => {
+      let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
+      const STK = BASE_DEPTH + 4;
+      const stRot = new Uint8Array(STK);
+      const stMir = new Uint8Array(STK);
+      const stTx  = new Float64Array(STK);
+      const stTy  = new Float64Array(STK);
+      function recurse(mt: MetaTile, d: number) {
+        if (mt.kind === "leaf") {
+          // Account for the spectre's bbox in the leaf's local frame:
+          // every spectre vertex sits within _spectreBoundRadius of the
+          // tile origin, so a circular pad is rotation-invariant.
+          const tx = stTx[d], ty = stTy[d];
+          const m = _spectreBoundRadius;
+          if (tx - m < mnx) mnx = tx - m;
+          if (tx + m > mxx) mxx = tx + m;
+          if (ty - m < mny) mny = ty - m;
+          if (ty + m > mxy) mxy = ty + m;
+          return;
+        }
+        const pRot = stRot[d], pMir = stMir[d];
+        const pTx = stTx[d], pTy = stTy[d];
+        const pc = _COS[pRot], ps = _SIN[pRot];
+        const d1 = d + 1;
+        for (const { child, transform: T2 } of mt.geometries) {
+          let cx = T2.t[0], cy = T2.t[1];
+          if (pMir) cy = -cy;
+          stTx[d1] = pc * cx - ps * cy + pTx;
+          stTy[d1] = ps * cx + pc * cy + pTy;
+          const rDiff = pMir ? -T2.rot : T2.rot;
+          stRot[d1] = (pRot + rDiff + 12) % 12;
+          stMir[d1] = (pMir ^ T2.mirror) as 0 | 1;
+          recurse(child, d1);
+        }
+      }
+      stRot[0] = 0; stMir[0] = 0; stTx[0] = 0; stTy[0] = 0;
+      recurse(rootMeta, 0);
+      return { minX: mnx, minY: mny, maxX: mxx, maxY: mxy };
+    })();
+  </script>
+
+  <script id="boundary-cache" type="text/x-typescript">
+    // Extract a metatile's outer boundary: walk its leaves, build an edge
+    // multiplicity map, the multiplicity-1 edges are exterior, stitch them
+    // into a closed loop, earcut for triangle indices.
+    //
+    // Skip extraction (return null) if the metatile has more than
+    // MAX_BOUNDARY_LEAVES leaves — at deep substitution levels this would
+    // be untenably slow without simplification. The walker falls back to
+    // treating those metatiles as "recurse normally" rather than aggregate.
+    const MAX_BOUNDARY_LEAVES = 200_000;
+    // Aggregated cells render at ≤ ~32 px on screen, so the boundary's
+    // fractal detail is below the AA floor. Simplify each cached polygon
+    // via Visvalingam-Whyatt (drop-smallest-triangle until target reached);
+    // 16 vertices ≈ 14 triangles per cell, and for the typical visible
+    // count of a few thousand to a few tens of thousand cells per frame
+    // that's well under 1 M triangles total.
+    const BOUNDARY_VERTEX_BUDGET = 16;
+    // Above this sub-level, skip raw extraction — Spectre supertile
+    // boundaries are self-similar after simplification to 16 verts, so a
+    // donor polygon extracted once at the cap can stand in for all higher
+    // levels by scaling up by the radius ratio. Without this cap, extension
+    // level 9 would mean the walker tries to extract polygons from
+    // metatiles with billions of leaves, falls back to recursion, and
+    // emits millions of instances per frame.
+    const EXTRACT_CAP = 5;
+
+    // Visvalingam-Whyatt for closed polygons. Removes the vertex whose
+    // triangle (with neighbors) has the smallest area; repeats until
+    // length === budget. Implemented with a doubly-linked-list ring and
+    // a linear search for the min — quadratic in polygon size, but
+    // bounded by MAX_BOUNDARY_LEAVES × 14 edges and only paid once per
+    // metatile thanks to the cache.
+    function _simplifyClosedPolygon(pts: Vec2[], budget: number): Vec2[] {
+      const n = pts.length;
+      if (n <= budget) return pts;
+      const next = new Int32Array(n);
+      const prev = new Int32Array(n);
+      const alive = new Uint8Array(n);
+      for (let i = 0; i < n; i++) { next[i] = (i + 1) % n; prev[i] = (i - 1 + n) % n; alive[i] = 1; }
+      const area = new Float64Array(n);
+      function _triArea(i: number) {
+        const a = pts[prev[i]], b = pts[i], c = pts[next[i]];
+        return Math.abs((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])) * 0.5;
+      }
+      for (let i = 0; i < n; i++) area[i] = _triArea(i);
+      let remaining = n;
+      while (remaining > budget) {
+        // Find smallest-area alive vertex.
+        let mi = -1, ma = Infinity;
+        for (let i = 0; i < n; i++) {
+          if (!alive[i]) continue;
+          if (area[i] < ma) { ma = area[i]; mi = i; }
+        }
+        if (mi === -1) break;
+        const p = prev[mi], q = next[mi];
+        next[p] = q; prev[q] = p;
+        alive[mi] = 0;
+        remaining--;
+        area[p] = _triArea(p);
+        area[q] = _triArea(q);
+      }
+      const out: Vec2[] = [];
+      // Find any alive vertex to start the walk.
+      let start = -1;
+      for (let i = 0; i < n; i++) if (alive[i]) { start = i; break; }
+      if (start === -1) return pts;
+      let cur = start;
+      do {
+        out.push(pts[cur]);
+        cur = next[cur];
+      } while (cur !== start);
+      return out;
+    }
+
+    type BoundaryMesh = {
+      polygon: Float32Array;        // flat (x0, y0, x1, y1, ...)
+      indices: Uint32Array;
+    };
+    const _boundaryCache = new WeakMap<MetaTile, BoundaryMesh | null>();
+
+    function _collectLeafTransforms(mt: MetaTile, accum: Transform, out: Transform[]) {
+      if (mt.kind === "leaf") { out.push(accum); return; }
+      for (const { child, transform: T2 } of mt.geometries) {
+        _collectLeafTransforms(child, txCompose(accum, T2), out);
+      }
+    }
+
+    function extractBoundary(mt: MetaTile): BoundaryMesh | null {
+      if (mt.kind === "leaf") return null;
+      const cached = _boundaryCache.get(mt);
+      if (cached !== undefined) return cached;
+      const leafCount = countLeaves(mt);
+      if (leafCount > MAX_BOUNDARY_LEAVES) {
+        _boundaryCache.set(mt, null);
+        return null;
+      }
+
+      // 1. Collect every leaf's accumulated transform in mt's local frame.
+      const xforms: Transform[] = [];
+      _collectLeafTransforms(mt, txIdentity, xforms);
+
+      // 2. Quantize vertices to integer IDs. Substitution math involves
+      // sums of unit-length vectors at multiples of 30°, so 1e-7 rounding
+      // is well above the FP noise floor at any depth we'd extract here.
+      const Q = 1e7;
+      const vertMap = new Map<string, number>();
+      const vertList: Vec2[] = [];
+      function vertId(p: Vec2): number {
+        const qx = Math.round(p[0] * Q);
+        const qy = Math.round(p[1] * Q);
+        const key = qx + "," + qy;
+        let id = vertMap.get(key);
+        if (id === undefined) { id = vertList.length; vertMap.set(key, id); vertList.push([p[0], p[1]]); }
+        return id;
+      }
+
+      // 3. For each leaf, compute its 14 vertex IDs and 14 edge keys.
+      // edgeMult counts how many leaves share each edge; multiplicity 1
+      // means it's on the cluster boundary.
+      const edgeMult = new Map<number, number>();
+      for (const T of xforms) {
+        const ids: number[] = new Array(14);
+        for (let i = 0; i < 14; i++) ids[i] = vertId(txApply(T, spectreVertices[i]));
+        for (let i = 0; i < 14; i++) {
+          const a = ids[i], b = ids[(i + 1) % 14];
+          const lo = a < b ? a : b;
+          const hi = a < b ? b : a;
+          const key = lo * 0x100000 + hi;     // safe up to ~1M unique vertices
+          edgeMult.set(key, (edgeMult.get(key) ?? 0) + 1);
+        }
+      }
+
+      // 4. Adjacency map: vertId → 2 boundary neighbors (for a closed loop
+      // each boundary vertex has degree 2; degenerate cases would have
+      // higher degree, which we don't expect here).
+      const adj = new Map<number, number[]>();
+      for (const [key, mult] of edgeMult) {
+        if (mult !== 1) continue;
+        const lo = Math.floor(key / 0x100000);
+        const hi = key % 0x100000;
+        let la = adj.get(lo); if (!la) { la = []; adj.set(lo, la); } la.push(hi);
+        let lb = adj.get(hi); if (!lb) { lb = []; adj.set(hi, lb); } lb.push(lo);
+      }
+
+      // 5. Stitch into closed loops. Pick the longest as the outer
+      // boundary (Spectre clusters are simply connected, so there should
+      // only be one).
+      const visited = new Set<number>();
+      const loops: number[][] = [];
+      for (const start of adj.keys()) {
+        if (visited.has(start)) continue;
+        const loop: number[] = [];
+        let prev = -1;
+        let cur = start;
+        while (true) {
+          loop.push(cur);
+          visited.add(cur);
+          const ns = adj.get(cur)!;
+          let next = -1;
+          for (const n of ns) { if (n !== prev) { next = n; break; } }
+          if (next === -1 || next === start) break;
+          prev = cur;
+          cur = next;
+        }
+        loops.push(loop);
+      }
+      if (loops.length === 0) { _boundaryCache.set(mt, null); return null; }
+      loops.sort((a, b) => b.length - a.length);
+      const outer = loops[0];
+
+      // 6. Materialize the outer-boundary as Vec2 points, simplify with
+      // Visvalingam-Whyatt down to the vertex budget, then dilate slightly
+      // around the polygon's centroid so adjacent aggregates overlap by a
+      // small amount and the visible black streaks from FP-precision drift
+      // (and from simplification-induced edge-mismatch with neighbors) are
+      // hidden under the overlap. The metatile's local origin is at one
+      // corner of the cluster bbox, so dilating around the polygon centroid
+      // (not the origin) is what keeps the expansion isotropic.
+      const outerPts: Vec2[] = outer.map((id) => vertList[id]);
+      const simplified = _simplifyClosedPolygon(outerPts, BOUNDARY_VERTEX_BUDGET);
+      let cx = 0, cy = 0;
+      for (const p of simplified) { cx += p[0]; cy += p[1]; }
+      cx /= simplified.length; cy /= simplified.length;
+      const DILATE = 1.025;
+      const polygon = new Float32Array(simplified.length * 2);
+      const flat: number[] = new Array(simplified.length * 2);
+      for (let i = 0; i < simplified.length; i++) {
+        const x = cx + (simplified[i][0] - cx) * DILATE;
+        const y = cy + (simplified[i][1] - cy) * DILATE;
+        polygon[i * 2 + 0] = x;
+        polygon[i * 2 + 1] = y;
+        flat[i * 2 + 0] = x;
+        flat[i * 2 + 1] = y;
+      }
+      const indices = new Uint32Array(earcut(flat));
+      const mesh: BoundaryMesh = { polygon, indices };
+      _boundaryCache.set(mt, mesh);
+      return mesh;
+    }
+
+    // ─── GPU mesh handles ──────────────────────────────────────────────
+    // Per-metatile lazily-created vertex+index buffers. Memory is bounded
+    // by the number of unique metatiles encountered as aggregation
+    // candidates — at most ~9 metatypes × the deepest aggregation level.
+    import {
+      createVertexBuffer as _createVB,
+      createIndexBuffer as _createIB,
+    } from './lib/webgpu-canvas.js';
+
+    type GpuMesh = {
+      vertexBuffer: GPUBuffer;
+      indexBuffer: GPUBuffer;
+      indexCount: number;
+      indexFormat: 'uint32';
+    };
+    // Per-metatile-object cache (avoids re-checking the shape map every
+    // visit) and a shape-keyed cache that all 8 non-Γ types at the same
+    // substitution level point at, so we extract one boundary and create
+    // one pair of GPU buffers per (level, isGamma) instead of per type.
+    const _gpuMeshCache = new WeakMap<MetaTile, GpuMesh | null>();
+    const _gpuMeshByShape = new Map<string, GpuMesh | null>();
+
+    // Donor metatiles for boundary extraction, one per shape (Γ vs non-Γ).
+    // Their polygons are extracted on first demand and reused (scaled) for
+    // any same-shape metatile with subLevel > EXTRACT_CAP. The donor's
+    // _localRadius is captured so we can compute the scale factor without
+    // needing the Spectre inflation constant analytically.
+    //
+    // After BASE_DEPTH inflations every metatile in baseCluster has
+    // subLevel = BASE_DEPTH + 1, so we use baseCluster.Delta (non-Γ) and
+    // baseCluster.Gamma directly. baseCluster.Gamma isn't reachable from
+    // baseCluster.Delta, so its radii/sublevels aren't attached yet.
+    const _donors = (() => {
+      attachRadii(baseCluster.Gamma);
+      attachSubLevels(baseCluster.Gamma);
+      return { nonGamma: baseCluster.Delta, gamma: baseCluster.Gamma };
+    })();
+
+    function _getDonorBoundary(isGamma: boolean): { mesh: BoundaryMesh; radius: number } | null {
+      const donor = isGamma ? _donors.gamma : _donors.nonGamma;
+      const mesh = extractBoundary(donor);
+      if (mesh === null) return null;
+      return { mesh, radius: (donor as any)._localRadius };
+    }
+
+    function getGpuMesh(mt: MetaTile): GpuMesh | null {
+      const cached = _gpuMeshCache.get(mt);
+      if (cached !== undefined) return cached;
+      const subLevel = (mt as any)._subLevel as number;
+      const isGamma = mt.kind === "meta" && mt.name === "Gamma";
+      const shapeKey = subLevel + (isGamma ? "g" : "n");
+      const shared = _gpuMeshByShape.get(shapeKey);
+      if (shared !== undefined) {
+        _gpuMeshCache.set(mt, shared);
+        return shared;
+      }
+      let polygon: Float32Array;
+      let indices: Uint32Array;
+      if (subLevel <= EXTRACT_CAP) {
+        // Extract directly from this metatile.
+        const boundary = extractBoundary(mt);
+        if (boundary === null) {
+          _gpuMeshByShape.set(shapeKey, null);
+          _gpuMeshCache.set(mt, null);
+          return null;
+        }
+        polygon = boundary.polygon;
+        indices = boundary.indices;
+      } else {
+        // Reuse donor polygon scaled by radius ratio.
+        const donor = _getDonorBoundary(isGamma);
+        if (donor === null) {
+          _gpuMeshByShape.set(shapeKey, null);
+          _gpuMeshCache.set(mt, null);
+          return null;
+        }
+        const scale = ((mt as any)._localRadius as number) / donor.radius;
+        polygon = new Float32Array(donor.mesh.polygon.length);
+        for (let i = 0; i < polygon.length; i++) polygon[i] = donor.mesh.polygon[i] * scale;
+        indices = donor.mesh.indices;
+      }
+      const vb = _createVB(device, 'agg-poly-verts', polygon);
+      const ib = _createIB(device, 'agg-poly-indices', indices);
+      const mesh: GpuMesh = {
+        vertexBuffer: vb, indexBuffer: ib,
+        indexCount: indices.length, indexFormat: 'uint32',
+      };
+      _gpuMeshByShape.set(shapeKey, mesh);
+      _gpuMeshCache.set(mt, mesh);
+      return mesh;
+    }
+  </script>
+
+  <script id="walker" type="text/x-typescript">
+    // View-driven walker: traverse the metatile DAG with a per-frame view
+    // rect, cull subtrees whose bounding circle is outside the rect, and
+    // emit one 16-byte instance per visible leaf:
+    //   offset  0 (8 B): float32x2 (tx, ty)
+    //   offset  8 (4 B): snorm16x2 (cos θ, sin θ)
+    //   offset 12 (4 B): unorm8x4  (r, g, b, mirror)
+    //
+    // Scratch state (the data buffer, the transform stack) is allocated
+    // once and reused; only the visible-leaf prefix changes per frame.
+    type WalkView = {
+      centerX: number; centerY: number;
+      pixelScale: number;
+      pixelWidth: number; pixelHeight: number;
+    };
+
+    // Aggregate at this on-screen pixel extent: a metatile whose actual
+    // diameter shrinks below AGG_PX is rendered as its outline polygon
+    // instead of recursing into individual leaves.
+    //
+    // The walker descends until the first cell falls under the threshold
+    // and aggregates there, so cell sizes after aggregation land in
+    // (AGG_PX/inflation, AGG_PX] = (~AGG_PX/2.8, AGG_PX]. Picking 56 puts
+    // typical aggregate cells around 20–55 px on screen — small enough
+    // that any solid-color region reads as a single mosaic tile rather
+    // than a monolithic block, large enough that the eye can resolve
+    // individual cells and the per-cell color differences register.
+    const AGG_PX = 56;
+    // _localRadius is measured from the spectre's corner origin (vertex 0),
+    // so for any supertile it's ~1.5× the cluster's true centered radius
+    // (empirically 1.44 at sub-level 3, growing to 1.64 at sub-level 5).
+    // Multiplying the threshold by this factor lets aggregates trigger at
+    // the cell's actual on-screen extent rather than a smaller fraction.
+    // Without it, the walker recurses one extra level on average and emits
+    // ~5× more cells than necessary.
+    const _LOOSE_RADIUS_FACTOR = 1.55;
+
+    // Zoom-dependent color via HSL channel encoding. The cell carries a
+    // color whose hue is read from the cell itself, saturation from its
+    // immediate parent meta, lightness from its grandparent, with viewLevel
+    // sliding the whole window up the ancestry chain in lockstep with the
+    // user's zoom-out. Three different substitution levels drive three
+    // perceptual axes simultaneously, so coarse, medium, and fine
+    // structure are all visible at once instead of any single one
+    // dominating. Transitions are continuous because each channel pick
+    // linearly interpolates between integer "levels-up" stack slots.
+    //
+    // viewLevel = 0 places leaves at the AGG_PX threshold (i.e., it's the
+    // log_inflation of how many supertile levels the user has zoomed past
+    // the leaf-aggregation boundary). At fine zoom (low viewLevel) the
+    // cell's own type colors the hue. At deep zoom each channel reads
+    // from progressively-higher ancestors, so what the eye picks up as
+    // hue/sat/lightness all reflect levels relevant to that zoom.
+    //
+    // Spectre supertile inflation factor — each substitution level's
+    // bounding circle scales by ~(1 + √3) ≈ 2.73 versus the previous;
+    // I'm using 2.5 here as a tuning compromise.
+    const _INFLATION = 2.5;
+    const _LEVEL0_PIXEL_SCALE = AGG_PX / (2 * _spectreBoundRadius);
+    function viewLevelFor(pixelScale: number): number {
+      if (pixelScale <= 0) return 0;
+      return -Math.log(pixelScale / _LEVEL0_PIXEL_SCALE) / Math.log(_INFLATION);
+    }
+
+    type WalkBucket = {
+      // null key = leaves drawn with the spectre mesh; otherwise the
+      // metatile whose outline polygon owns this bucket.
+      key: MetaTile | null;
+      data: ArrayBuffer;
+      f32: Float32Array;
+      i16: Int16Array;
+      u8: Uint8Array;
+      count: number;
+      capacity: number;
+    };
+
+    function _newBucket(key: MetaTile | null, initCap: number): WalkBucket {
+      const capacity = Math.max(16, initCap);
+      const data = new ArrayBuffer(capacity * 16);
+      return {
+        key,
+        data,
+        f32: new Float32Array(data),
+        i16: new Int16Array(data),
+        u8:  new Uint8Array(data),
+        count: 0,
+        capacity,
+      };
+    }
+
+    function _growBucket(b: WalkBucket, needed: number) {
+      if (needed <= b.capacity) return;
+      const newCap = Math.max(needed, b.capacity * 2);
+      const newData = new ArrayBuffer(newCap * 16);
+      new Uint8Array(newData).set(b.u8.subarray(0, b.count * 16));
+      b.data = newData;
+      b.f32 = new Float32Array(newData);
+      b.i16 = new Int16Array(newData);
+      b.u8  = new Uint8Array(newData);
+      b.capacity = newCap;
+    }
+
+    function makeWalker(initialLeafCap: number) {
+      // Generous depth budget — depth grows by 1 per upward-extension level.
+      const STK = 64;
+      const stRot = new Uint8Array(STK);
+      const stMir = new Uint8Array(STK);
+      const stTx  = new Float64Array(STK);
+      const stTy  = new Float64Array(STK);
+      // Ancestry channel stack: each entered meta pushes its (subLevel, hue,
+      // satMod, lightMod). The walker picks one ancestor per perceptual
+      // channel (different stack distances) so multiple substitution levels
+      // remain visible at once instead of any single one dominating.
+      // Stack is ordered with index 0 = root (highest subLevel) and
+      // index ancDepth−1 = immediate parent (lowest subLevel).
+      const stHue   = new Float64Array(STK);
+      const stSatM  = new Float64Array(STK);
+      const stLitM  = new Float64Array(STK);
+      const stSubL  = new Float64Array(STK);
+      let ancDepth = 0;
+
+      let vMnX = -Infinity, vMxX = Infinity, vMnY = -Infinity, vMxY = Infinity;
+      let pixelScale = 1;
+      let viewLevel = 0;
+      const buckets = new Map<MetaTile | null, WalkBucket>();
+      // Pre-seed the leaf bucket at the requested size; it reuses across
+      // frames. Aggregate buckets are created lazily and reset each frame.
+      buckets.set(null, _newBucket(null, initialLeafCap));
+
+      // Channel-offset assignments. Cell (level 0 in the "levels-up" sense)
+      // contributes hue. Each step up the ancestry chain adds 1 to the
+      // levels-up count, so an offset of N means "N levels above the cell."
+      // Picking saturation from the +1 ancestor and lightness from the +2
+      // ancestor encodes three substitution scales into the cell's color
+      // simultaneously.
+      const _HUE_OFFSET   = 0;
+      const _SAT_OFFSET   = 1;
+      const _LIGHT_OFFSET = 2;
+      const _BASE_SAT   = 0.55;
+      const _SAT_AMP    = 0.30;
+      const _BASE_LIGHT = 0.55;
+      const _LIGHT_AMP  = 0.20;
+
+      // Pick a channel value at a given "levels-up" target with linear
+      // interpolation between the two adjacent stack levels. levelsUp is
+      // continuous and viewLevel-dependent, so transitions between integer
+      // levels remain smooth as the user zooms.
+      //
+      // levelsUp = 0 → cell itself; 1 → parent; 2 → grandparent; clamped at
+      // root for values past the stack height.
+      function _pickChannel(
+        levelsUp: number,
+        cellValue: number,
+        getter: (idx: number) => number,
+      ): number {
+        const f = levelsUp;
+        const lo = Math.floor(f);
+        const t = f - lo;
+        const getAt = (li: number): number => {
+          if (li <= 0) return cellValue;
+          const idx = ancDepth - li;
+          if (idx < 0) return ancDepth > 0 ? getter(0) : cellValue;
+          return getter(idx);
+        };
+        return getAt(lo) * (1 - t) + getAt(lo + 1) * t;
+      }
+
+      function emit(bucketKey: MetaTile | null, label: string, d: number, cellSubLevel: number) {
+        let b = buckets.get(bucketKey);
+        if (!b) { b = _newBucket(bucketKey, 64); buckets.set(bucketKey, b); }
+        if (b.count >= b.capacity) _growBucket(b, b.count + 1);
+        const i = b.count;
+        b.f32[i * 4 + 0] = stTx[d];
+        b.f32[i * 4 + 1] = stTy[d];
+        const c = _COS[stRot[d]], s = _SIN[stRot[d]];
+        b.i16[i * 8 + 4] = Math.max(-32768, Math.min(32767, Math.round(c * 32767)));
+        b.i16[i * 8 + 5] = Math.max(-32768, Math.min(32767, Math.round(s * 32767)));
+
+        // Cell's own (hue, satMod, lightMod) — used when no ancestor exists
+        // at the requested levels-up.
+        const type = _typeForLabel(label);
+        const cellHue = (_TYPE_BASE_HUE[type] ?? 0) + cellSubLevel * _LEVEL_HUE_STEP;
+        const cellSatMod = _TYPE_SAT_MOD[type] ?? 0;
+        const cellLitMod = _TYPE_LIGHT_MOD[type] ?? 0;
+
+        // Channel encoding: each scale's structure shows up in a different
+        // perceptual axis. levelsUp targets are positive offsets from the
+        // cell, advanced by viewLevel so as the user zooms out the whole
+        // window slides up the ancestry chain in lockstep.
+        const huePick   = _pickChannel(viewLevel + _HUE_OFFSET,   cellHue,    (k) => stHue[k]);
+        const satPick   = _pickChannel(viewLevel + _SAT_OFFSET,   cellSatMod, (k) => stSatM[k]);
+        const litPick   = _pickChannel(viewLevel + _LIGHT_OFFSET, cellLitMod, (k) => stLitM[k]);
+        const sat   = Math.max(0, Math.min(1, _BASE_SAT   + _SAT_AMP   * satPick));
+        const light = Math.max(0, Math.min(1, _BASE_LIGHT + _LIGHT_AMP * litPick));
+        const [R, G, B] = _hslToRgb(huePick, sat, light);
+
+        const off = i * 16;
+        b.u8[off + 12] = Math.max(0, Math.min(255, Math.round(R * 255)));
+        b.u8[off + 13] = Math.max(0, Math.min(255, Math.round(G * 255)));
+        b.u8[off + 14] = Math.max(0, Math.min(255, Math.round(B * 255)));
+        b.u8[off + 15] = stMir[d] ? 255 : 0;
+        b.count = i + 1;
+      }
+
+      function recurse(mt: MetaTile, d: number) {
+        const cx = stTx[d], cy = stTy[d];
+        const r = (mt as any)._localRadius ?? 0;
+        if (cx + r < vMnX || cx - r > vMxX || cy + r < vMnY || cy - r > vMxY) return;
+        if (mt.kind === "leaf") { emit(null, mt.label, d, 0); return; }
+
+        // Aggregate if this metatile would render below the threshold.
+        // 2·r is the bounding-circle diameter; pixelExtent is its size
+        // in screen pixels. If the boundary cache yields a polygon, emit
+        // one aggregate instance using the metatile's name color; if the
+        // metatile is too big to extract a boundary for, fall through
+        // to the recursive case.
+        const pixelExtent = 2 * r * pixelScale;
+        if (pixelExtent < AGG_PX * _LOOSE_RADIUS_FACTOR) {
+          const mesh = getGpuMesh(mt);
+          if (mesh) { emit(mt, mt.name, d, (mt as any)._subLevel); return; }
+        }
+
+        // Push this meta's channel info onto the ancestry stack, recurse, pop.
+        const mySL = (mt as any)._subLevel as number;
+        stHue [ancDepth] = (_TYPE_BASE_HUE [mt.name] ?? 0) + mySL * _LEVEL_HUE_STEP;
+        stSatM[ancDepth] = _TYPE_SAT_MOD  [mt.name] ?? 0;
+        stLitM[ancDepth] = _TYPE_LIGHT_MOD[mt.name] ?? 0;
+        stSubL[ancDepth] = mySL;
+        ancDepth++;
+
+        const pRot = stRot[d], pMir = stMir[d];
+        const pTx = stTx[d], pTy = stTy[d];
+        const pc = _COS[pRot], ps = _SIN[pRot];
+        const d1 = d + 1;
+        for (const { child, transform: T2 } of mt.geometries) {
+          let ccx = T2.t[0], ccy = T2.t[1];
+          if (pMir) ccy = -ccy;
+          stTx[d1] = pc * ccx - ps * ccy + pTx;
+          stTy[d1] = ps * ccx + pc * ccy + pTy;
+          const rDiff = pMir ? -T2.rot : T2.rot;
+          stRot[d1] = (pRot + rDiff + 12) % 12;
+          stMir[d1] = (pMir ^ T2.mirror) as 0 | 1;
+          recurse(child, d1);
+        }
+        ancDepth--;
+      }
+
+      // Single shared buffer, populated by concatenating bucket data
+      // post-walk. Re-used across frames; grows on demand.
+      let outData = new ArrayBuffer(initialLeafCap * 16);
+      let outU8 = new Uint8Array(outData);
+
+      return function walk(rootMeta: MetaTile, rootTransform: Transform, view: WalkView): {
+        data: ArrayBuffer; totalCount: number;
+        groups: Array<{ key: MetaTile | null; instanceOffset: number; instanceCount: number }>;
+      } {
+        const halfW = view.pixelWidth / (2 * view.pixelScale);
+        const halfH = view.pixelHeight / (2 * view.pixelScale);
+        const m = _spectreBoundRadius;
+        vMnX = view.centerX - halfW - m;
+        vMxX = view.centerX + halfW + m;
+        vMnY = view.centerY - halfH - m;
+        vMxY = view.centerY + halfH + m;
+        pixelScale = view.pixelScale;
+        viewLevel = viewLevelFor(pixelScale);
+        ancDepth = 0;
+
+        // Reset all buckets.
+        for (const b of buckets.values()) b.count = 0;
+
+        stRot[0] = rootTransform.rot;
+        stMir[0] = rootTransform.mirror;
+        stTx[0]  = rootTransform.t[0];
+        stTy[0]  = rootTransform.t[1];
+        recurse(rootMeta, 0);
+
+        // Concatenate buckets into outData. Leaves first (key === null),
+        // then aggregates in insertion order.
+        let totalCount = 0;
+        for (const b of buckets.values()) totalCount += b.count;
+        if (totalCount * 16 > outData.byteLength) {
+          const newCap = Math.max(totalCount, (outData.byteLength / 16) * 2);
+          outData = new ArrayBuffer(newCap * 16);
+          outU8 = new Uint8Array(outData);
+        }
+        const groups: Array<{ key: MetaTile | null; instanceOffset: number; instanceCount: number }> = [];
+        let off = 0;
+        const leafBucket = buckets.get(null)!;
+        if (leafBucket.count > 0) {
+          outU8.set(leafBucket.u8.subarray(0, leafBucket.count * 16), off * 16);
+          groups.push({ key: null, instanceOffset: off, instanceCount: leafBucket.count });
+          off += leafBucket.count;
+        }
+        for (const b of buckets.values()) {
+          if (b.key === null) continue;
+          if (b.count === 0) continue;
+          outU8.set(b.u8.subarray(0, b.count * 16), off * 16);
+          groups.push({ key: b.key, instanceOffset: off, instanceCount: b.count });
+          off += b.count;
+        }
+        return { data: outData, totalCount, groups };
+      };
+    }
+
+    const walker = makeWalker(countLeaves(rootMeta));
+
+    // ─── Upward extension ───────────────────────────────────────────────
+    // Wrap the current root in a level-up Δ parent. Slot 1 of Δ is Δ
+    // (per superRules.Delta[1]), so the existing root becomes the slot-1
+    // child of the new root. The new root's pose in absolute world is
+    // chosen so that the slot-1 child's accumulated transform stays
+    // exactly equal to the current root's transform — visible tiles
+    // remain in the same world position.
+    function extendRootUpward() {
+      const nextRecord = buildSupertiles(walkerState.currentBaseRecord);
+      const newRoot = nextRecord.Delta;
+      attachRadii(newRoot);
+      attachSubLevels(newRoot);
+      // Non-Γ types: geometries[i] corresponds directly to slot i (no
+      // null slots). Slot 1 of Δ is "Delta", so newRoot.geometries[1]
+      // is the geometry whose child === walkerState.currentRoot.
+      const slot1Transform = newRoot.geometries[1].transform;
+      walkerState.currentRootTransform = txCompose(
+        walkerState.currentRootTransform,
+        txInverse(slot1Transform),
+      );
+      walkerState.currentRoot = newRoot;
+      walkerState.currentBaseRecord = nextRecord;
+      walkerState.extensionLevel += 1;
+    }
+
+    // Extend while the current root's bounding circle doesn't cover the
+    // view-corner farthest from the root center. The 0.95 factor leaves
+    // a small margin so we extend before the user actually sees an edge.
+    function maybeExtend(view: WalkView): void {
+      let safety = 64;
+      while (safety-- > 0) {
+        const r = (walkerState.currentRoot as any)._localRadius;
+        const cx = walkerState.currentRootTransform.t[0];
+        const cy = walkerState.currentRootTransform.t[1];
+        const halfW = view.pixelWidth / (2 * view.pixelScale);
+        const halfH = view.pixelHeight / (2 * view.pixelScale);
+        const dx = Math.abs(view.centerX - cx) + halfW;
+        const dy = Math.abs(view.centerY - cy) + halfH;
+        const distToCorner = Math.hypot(dx, dy);
+        if (distToCorner <= 0.95 * r) return;
+        extendRootUpward();
+      }
+    }
+  </script>
+
+  <script id="renderer-setup" type="text/x-typescript">
+    import { expandable } from './lib/expandable.js';
+    import { createInfiniteRenderer } from './infinite-renderer.js';
+
+    // Rebuilt on every view change; the walker's scratch buffer is
+    // reused so this call is allocation-free in the hot path.
+    let _initialFitDone = false;
+    function repackInstances(): void {
+      if (viewerState.pixelWidth === 0) return;
+      const view = {
+        centerX: viewerState.centerX,
+        centerY: viewerState.centerY,
+        pixelScale: viewerState.pixelScale,
+        pixelWidth: viewerState.pixelWidth,
+        pixelHeight: viewerState.pixelHeight,
+      };
+      maybeExtend(view);
+      const result = walker(walkerState.currentRoot, walkerState.currentRootTransform, view);
+
+      // Resolve bucket keys → renderer meshes. The leaf bucket uses the
+      // renderer's default spectre mesh; aggregates use per-metatile
+      // boundary meshes. getGpuMesh is memoized so repeats are cheap.
+      const renderGroups = [];
+      for (const g of result.groups) {
+        const mesh = g.key === null ? viewerState.defaultMesh : getGpuMesh(g.key);
+        if (!mesh) continue;
+        renderGroups.push({
+          mesh,
+          instanceOffset: g.instanceOffset,
+          instanceCount: g.instanceCount,
+        });
+      }
+      viewerState.setDrawList({ data: result.data, totalCount: result.totalCount, groups: renderGroups });
+    }
+
+    const { canvas: viewerCanvas, state: viewerState } = createInfiniteRenderer({
+      device,
+      canvasFormat,
+      invalidation,
+      meshVertexData,
+      meshFillIndices,
+      onViewChange: () => repackInstances(),
+    });
+
+    const viewerExpandable = expandable(viewerCanvas, {
+      id: 'spectre-infinite',
+      width: 640,
+      height: 640,
+      wide: true,
+      onResize: (_el, w, h) => {
+        viewerState.resize(w, h);
+        if (!_initialFitDone && viewerState.pixelWidth > 0) {
+          // First valid pixel size: center on the cluster centroid and
+          // pick the largest pixelScale that keeps the cluster inside
+          // the viewport with a 5% margin.
+          const b = rootBounds;
+          viewerState.centerX = (b.minX + b.maxX) / 2;
+          viewerState.centerY = (b.minY + b.maxY) / 2;
+          const fitX = viewerState.pixelWidth  / (b.maxX - b.minX);
+          const fitY = viewerState.pixelHeight / (b.maxY - b.minY);
+          viewerState.pixelScale = 0.95 * Math.min(fitX, fitY);
+          _initialFitDone = true;
+        }
+        repackInstances();
+        viewerState.requestFrame();
+      },
+    });
+  </script>
+</notebook>

--- a/src/notebooks/aperiodic-monotile/infinite.html
+++ b/src/notebooks/aperiodic-monotile/infinite.html
@@ -8,37 +8,272 @@
     A pared-down Spectre viewer that lets you zoom out arbitrarily. Supertiles are generated on demand, and tiles that shrink below a few pixels collapse into earcut polygon meshes. This first cut is a plain viewer at fixed depth; the walker, upward extension, aggregation, and zoom-driven coloring are layered in afterwards.
   </script>
 
-  <script id="figure" type="text/x-typescript">
-    display(viewerExpandable);
-  </script>
-
-  <script id="figure-caption" type="text/x-typescript">
-    const _totalLeaves = countLeaves(rootMeta);
-    display(html`<figcaption>
-      Depth-${BASE_DEPTH} Δ supertile, Cartesian coordinates only (no morph). ${_totalLeaves.toLocaleString()} spectres total; only the visible subset is uploaded each frame.
-    </figcaption>`);
+  <script id="editor-styles" type="text/html">
+    <style>
+      .spectre-card {
+        --gap: 8px;
+        display: flex; flex-direction: column; gap: 6px;
+        padding: 10px 12px; margin: 8px 0;
+        border-radius: 6px;
+        border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+        background: color-mix(in srgb, currentColor 4%, transparent);
+        font-family: var(--sans-serif, sans-serif);
+        font-size: 12px;
+      }
+      .spectre-row {
+        display: flex; gap: var(--gap, 8px); align-items: center;
+        flex-wrap: wrap;
+      }
+      .spectre-row > .grow { flex: 1 1 0; min-width: 0; }
+      .spectre-input, .spectre-select {
+        font-family: var(--mono, monospace);
+        font-size: 11px;
+        padding: 4px 7px;
+        border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+        border-radius: 3px;
+        background: color-mix(in srgb, currentColor 6%, transparent);
+        color: inherit;
+        box-sizing: border-box;
+      }
+      .spectre-input:focus, .spectre-select:focus {
+        outline: 1px solid color-mix(in srgb, currentColor 60%, transparent);
+        outline-offset: -1px;
+      }
+      .spectre-input.grow { flex: 1 1 0; min-width: 0; }
+      .spectre-input.num    { width: 60px; text-align: right; }
+      .spectre-input.num-sm { width: 52px; text-align: right; }
+      .spectre-input.num-md { width: 70px; text-align: right; }
+      .spectre-input.num-lg { width: 96px; text-align: right; }
+      .spectre-input[readonly] {
+        cursor: text;
+        background: color-mix(in srgb, currentColor 3%, transparent);
+      }
+      .spectre-btn {
+        font-family: var(--sans-serif, sans-serif);
+        font-size: 11px;
+        padding: 4px 10px;
+        border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+        border-radius: 3px;
+        background: color-mix(in srgb, currentColor 8%, transparent);
+        color: inherit;
+        cursor: pointer;
+        white-space: nowrap;
+        line-height: 1.2;
+      }
+      .spectre-btn:hover { background: color-mix(in srgb, currentColor 16%, transparent); }
+      .spectre-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+      .spectre-btn.icon {
+        padding: 3px 8px; min-width: 28px; text-align: center;
+        font-family: var(--mono, monospace);
+      }
+      .spectre-btn.primary {
+        background: color-mix(in srgb, #4a9eff 22%, transparent);
+        border-color: color-mix(in srgb, #4a9eff 50%, transparent);
+        font-weight: 600;
+      }
+      .spectre-btn.primary:hover {
+        background: color-mix(in srgb, #4a9eff 34%, transparent);
+      }
+      .spectre-btn.danger:hover:not(:disabled) {
+        background: color-mix(in srgb, #d04848 28%, transparent);
+        border-color: color-mix(in srgb, #d04848 60%, transparent);
+      }
+      .spectre-label {
+        font-size: 11px;
+        opacity: 0.55;
+        flex: 0 0 auto;
+      }
+      .spectre-tag {
+        font-family: var(--mono, monospace);
+        font-weight: 700;
+        font-size: 11px;
+        padding: 3px 9px;
+        border-radius: 999px;
+        background: color-mix(in srgb, currentColor 14%, transparent);
+        flex: 0 0 auto;
+        letter-spacing: 0.03em;
+        min-width: 40px;
+        text-align: center;
+      }
+      .spectre-mono {
+        font-family: var(--mono, monospace);
+        font-size: 11px;
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .spectre-checkbox {
+        display: inline-flex; gap: 4px; align-items: center;
+        cursor: pointer; user-select: none;
+        font-size: 11px;
+        flex: 0 0 auto;
+      }
+      .spectre-divider {
+        flex: 1 1 0;
+        border: 0;
+        border-top: 1px dashed color-mix(in srgb, currentColor 16%, transparent);
+        margin: 0 4px;
+        align-self: center;
+      }
+      .spectre-kf-row {
+        display: flex; gap: 8px; align-items: center;
+        padding: 4px 0;
+      }
+      .spectre-seg {
+        display: flex; flex-direction: column; gap: 4px;
+        padding: 6px 8px 6px 12px;
+        margin: 2px 0 6px 22px;
+        border-left: 2px solid color-mix(in srgb, currentColor 12%, transparent);
+        border-radius: 0 4px 4px 0;
+      }
+      .spectre-seg.is-smooth {
+        border-left-color: color-mix(in srgb, #4a9eff 65%, transparent);
+        background: linear-gradient(
+          90deg,
+          color-mix(in srgb, #4a9eff 6%, transparent) 0,
+          transparent 280px
+        );
+      }
+      .spectre-seg-row {
+        display: flex; gap: 8px; align-items: center;
+        font-size: 11px;
+        flex-wrap: wrap;
+      }
+      .spectre-section-head {
+        display: flex; gap: 8px; align-items: baseline;
+        margin: 0 0 6px 0;
+      }
+      .spectre-section-head h4 {
+        margin: 0;
+        font-size: 10px; font-weight: 700;
+        letter-spacing: 0.06em; text-transform: uppercase;
+        opacity: 0.55;
+      }
+      .spectre-section-head .meta {
+        font-family: var(--mono, monospace);
+        font-size: 11px;
+        opacity: 0.7;
+        margin-left: auto;
+      }
+      .spectre-actions {
+        display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+      }
+      .spectre-cull-slider {
+        flex: 1 1 0;
+        min-width: 80px;
+        max-width: 200px;
+      }
+      .spectre-help {
+        font-family: var(--sans-serif, sans-serif);
+        font-size: 12px;
+        line-height: 1.45;
+        opacity: 0.75;
+        margin: 0 0 4px 0;
+      }
+      .spectre-help > summary {
+        cursor: pointer;
+        font-size: 11px;
+        opacity: 0.7;
+        list-style: none;
+        display: inline-flex; align-items: center; gap: 4px;
+        user-select: none;
+      }
+      .spectre-help > summary::-webkit-details-marker { display: none; }
+      .spectre-help > summary::before {
+        content: '▸';
+        font-size: 9px;
+        transition: transform 0.12s ease;
+        display: inline-block;
+        width: 9px;
+      }
+      .spectre-help[open] > summary::before { transform: rotate(90deg); }
+      .spectre-help > summary:hover { opacity: 1; }
+      .spectre-help > p {
+        margin: 6px 0 0 0;
+        max-width: 70ch;
+      }
+      .spectre-swatch-row {
+        display: flex; gap: 2px; align-items: flex-end;
+        width: 100%;
+        max-width: 360px;
+      }
+      .spectre-swatch-cell {
+        display: flex; flex-direction: column;
+        flex: 1 1 0; min-width: 0;
+        align-items: center;
+        gap: 2px;
+        font-family: var(--sans-serif, sans-serif);
+        font-size: 11px;
+        opacity: 0.85;
+      }
+      input.spectre-swatch {
+        -webkit-appearance: none; -moz-appearance: none; appearance: none;
+        width: 100%;
+        height: 18px;
+        padding: 0;
+        border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+        border-radius: 3px;
+        background: transparent;
+        cursor: pointer;
+      }
+      input.spectre-swatch::-webkit-color-swatch-wrapper { padding: 0; }
+      input.spectre-swatch::-webkit-color-swatch { border: none; border-radius: 2px; }
+      input.spectre-swatch::-moz-color-swatch { border: none; }
+    </style>
   </script>
 
   <script id="palette-controls" type="text/x-typescript">
-    // A "Randomize" button that picks a new palette seed and triggers a
-    // redraw. paletteState.rgb is mutated in place, so the next frame's
-    // walker reads the new colours without re-running any cells.
+    // 11 colour swatches (one per tile label, including Γ₁/Γ₂) plus a
+    // Randomize button + seed input. paletteState.rgb is mutated in place,
+    // so the next frame's walker reads the new colours without re-running
+    // any cells.
+    const _SWATCH_GLYPH: Record<string, string> = {
+      Gamma: 'Γ', Gamma1: 'Γ₁', Gamma2: 'Γ₂',
+      Delta: 'Δ', Theta: 'Θ', Lambda: 'Λ', Xi: 'Ξ',
+      Pi: 'Π', Sigma: 'Σ', Phi: 'Φ', Psi: 'Ψ',
+    };
+    const _swatchRow = document.createElement('div');
+    _swatchRow.className = 'spectre-swatch-row';
+    _swatchRow.id = 'spectre-palette-swatch-row';
+    const _swatchInputs: Record<string, HTMLInputElement> = {};
+    for (const label of _ALL_LABELS) {
+      const cell = document.createElement('label');
+      cell.className = 'spectre-swatch-cell';
+      cell.title = label;
+      const inp = document.createElement('input');
+      inp.type = 'color';
+      inp.className = 'spectre-swatch';
+      inp.value = paletteState.hex[label];
+      inp.addEventListener('input', () => {
+        paletteState.setHex(label, inp.value);
+        _updateClearValue();
+        viewerState.onViewChange?.(viewerState);
+        viewerState.requestFrame();
+        (window as any)._spectreSaveLocal?.();
+      });
+      _swatchInputs[label] = inp;
+      const glyph = document.createElement('span');
+      glyph.textContent = _SWATCH_GLYPH[label] ?? label;
+      cell.append(inp, glyph);
+      _swatchRow.append(cell);
+    }
+    function _syncSwatches() {
+      for (const label of _ALL_LABELS) {
+        if (_swatchInputs[label]) _swatchInputs[label].value = paletteState.hex[label];
+      }
+    }
+
     const _ctrlBtn = document.createElement('button');
     _ctrlBtn.type = 'button';
-    _ctrlBtn.textContent = 'Randomize colours';
-    _ctrlBtn.style.padding = '4px 12px';
-    _ctrlBtn.style.fontSize = '12px';
-    _ctrlBtn.style.cursor = 'pointer';
+    _ctrlBtn.textContent = 'Randomize';
+    _ctrlBtn.className = 'spectre-btn';
     const _ctrlSeed = document.createElement('input');
     _ctrlSeed.type = 'number';
     _ctrlSeed.min = '0';
     _ctrlSeed.value = String(paletteState.seed);
+    _ctrlSeed.className = 'spectre-input num-md';
     // Stable id so the video-export "Load config" button can sync this
     // input's displayed value when it programmatically changes the seed.
     _ctrlSeed.id = 'spectre-palette-seed-input';
-    _ctrlSeed.style.width = '80px';
-    _ctrlSeed.style.fontSize = '12px';
-    _ctrlSeed.style.padding = '2px 6px';
     function _updateClearValue() {
       // Average RGB across all 11 palette labels — used as the canvas's
       // clear colour so any uncovered pixels (sub-pixel gaps between
@@ -61,6 +296,7 @@
     function _applySeed(s: number) {
       paletteState.setSeed(s);
       _ctrlSeed.value = String(paletteState.seed);
+      _syncSwatches();
       _updateClearValue();
       // requestFrame just redraws the existing instance buffer with the
       // colours it already has. To pick up the new palette we need to
@@ -71,26 +307,341 @@
     }
     // Initial clear value at page load.
     _updateClearValue();
+    // Exposed so the video-export "Load config" button can refresh the
+    // swatches and clear colour after a programmatic palette change.
+    (window as any)._spectreSyncSwatches = () => {
+      _syncSwatches();
+      _updateClearValue();
+    };
     _ctrlBtn.addEventListener('click', () => {
       _applySeed(Math.floor(Math.random() * 99999));
+      (window as any)._spectreSaveLocal?.();
     });
     _ctrlSeed.addEventListener('input', () => {
       _applySeed(parseInt(_ctrlSeed.value, 10) || 0);
+      (window as any)._spectreSaveLocal?.();
     });
-    const _ctrlRow = document.createElement('div');
-    _ctrlRow.style.display = 'flex';
-    _ctrlRow.style.gap = '8px';
-    _ctrlRow.style.alignItems = 'center';
-    _ctrlRow.style.margin = '8px 0';
-    _ctrlRow.style.fontFamily = 'var(--sans-serif)';
     const _ctrlSeedLabel = document.createElement('label');
-    _ctrlSeedLabel.style.display = 'inline-flex';
-    _ctrlSeedLabel.style.gap = '6px';
-    _ctrlSeedLabel.style.alignItems = 'center';
-    _ctrlSeedLabel.style.fontSize = '12px';
-    _ctrlSeedLabel.append('seed ', _ctrlSeed);
+    _ctrlSeedLabel.className = 'spectre-checkbox';
+    const _ctrlSeedSpan = document.createElement('span');
+    _ctrlSeedSpan.className = 'spectre-label';
+    _ctrlSeedSpan.textContent = 'seed';
+    _ctrlSeedLabel.append(_ctrlSeedSpan, _ctrlSeed);
+    const _ctrlRow = document.createElement('div');
+    _ctrlRow.className = 'spectre-row';
     _ctrlRow.append(_ctrlBtn, _ctrlSeedLabel);
-    display(_ctrlRow);
+    const _paletteCard = document.createElement('div');
+    _paletteCard.className = 'spectre-card';
+    const _paletteHead = document.createElement('div');
+    _paletteHead.className = 'spectre-section-head';
+    const _paletteH = document.createElement('h4');
+    _paletteH.textContent = 'palette';
+    _paletteHead.append(_paletteH);
+    _paletteCard.append(_paletteHead, _swatchRow, _ctrlRow);
+    display(_paletteCard);
+  </script>
+
+  <script id="figure" type="text/x-typescript">
+    display(viewerExpandable);
+  </script>
+
+  <script id="find-distant-match" type="text/x-typescript">
+    // ─── Find a distant pattern-matching view ─────────────────────────
+    // For a given source view (the current viewport), find another world
+    // position whose local pattern is identical to the source within a
+    // radius determined by the suffix length K. Two leaves with the same
+    // K-suffix (last K geometry indices in the substitution path, same
+    // type at level K) sit inside identically-substituted level-K
+    // supertiles, so their local environments are byte-identical out to
+    // ~(2.45)^K world units.
+    type LeafAddress = {
+      path: number[];        // geom indices, root → leaf
+      types: TileName[];     // type at each meta level
+      rots: number[];        // accumulated world rot at each meta level
+      mirs: number[];        // accumulated world mirror at each meta level
+      leafCx: number;        // world X of the located leaf's centroid
+      leafCy: number;        // world Y of the located leaf's centroid
+    };
+    // Closest-child descent: always reaches a leaf (the one whose
+    // centroid is nearest to the target). Robust to floating-point
+    // precision at deep extension levels and to the case where the
+    // target is on a polygon boundary.
+    function _findLeafNear(targetX: number, targetY: number): LeafAddress | null {
+      let mt: any = walkerState.currentRoot;
+      let tx: any = walkerState.currentRootTransform;
+      if (mt.kind !== 'meta') return null;
+      const path: number[] = [];
+      const types: TileName[] = [mt.name];
+      const rots: number[] = [tx.rot];
+      const mirs: number[] = [tx.mirror];
+      while (mt.kind === 'meta') {
+        let bestI = -1, bestD = Infinity;
+        for (let i = 0; i < mt.geometries.length; i++) {
+          const geom = mt.geometries[i];
+          const child = geom.child;
+          const childTx = txCompose(tx, geom.transform);
+          const cx = (child as any)._cCx ?? 0;
+          const cy = (child as any)._cCy ?? 0;
+          const wc = txApply(childTx, [cx, cy]);
+          const d = Math.hypot(wc[0] - targetX, wc[1] - targetY);
+          if (d < bestD) { bestD = d; bestI = i; }
+        }
+        if (bestI < 0) break;
+        path.push(bestI);
+        const geom = mt.geometries[bestI];
+        tx = txCompose(tx, geom.transform);
+        mt = geom.child;
+        if (mt.kind === 'meta') {
+          types.push(mt.name as TileName);
+          rots.push(tx.rot);
+          mirs.push(tx.mirror);
+        }
+      }
+      // mt is the leaf — compute its world centroid for offset
+      // preservation in the caller.
+      const lcx = (mt as any)._cCx ?? 0;
+      const lcy = (mt as any)._cCy ?? 0;
+      const wc = txApply(tx, [lcx, lcy]);
+      return { path, types, rots, mirs, leafCx: wc[0], leafCy: wc[1] };
+    }
+
+    interface FindMatchResult { centerX: number; centerY: number; attempts: number }
+    function _findMatchingLeaf(args: {
+      sourceX: number; sourceY: number;
+      parentType: TileName;
+      parentRot: number;     // world rotation of source's level-K ancestor
+      parentMir: number;     // world mirror of source's level-K ancestor
+      parentSubLevel: number;
+      suffix: number[];
+      minDistance: number;
+      maxAttempts?: number;
+    }): FindMatchResult | null {
+      const root = walkerState.currentRoot;
+      const rootTransform = walkerState.currentRootTransform;
+      if (root.kind !== 'meta') return null;
+      const rootSubLevel = (root as any)._subLevel as number;
+      const stepsToParent = rootSubLevel - args.parentSubLevel;
+      if (stepsToParent < 0) return null;
+      const seed = ((Math.floor(args.sourceX) ^ Math.floor(args.sourceY)) >>> 0) || 1;
+      const rng = _makeSeededRng(seed);
+      const max = args.maxAttempts ?? 200000;
+      for (let attempt = 0; attempt < max; attempt++) {
+        let mt: any = root;
+        let tx: any = rootTransform;
+        let ok = true;
+        for (let d = 0; d < stepsToParent; d++) {
+          if (mt.kind !== 'meta') { ok = false; break; }
+          const i = Math.floor(rng() * mt.geometries.length);
+          const geom = mt.geometries[i];
+          tx = txCompose(tx, geom.transform);
+          mt = geom.child;
+        }
+        if (!ok || mt.kind !== 'meta' || mt.name !== args.parentType) continue;
+        // Match world orientation: same rot and mirror means the
+        // candidate's local pattern is in the same on-screen orientation
+        // as the source, not just congruent up to a rotation.
+        if (tx.rot !== args.parentRot || tx.mirror !== args.parentMir) continue;
+        // Apply suffix.
+        let suffOk = true;
+        for (const i of args.suffix) {
+          if (mt.kind !== 'meta' || i >= mt.geometries.length) { suffOk = false; break; }
+          const geom = mt.geometries[i];
+          tx = txCompose(tx, geom.transform);
+          mt = geom.child;
+        }
+        if (!suffOk || mt.kind !== 'leaf') continue;
+        const lcx = (mt as any)._cCx ?? 0;
+        const lcy = (mt as any)._cCy ?? 0;
+        const c = txApply(tx, [lcx, lcy]);
+        const dx = c[0] - args.sourceX, dy = c[1] - args.sourceY;
+        if (Math.hypot(dx, dy) < args.minDistance) continue;
+        return { centerX: c[0], centerY: c[1], attempts: attempt + 1 };
+      }
+      return null;
+    }
+
+    function _findDistantMatchForCurrentView(K: number, minDistance: number):
+      { result: FindMatchResult | null; sourceLeaf: LeafAddress | null } {
+      const v = viewerState.getView();
+      const sourceLeaf = _findLeafNear(v.centerX, v.centerY);
+      if (!sourceLeaf) return { result: null, sourceLeaf: null };
+      const D = sourceLeaf.path.length;
+      if (D < K) return { result: null, sourceLeaf };
+      const suffix = sourceLeaf.path.slice(D - K);
+      const idx = D - K;
+      const parentType = sourceLeaf.types[idx];
+      const parentRot = sourceLeaf.rots[idx];
+      const parentMir = sourceLeaf.mirs[idx];
+      const root = walkerState.currentRoot;
+      const rootSubLevel = (root as any)._subLevel as number;
+      const parentSubLevel = rootSubLevel - idx;
+      const result = _findMatchingLeaf({
+        sourceX: v.centerX, sourceY: v.centerY,
+        parentType, parentRot, parentMir, parentSubLevel,
+        suffix, minDistance,
+      });
+      return { result, sourceLeaf };
+    }
+
+    // Local button helper (keeps this cell self-contained — the
+    // video-export cell has its own _btn, but cross-cell helper sharing
+    // is brittle and this is two lines.)
+    function _fdmBtn(text: string, classes = '', title?: string): HTMLButtonElement {
+      const b = document.createElement('button');
+      b.textContent = text;
+      b.className = `spectre-btn ${classes}`.trim();
+      if (title) b.title = title;
+      return b;
+    }
+
+    const _loopRow = document.createElement('div');
+    _loopRow.className = 'spectre-card';
+    const _loopHead = document.createElement('div');
+    _loopHead.className = 'spectre-section-head';
+    const _loopH = document.createElement('h4');
+    _loopH.textContent = 'find distant match';
+    _loopHead.append(_loopH);
+    _loopRow.append(_loopHead);
+    const _loopHelp = document.createElement('details');
+    _loopHelp.className = 'spectre-help';
+    const _loopHelpSummary = document.createElement('summary');
+    _loopHelpSummary.textContent = 'how this works';
+    const _loopHelpBody = document.createElement('p');
+    _loopHelpBody.textContent =
+      'Locates a far-away spot whose local pattern matches the current view exactly, ' +
+      'useful for building a seamless looping zoom. Frame a view, click Find, then Go ' +
+      'to jump there; paste the output into a keyframe to use it as an endpoint. ' +
+      'Match depth is bounded by the supertile levels currently loaded around the view, ' +
+      'so if it fails, zoom out slightly (to extend the tree) or reduce depth / min dist.';
+    _loopHelp.append(_loopHelpSummary, _loopHelpBody);
+    _loopRow.append(_loopHelp);
+    const _loopControls = document.createElement('div');
+    _loopControls.className = 'spectre-row';
+
+    function _labeledInput(
+      label: string, type: string, value: string, cls: string, title: string,
+    ) {
+      const wrap = document.createElement('label');
+      wrap.className = 'spectre-checkbox';
+      const span = document.createElement('span');
+      span.className = 'spectre-label';
+      span.textContent = label;
+      const inp = document.createElement('input');
+      inp.type = type;
+      inp.value = value;
+      inp.className = `spectre-input ${cls}`.trim();
+      inp.title = title;
+      wrap.append(span, inp);
+      return { wrap, inp };
+    }
+    // K can be left as 'auto' (or 0/empty) to be derived from the current
+    // viewport's world extent. Match radius is ~2.45^K world units, so K
+    // needs to scale with how zoomed-out the user is.
+    const _kInput = _labeledInput(
+      'match depth', 'text', 'auto', 'num-sm',
+      'How many substitution levels of context the match must reproduce. ' +
+        'Match radius ≈ 2.45^depth world units. "auto" picks the smallest depth ' +
+        'whose radius comfortably exceeds the current viewport. ' +
+        'Capped by the supertile levels currently loaded around the view — ' +
+        'if no match is found, zoom out a bit (to load more levels) or lower the depth.',
+    );
+    const _minDistInput = _labeledInput(
+      'min dist', 'text', 'auto', 'num-md',
+      'Minimum world-units distance from current view to candidate. "auto" = current viewport diameter.',
+    );
+
+    const _matchBtn = _fdmBtn('Find distant match', 'primary');
+    const _matchOut = document.createElement('input');
+    _matchOut.type = 'text';
+    _matchOut.readOnly = true;
+    _matchOut.className = 'spectre-input grow';
+    _matchOut.placeholder = 'paste output into a keyframe';
+
+    const _matchGoBtn = _fdmBtn('Go', '', 'Jump the live view to the matched coordinates.');
+    _matchGoBtn.disabled = true;
+
+    // Separate status line so the output box stays cleanly copy-able.
+    const _matchStatus = document.createElement('span');
+    _matchStatus.className = 'spectre-mono';
+
+    function _autoK(viewPxW: number, pixelScale: number): number {
+      // Want 2.45^K >> viewport world diameter so the entire visible
+      // area is well inside the matching radius — and so a small
+      // offset drift after Go can't push the next-iteration source
+      // onto a *different* leaf with a different K-suffix. +2 gives
+      // ~6× headroom over the viewport extent.
+      const worldExtent = Math.max(1, viewPxW) / Math.max(1e-30, pixelScale);
+      return Math.max(2, Math.ceil(Math.log(worldExtent) / Math.log(2.45)) + 2);
+    }
+
+    type _FdmView = { centerX: number; centerY: number; pixelScale: number };
+    let _matchedView: _FdmView | null = null;
+    _matchBtn.addEventListener('click', () => {
+      const v = viewerState.getView();
+      const liveW = viewerState.pixelWidth || 1280;
+      // Resolve K: 'auto' / 0 / empty → derive from viewport.
+      let K = parseInt(_kInput.inp.value, 10);
+      if (!Number.isFinite(K) || K < 1) K = _autoK(liveW, v.pixelScale);
+      // Resolve min distance: 'auto' / empty → viewport world diameter.
+      let minDist = Number(_minDistInput.inp.value);
+      if (!Number.isFinite(minDist) || minDist < 0) {
+        minDist = liveW / Math.max(1e-30, v.pixelScale);
+      }
+      const t0 = performance.now();
+      const { result, sourceLeaf } = _findDistantMatchForCurrentView(K, minDist);
+      const ms = (performance.now() - t0).toFixed(0);
+      if (!sourceLeaf) {
+        _matchOut.value = '';
+        _matchStatus.textContent = 'could not locate source leaf at view center';
+        _matchedView = null;
+        _matchGoBtn.disabled = true;
+        return;
+      }
+      if (!result) {
+        _matchOut.value = '';
+        _matchStatus.textContent = `no match · depth=${K} · min dist=${minDist.toExponential(2)} · try lower depth, smaller min dist, or zoom out to load more levels`;
+        _matchedView = null;
+        _matchGoBtn.disabled = true;
+        return;
+      }
+      // Preserve the source view's offset from its own leaf's centroid:
+      // both source and matched leaves are at the same K-suffix path
+      // and share the same level-K ancestor world rotation, so their
+      // local environments are byte-identical. Setting the new view to
+      // (matchedLeaf.centroid + sourceOffset) reproduces what the user
+      // was looking at, just at the matched coordinates — instead of
+      // shifting the framing to the matched leaf's centroid.
+      const offX = v.centerX - sourceLeaf.leafCx;
+      const offY = v.centerY - sourceLeaf.leafCy;
+      _matchedView = {
+        centerX: result.centerX + offX,
+        centerY: result.centerY + offY,
+        pixelScale: v.pixelScale,
+      };
+      const radius = Math.pow(2.45, K);
+      _matchOut.value = `${_matchedView.pixelScale}/${_matchedView.centerX}/${_matchedView.centerY}`;
+      _matchStatus.textContent = `depth=${K} · r≈${radius.toExponential(1)} · ${result.attempts} attempts · ${ms}ms`;
+      _matchGoBtn.disabled = false;
+      // No auto-go: clicking "Find" again with the same view re-runs
+      // deterministically (same seeded RNG → same result). Click "Go"
+      // to inspect the match and use it as the next source.
+      // eslint-disable-next-line no-console
+      console.log('match found:', {
+        ...(_matchedView as any),
+        K, attempts: result.attempts, ms: +ms, matchRadius: radius,
+      });
+    });
+
+    _matchGoBtn.addEventListener('click', () => {
+      if (_matchedView) viewerState.setView(_matchedView);
+    });
+
+    _loopControls.append(_kInput.wrap, _minDistInput.wrap, _matchBtn, _matchOut, _matchGoBtn);
+    const _loopStatusRow = document.createElement('div');
+    _loopStatusRow.className = 'spectre-row';
+    _loopStatusRow.append(_matchStatus);
+    _loopRow.append(_loopControls, _loopStatusRow);
+    display(_loopRow);
   </script>
 
   <script id="gpu-context" type="text/x-typescript">
@@ -429,6 +980,7 @@
       hex: Record<string, string>;
       rgb: Record<string, [number, number, number]>;
       setSeed(seed: number): void;
+      setHex(label: string, hex: string): void;
     };
     const paletteState: PaletteState = {
       seed: 12345,
@@ -440,6 +992,11 @@
         for (const label of _ALL_LABELS) {
           this.rgb[label] = _hexToRgb(this.hex[label]);
         }
+      },
+      setHex(label: string, hex: string) {
+        if (!_ALL_LABELS.includes(label)) return;
+        this.hex[label] = hex;
+        this.rgb[label] = _hexToRgb(hex);
       },
     };
     paletteState.setSeed(paletteState.seed);
@@ -1391,7 +1948,9 @@
     })();
     function extendRootUpward() {
       const nextRecord = buildSupertiles(walkerState.currentBaseRecord);
-      const currentType = (walkerState.currentRoot as any).name as TileName;
+      const root = walkerState.currentRoot;
+      if (root.kind !== 'meta') throw new Error('root must be a meta tile');
+      const currentType = root.name;
       const opts = _PARENT_OPTIONS[currentType];
       // Cycle through options. The simple modulo is good enough; for
       // bottleneck types (Θ, Λ) opts.length === 1 and we always pick it.
@@ -1530,20 +2089,11 @@
     const _viewOutput = document.createElement('input');
     _viewOutput.type = 'text';
     _viewOutput.readOnly = true;
-    _viewOutput.style.flex = '1';
-    _viewOutput.style.minWidth = '0';
-    _viewOutput.style.fontFamily = 'var(--mono, monospace)';
-    _viewOutput.style.fontSize = '11px';
-    _viewOutput.style.padding = '2px 6px';
-    _viewOutput.title = 'Current view as JSON. Click to select, copy to share.';
-    _viewOutput.addEventListener('focus', () => _viewOutput.select());
+    _viewOutput.className = 'spectre-input grow';
+    _viewOutput.title = 'Current view as pixelScale/centerX/centerY.';
     function _formatView(): string {
       const v = viewerState.getView();
-      return JSON.stringify({
-        centerX: v.centerX,
-        centerY: v.centerY,
-        pixelScale: v.pixelScale,
-      });
+      return `${v.pixelScale}/${v.centerX}/${v.centerY}`;
     }
     function _refreshViewOutput() { _viewOutput.value = _formatView(); }
     // Wrap the existing onViewChange so each view update also refreshes
@@ -1558,18 +2108,17 @@
 
     const _viewInput = document.createElement('input');
     _viewInput.type = 'text';
-    _viewInput.placeholder = 'Paste view JSON to restore';
-    _viewInput.style.flex = '1';
-    _viewInput.style.minWidth = '0';
-    _viewInput.style.fontFamily = 'var(--mono, monospace)';
-    _viewInput.style.fontSize = '11px';
-    _viewInput.style.padding = '2px 6px';
+    _viewInput.placeholder = 'pixelScale/centerX/centerY';
+    _viewInput.className = 'spectre-input grow';
     _viewInput.addEventListener('change', () => {
-      try {
-        const parsed = JSON.parse(_viewInput.value);
-        viewerState.setView(parsed);
+      const parts = _viewInput.value.split('/');
+      const ps = parts.length === 3 ? Number(parts[0]) : NaN;
+      const cx = parts.length === 3 ? Number(parts[1]) : NaN;
+      const cy = parts.length === 3 ? Number(parts[2]) : NaN;
+      if (Number.isFinite(ps) && Number.isFinite(cx) && Number.isFinite(cy)) {
+        viewerState.setView({ pixelScale: ps, centerX: cx, centerY: cy });
         _viewInput.value = '';
-      } catch (e) {
+      } else {
         _viewInput.style.outline = '1px solid red';
         setTimeout(() => { _viewInput.style.outline = ''; }, 600);
       }
@@ -1579,14 +2128,15 @@
     // the moment the box was checked, so zooming in past the threshold
     // doesn't trigger refinement. Useful for inspecting a specific
     // aggregation level's geometry up close.
+    const _freezeWrap = document.createElement('label');
+    _freezeWrap.className = 'spectre-checkbox';
+    _freezeWrap.htmlFor = 'spectre-freeze';
     const _freezeCb = document.createElement('input');
     _freezeCb.type = 'checkbox';
     _freezeCb.id = 'spectre-freeze';
-    const _freezeLabel = document.createElement('label');
-    _freezeLabel.htmlFor = 'spectre-freeze';
-    _freezeLabel.textContent = 'freeze structure';
-    _freezeLabel.style.flex = '0 0 auto';
-    _freezeLabel.style.cursor = 'pointer';
+    const _freezeText = document.createElement('span');
+    _freezeText.textContent = 'freeze structure';
+    _freezeWrap.append(_freezeCb, _freezeText);
     _freezeCb.addEventListener('change', () => {
       freezeState.aggPixelScale = _freezeCb.checked ? viewerState.pixelScale : null;
       viewerState.onViewChange?.(viewerState);
@@ -1594,19 +2144,15 @@
     });
 
     const _viewRow = document.createElement('div');
-    _viewRow.style.display = 'flex';
-    _viewRow.style.gap = '8px';
-    _viewRow.style.alignItems = 'center';
+    _viewRow.className = 'spectre-row';
     _viewRow.style.margin = '8px 0';
-    _viewRow.style.fontFamily = 'var(--sans-serif)';
-    _viewRow.style.fontSize = '11px';
-    const _viewLabel1 = document.createElement('label');
-    _viewLabel1.textContent = 'view:';
-    _viewLabel1.style.flex = '0 0 auto';
-    const _viewLabel2 = document.createElement('label');
-    _viewLabel2.textContent = 'set:';
-    _viewLabel2.style.flex = '0 0 auto';
-    _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput, _freezeCb, _freezeLabel);
+    const _viewLabel1 = document.createElement('span');
+    _viewLabel1.className = 'spectre-label';
+    _viewLabel1.textContent = 'view';
+    const _viewLabel2 = document.createElement('span');
+    _viewLabel2.className = 'spectre-label';
+    _viewLabel2.textContent = 'set';
+    _viewRow.append(_viewLabel1, _viewOutput, _viewLabel2, _viewInput, _freezeWrap);
     display(_viewRow);
   </script>
 
@@ -1638,22 +2184,141 @@
     }
 
     type View = { centerX: number; centerY: number; pixelScale: number };
-    type Ease = 'linear' | 'cubic' | 'quintic';
-    type SegConfig = { sec: number; ease: Ease };
+    type Ease = 'linear' | 'sinusoidal' | 'cubic' | 'quintic';
+    // Each transition independently chooses smooth (van Wijk geodesic
+    // with auto duration) or legacy (manual `sec`, log-zoom + exponential
+    // pan). All parameters live per-segment so the user can mix
+    // approaches across a single trajectory.
+    type SegConfig = {
+      smooth: boolean;
+      sec: number;     // legacy: duration. Ignored when smooth.
+      ease: Ease;
+      speed: number;   // smooth-only (V).
+      rho: number;     // smooth-only (zoom-vs-pan tradeoff).
+    };
+    const _DEFAULT_SPEED = 0.9;
+    const _DEFAULT_RHO = Math.sqrt(2);
 
     function _easeFn(name: Ease): (t: number) => number {
-      // cubic = standard smoothstep (C¹ at endpoints).
+      // sinusoidal = (1 − cos πt) / 2. C∞, peak velocity π/2 ≈ 1.571.
+      // cubic = standard smoothstep (C¹ at endpoints), peak 1.5.
       // quintic = smootherstep (C² at endpoints — zero velocity AND zero
-      // acceleration). For a long zoom that starts/ends at rest, quintic
-      // is what makes the very-beginning and very-end feel smooth.
-      if (name === 'cubic')   return (t) => t * t * (3 - 2 * t);
-      if (name === 'quintic') return (t) => t * t * t * (t * (t * 6 - 15) + 10);
+      // acceleration), peak 1.875. For a long zoom that starts/ends at
+      // rest, quintic is what makes the very-beginning and very-end feel
+      // smooth, while sinusoidal stays closer to constant-velocity in
+      // the middle.
+      if (name === 'sinusoidal') return (t) => 0.5 - 0.5 * Math.cos(Math.PI * t);
+      if (name === 'cubic')      return (t) => t * t * (3 - 2 * t);
+      if (name === 'quintic')    return (t) => t * t * t * (t * (t * 6 - 15) + 10);
       return (t) => t;
     }
 
-    // Mutable trajectory state. Initial values are the user's debugging
-    // script (start → zoom-out → pan → zoom-in). The widget below mutates
-    // these in place; _recordVideo reads them at click time.
+    // ─── van Wijk & Nuij geodesic ─────────────────────────────────────
+    // Smooth and efficient zooming and panning, IEEE InfoVis 2003.
+    // The path between two views (c0, w0) → (c1, w1) is the geodesic of
+    // the metric ds² = (ρ²/w²) du² + (1/(ρ²w²)) dw², where u is pan
+    // distance along the line c0→c1 (world units) and w is the viewport
+    // width (world units, same units as u — this is the dimensional
+    // requirement of the metric: u/w is "pan in viewport widths" and
+    // dw/w is "e-folds of zoom"). We map our coordinates via
+    // w = refPxWidth / pixelScale (a true world width), where
+    // refPxWidth is the live canvas pixel width captured at the time
+    // the trajectory is built. The paper's recommended ρ=√2 only
+    // produces the documented behaviour with this dimensional setup.
+    // Free parameters: ρ (zoom-vs-pan tradeoff, recommended √2) and V
+    // (animation speed, paper user-study average 0.9). Total time = S/V.
+    type VwPath = {
+      S: number;
+      sample: (s: number) => View;
+    };
+    function _vanWijkPath(
+      c0: [number, number], ps0: number,
+      c1: [number, number], ps1: number,
+      rho: number, refPxWidth: number,
+    ): VwPath {
+      const w0 = refPxWidth / ps0;
+      const w1 = refPxWidth / ps1;
+      const dx = c1[0] - c0[0];
+      const dy = c1[1] - c0[1];
+      const U = Math.hypot(dx, dy);
+      const screenPan = U / Math.max(w0, w1);
+      // Identical-or-degenerate segment.
+      if (screenPan < 1e-9 && Math.abs(Math.log(w1 / w0)) < 1e-12) {
+        return {
+          S: 0,
+          sample: () => ({ centerX: c0[0], centerY: c0[1], pixelScale: ps0 }),
+        };
+      }
+      // Pure zoom: sub-pixel pan over the segment.
+      if (screenPan < 1e-9) {
+        const lnRatio = Math.log(w1 / w0);
+        const k = lnRatio < 0 ? -1 : 1;
+        const S = Math.abs(lnRatio) / rho;
+        return {
+          S,
+          sample: (s) => {
+            const w = w0 * Math.exp(k * rho * s);
+            return { centerX: c0[0], centerY: c0[1], pixelScale: refPxWidth / w };
+          },
+        };
+      }
+      // General case: equation (9) of the paper.
+      const dirX = dx / U;
+      const dirY = dy / U;
+      const rho2 = rho * rho;
+      const rho4 = rho2 * rho2;
+      const denom0 = 2 * w0 * rho2 * U;
+      const denom1 = 2 * w1 * rho2 * U;
+      const b0 = (w1 * w1 - w0 * w0 + rho4 * U * U) / denom0;
+      const b1 = (w1 * w1 - w0 * w0 - rho4 * U * U) / denom1;
+      // -asinh(b) is the numerically stable form of ln(-b + sqrt(b²+1));
+      // the paper's literal expression catastrophically cancels for large
+      // positive b (e.g., the user's 5e9× zoom segment has b₀ ≈ 5e11).
+      const r0 = -Math.asinh(b0);
+      const r1 = -Math.asinh(b1);
+      const S = (r1 - r0) / rho;
+      const w0_cosh_r0 = w0 * Math.cosh(r0);
+      const sinh_r0 = Math.sinh(r0);
+      const log_w0 = Math.log(w0);
+      const log_cosh_r0 = Math.log(Math.cosh(r0));
+      return {
+        S,
+        sample: (s) => {
+          const arg = rho * s + r0;
+          const u = (w0_cosh_r0 / rho2) * Math.tanh(arg)
+                  - (w0 / rho2) * sinh_r0;
+          // Compute log w then exponentiate; cosh(arg) can otherwise
+          // overflow at extreme zoom apex (paper's deepest segments).
+          const logCosh = arg < 0
+            ? Math.log(Math.cosh(arg))
+            : arg + Math.log(0.5 + 0.5 * Math.exp(-2 * arg));
+          const log_w = log_w0 + log_cosh_r0 - logCosh;
+          // pixelScale = refPxWidth / w = exp(log(refPxWidth) - log_w).
+          return {
+            centerX: c0[0] + dirX * u,
+            centerY: c0[1] + dirY * u,
+            pixelScale: refPxWidth * Math.exp(-log_w),
+          };
+        },
+      };
+    }
+
+    // ─── Trajectory state ──────────────────────────────────────────────
+    // Initial values are the user's debugging script (start → zoom-out →
+    // pan → zoom-in). The widget below mutates these in place;
+    // _recordVideo reads them at click time. Each segment carries its
+    // own smooth/legacy choice and parameters.
+    //
+    // Reference pixel width for the van Wijk metric. During preview we
+    // read viewerState.pixelWidth live; during capture we capture the
+    // live width into _vwRefWidthOverride before beginCapture overrides
+    // viewerState.pixelWidth, so the trajectory math stays referenced
+    // to the live canvas the user designed against.
+    let _vwRefWidthOverride: number | null = null;
+    function _vwRefWidth(): number {
+      const w = _vwRefWidthOverride ?? viewerState.pixelWidth;
+      return w > 0 ? w : 1; // fallback while canvas not yet sized
+    }
     const _kf: View[] = [
       { centerX: 62.90020681398703,        centerY: -69.41475882293156,    pixelScale: 159.57638576360853 },
       { centerX: -276309144.8722216,       centerY: 813097338.8738983,     pixelScale: 8.685921175201373e-8 },
@@ -1661,52 +2326,84 @@
       { centerX: 52651834944.69957,        centerY: 31501858022.634777,    pixelScale: 118.57227795600912 },
     ];
     const _seg: SegConfig[] = [
-      { sec: 6, ease: 'quintic' },
-      { sec: 4, ease: 'cubic' },
-      { sec: 6, ease: 'quintic' },
+      { smooth: false, sec: 6, ease: 'quintic', speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
+      { smooth: false, sec: 4, ease: 'cubic',   speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
+      { smooth: false, sec: 6, ease: 'quintic', speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO },
     ];
 
-    function _viewAt(frac: number): View {
-      // Map overall progress into a particular segment and apply that
-      // segment's local ease. Use quintic on the first/last segments to
-      // get a smooth video start/end (zero velocity AND zero acceleration
-      // at endpoints), and cubic or linear on interior segments to avoid
-      // visible pauses at intermediate keyframes.
-      //
-      // Pan interpolates in *log-pixelScale space*, not linearly. Linear
-      // world-coord pan during a logarithmic zoom-out shoots off-screen
-      // mid-segment (the camera covers ~half the world distance while
-      // pixelScale is still small, so half-distance × small-scale = many
-      // screen pixels). The exponential form below makes the pan's
-      // screen-pixel velocity constant under the simultaneous zoom:
-      //
-      //   p(t) = p₀ · (p₁/p₀)ᵗ          (log interp of pixelScale)
-      //   x(t) = x₀ + (x₁−x₀) · fac(t)
+    // For each segment, return its evaluated form: a duration in seconds
+    // and a sample(localT) function mapping local time ∈ [0, 1] → View.
+    // Smooth segments compute the van Wijk geodesic and scale by S/V;
+    // legacy segments use the user-set sec and the log-zoom +
+    // exponential-pan interpolation. Per-segment ease is applied to the
+    // local time so velocity zeros at every keyframe junction (no bounce
+    // between segments, regardless of whether each end is smooth).
+    type SegmentEval = {
+      duration: number;
+      sample: (localT: number) => View;
+    };
+    function _legacyInterp(a: View, b: View, t: number): View {
+      // Pan interpolates in log-pixelScale space so screen-pixel pan
+      // velocity stays constant under the simultaneous log-zoom:
       //   fac(t) = (1 − e^{−tL}) / (1 − e^{−L})   with L = ln(p₁/p₀)
-      //
       // fac(t) → t as L → 0, so pure-pan segments degenerate to linear.
-      const total = _seg.reduce((a, s) => a + s.sec, 0);
-      let elapsed = Math.max(0, Math.min(1, frac)) * total;
-      let prev = _kf[0];
-      for (let i = 0; i < _seg.length; i++) {
+      const p0 = a.pixelScale, p1 = b.pixelScale;
+      const L = Math.log(p1 / p0);
+      const fac = Math.abs(L) < 1e-6
+        ? t
+        : (1 - Math.exp(-t * L)) / (1 - Math.exp(-L));
+      return {
+        centerX: a.centerX + (b.centerX - a.centerX) * fac,
+        centerY: a.centerY + (b.centerY - a.centerY) * fac,
+        pixelScale: p0 * Math.exp(t * L),
+      };
+    }
+    function _buildSegments(): SegmentEval[] {
+      const out: SegmentEval[] = [];
+      const refW = _vwRefWidth();
+      for (let i = 0; i < _seg.length && i < _kf.length - 1; i++) {
         const s = _seg[i];
-        if (elapsed <= s.sec || i === _seg.length - 1) {
-          const lt = Math.max(0, Math.min(1, elapsed / s.sec));
-          const t = _easeFn(s.ease)(lt);
-          const next = _kf[i + 1];
-          const p0 = prev.pixelScale, p1 = next.pixelScale;
-          const L = Math.log(p1 / p0);
-          const fac = Math.abs(L) < 1e-6
-            ? t
-            : (1 - Math.exp(-t * L)) / (1 - Math.exp(-L));
-          return {
-            centerX: prev.centerX + (next.centerX - prev.centerX) * fac,
-            centerY: prev.centerY + (next.centerY - prev.centerY) * fac,
-            pixelScale: p0 * Math.exp(t * L),
-          };
+        const a = _kf[i], b = _kf[i + 1];
+        const ease = _easeFn(s.ease);
+        if (s.smooth) {
+          const path = _vanWijkPath(
+            [a.centerX, a.centerY], a.pixelScale,
+            [b.centerX, b.centerY], b.pixelScale,
+            s.rho, refW,
+          );
+          const speed = s.speed > 0 ? s.speed : _DEFAULT_SPEED;
+          const duration = path.S / speed;
+          out.push({
+            duration,
+            sample: (lt) => path.sample(ease(Math.max(0, Math.min(1, lt))) * path.S),
+          });
+        } else {
+          out.push({
+            duration: Math.max(0, s.sec),
+            sample: (lt) => _legacyInterp(a, b, ease(Math.max(0, Math.min(1, lt)))),
+          });
         }
-        elapsed -= s.sec;
-        prev = _kf[i + 1];
+      }
+      return out;
+    }
+
+    function _trajectoryTotalSec(): number {
+      return _buildSegments().reduce((acc, s) => acc + s.duration, 0);
+    }
+
+    function _viewAt(frac: number): View {
+      const segs = _buildSegments();
+      const total = segs.reduce((acc, s) => acc + s.duration, 0);
+      if (total === 0) return _kf[0];
+      let elapsed = Math.max(0, Math.min(1, frac)) * total;
+      for (let i = 0; i < segs.length; i++) {
+        const s = segs[i];
+        if (s.duration === 0) continue;
+        if (elapsed <= s.duration || i === segs.length - 1) {
+          const lt = Math.max(0, Math.min(1, elapsed / s.duration));
+          return s.sample(lt);
+        }
+        elapsed -= s.duration;
       }
       return _kf[_kf.length - 1];
     }
@@ -1743,7 +2440,16 @@
       const wR = w / liveW, hR = h / liveH;
       const psScale = opts.fitMode === 'fit' ? Math.min(wR, hR) : Math.max(wR, hR);
 
-      const totalSec = _seg.reduce((a, s) => a + s.sec, 0);
+      // Pin the van Wijk reference width to the *live* canvas so the
+      // trajectory shape and arc lengths stay tied to what the user
+      // designed against, not to whatever beginCapture overrides
+      // viewerState.pixelWidth to during the loop.
+      _vwRefWidthOverride = liveW;
+      const totalSec = _trajectoryTotalSec();
+      if (!(totalSec > 0)) {
+        _vwRefWidthOverride = null;
+        throw new Error('trajectory has zero length');
+      }
       const totalFrames = Math.max(2, Math.round(totalSec * opts.fps));
       const savedView = viewerState.getView();
 
@@ -1803,6 +2509,7 @@
         enc.delete();
         (viewerState as any).endCapture();
         viewerState.setView(savedView);
+        _vwRefWidthOverride = null;
       }
     }
 
@@ -1811,245 +2518,325 @@
     // pixelScale). Text inputs (not type="number") so scientific
     // notation round-trips cleanly through Number(); also avoids a
     // browser-side spinner on huge values like 5.2e10.
-    function _viewInput(value: number, w: string): HTMLInputElement {
-      const inp = document.createElement('input');
-      inp.type = 'text';
-      inp.value = String(value);
-      inp.style.flex = '1';
-      inp.style.minWidth = w;
-      inp.style.fontFamily = 'var(--mono, monospace)';
-      inp.style.fontSize = '10px';
-      inp.style.padding = '2px 4px';
-      return inp;
-    }
-    function _smallBtn(text: string, title?: string): HTMLButtonElement {
+    // Small DOM helpers for the keyframe widget.
+    function _btn(text: string, classes = '', title?: string): HTMLButtonElement {
       const b = document.createElement('button');
       b.textContent = text;
+      b.className = `spectre-btn ${classes}`.trim();
       if (title) b.title = title;
-      b.style.padding = '2px 6px';
-      b.style.fontSize = '11px';
-      b.style.fontFamily = 'var(--sans-serif)';
       return b;
+    }
+    function _label(text: string): HTMLSpanElement {
+      const s = document.createElement('span');
+      s.className = 'spectre-label';
+      s.textContent = text;
+      return s;
+    }
+    function _easeSelect(initial: Ease, onChange: (e: Ease) => void): HTMLSelectElement {
+      const sel = document.createElement('select');
+      sel.className = 'spectre-select';
+      for (const name of ['linear', 'sinusoidal', 'cubic', 'quintic'] as Ease[]) {
+        const opt = document.createElement('option');
+        opt.value = name; opt.textContent = name;
+        if (initial === name) opt.selected = true;
+        sel.append(opt);
+      }
+      sel.addEventListener('change', () => onChange(sel.value as Ease));
+      return sel;
     }
 
     const _kfContainer = document.createElement('div');
-    _kfContainer.style.display = 'flex';
-    _kfContainer.style.flexDirection = 'column';
-    _kfContainer.style.gap = '4px';
-    _kfContainer.style.margin = '8px 0';
-    _kfContainer.style.fontFamily = 'var(--sans-serif)';
-    _kfContainer.style.fontSize = '11px';
+    _kfContainer.className = 'spectre-card';
 
     function _rebuildKfWidget(): void {
       _kfContainer.innerHTML = '';
+      const head = document.createElement('div');
+      head.className = 'spectre-section-head';
+      const h = document.createElement('h4');
+      h.textContent = 'trajectory';
+      head.append(h);
+      _kfContainer.append(head);
+
       for (let i = 0; i < _kf.length; i++) {
-        // Keyframe row.
+        // ── Keyframe row ──────────────────────────────────────────────
         const kfRow = document.createElement('div');
-        kfRow.style.display = 'flex';
-        kfRow.style.gap = '6px';
-        kfRow.style.alignItems = 'center';
+        kfRow.className = 'spectre-kf-row';
 
-        const idx = document.createElement('span');
-        idx.textContent = `KF${i}`;
-        idx.style.flex = '0 0 28px';
-        idx.style.fontFamily = 'var(--mono, monospace)';
-        idx.style.fontWeight = 'bold';
+        const tag = document.createElement('span');
+        tag.className = 'spectre-tag';
+        tag.textContent = `KF${i}`;
 
-        const cxLbl = document.createElement('span'); cxLbl.textContent = 'cx';
-        const cyLbl = document.createElement('span'); cyLbl.textContent = 'cy';
-        const psLbl = document.createElement('span'); psLbl.textContent = 'ps';
-        for (const lbl of [cxLbl, cyLbl, psLbl]) {
-          lbl.style.flex = '0 0 auto';
-          lbl.style.opacity = '0.6';
+        const posInp = document.createElement('input');
+        posInp.type = 'text';
+        posInp.className = 'spectre-input grow';
+        posInp.value = `${_kf[i].pixelScale}/${_kf[i].centerX}/${_kf[i].centerY}`;
+        posInp.title = 'pixelScale / centerX / centerY';
+
+        function _setKfFromString(s: string): boolean {
+          const parts = s.split('/');
+          if (parts.length !== 3) return false;
+          const ps = Number(parts[0]);
+          const cx = Number(parts[1]);
+          const cy = Number(parts[2]);
+          if (!(Number.isFinite(ps) && Number.isFinite(cx) && Number.isFinite(cy))) {
+            return false;
+          }
+          _kf[i] = { pixelScale: ps, centerX: cx, centerY: cy };
+          return true;
         }
-        const cxInp = _viewInput(_kf[i].centerX,    '120px');
-        const cyInp = _viewInput(_kf[i].centerY,    '120px');
-        const psInp = _viewInput(_kf[i].pixelScale, '90px');
-        const _bind = (inp: HTMLInputElement, key: 'centerX' | 'centerY' | 'pixelScale') => {
-          inp.addEventListener('change', () => {
-            const v = Number(inp.value);
-            if (Number.isFinite(v)) { _kf[i][key] = v; inp.style.outline = ''; }
-            else                     { inp.style.outline = '1px solid red'; }
-          });
-        };
-        _bind(cxInp, 'centerX'); _bind(cyInp, 'centerY'); _bind(psInp, 'pixelScale');
+        function _writeKfToInput(): void {
+          posInp.value = `${_kf[i].pixelScale}/${_kf[i].centerX}/${_kf[i].centerY}`;
+        }
+        posInp.addEventListener('change', () => {
+          if (_setKfFromString(posInp.value)) {
+            posInp.style.outline = '';
+            _rebuildKfWidget();
+            _refreshTotalLabel();
+          } else {
+            posInp.style.outline = '1px solid #d04848';
+          }
+        });
 
-        const captureBtn = _smallBtn('grab', 'set this keyframe to the current view');
+        const captureBtn = _btn('grab', '', 'set this keyframe to the current view');
         captureBtn.addEventListener('click', () => {
           _kf[i] = viewerState.getView();
-          cxInp.value = String(_kf[i].centerX);
-          cyInp.value = String(_kf[i].centerY);
-          psInp.value = String(_kf[i].pixelScale);
-          for (const inp of [cxInp, cyInp, psInp]) inp.style.outline = '';
+          _writeKfToInput();
+          posInp.style.outline = '';
+          _rebuildKfWidget();
+          _refreshTotalLabel();
         });
-        const gotoBtn = _smallBtn('go', 'jump the live view to this keyframe');
+        const gotoBtn = _btn('go', '', 'jump the live view to this keyframe');
         gotoBtn.addEventListener('click', () => {
           viewerState.setView(_kf[i]);
         });
-        const removeBtn = _smallBtn('×', 'remove this keyframe');
+        const removeBtn = _btn('×', 'icon danger', 'remove this keyframe');
         removeBtn.disabled = _kf.length <= 2;
         removeBtn.addEventListener('click', () => {
           if (_kf.length <= 2) return;
           _kf.splice(i, 1);
-          // Drop the segment that fed this keyframe (or the last one if i=0).
           const segIdx = i === 0 ? 0 : i - 1;
           _seg.splice(segIdx, 1);
           _rebuildKfWidget();
+          _refreshTotalLabel();
         });
 
-        kfRow.append(idx, cxLbl, cxInp, cyLbl, cyInp, psLbl, psInp, captureBtn, gotoBtn, removeBtn);
+        kfRow.append(tag, posInp, captureBtn, gotoBtn, removeBtn);
         _kfContainer.append(kfRow);
 
-        // Segment row (between this kf and the next, if any).
+        // ── Segment (transition to next keyframe) ─────────────────────
         if (i < _kf.length - 1) {
+          const seg = _seg[i];
+          const segWrap = document.createElement('div');
+          segWrap.className = 'spectre-seg' + (seg.smooth ? ' is-smooth' : '');
+
           const sRow = document.createElement('div');
-          sRow.style.display = 'flex';
-          sRow.style.gap = '6px';
-          sRow.style.alignItems = 'center';
-          sRow.style.paddingLeft = '34px';
-          sRow.style.opacity = '0.85';
+          sRow.className = 'spectre-seg-row';
 
-          const arrow = document.createElement('span');
-          arrow.textContent = '↓';
-          arrow.style.flex = '0 0 14px';
-
-          const durLbl = document.createElement('span');
-          durLbl.textContent = 'sec';
-          const dur = document.createElement('input');
-          dur.type = 'number';
-          dur.step = '0.1';
-          dur.value = String(_seg[i].sec);
-          dur.style.width = '60px';
-          dur.style.fontFamily = 'var(--mono, monospace)';
-          dur.style.fontSize = '11px';
-          dur.style.padding = '2px 4px';
-          dur.addEventListener('change', () => {
-            const v = +dur.value;
-            if (Number.isFinite(v) && v > 0) _seg[i].sec = v;
+          // Smooth checkbox.
+          const smLbl = document.createElement('label');
+          smLbl.className = 'spectre-checkbox';
+          const smCb = document.createElement('input');
+          smCb.type = 'checkbox';
+          smCb.checked = seg.smooth;
+          smCb.title = 'Smooth (van Wijk geodesic, auto-duration). Off = legacy log-zoom + exponential pan with manual sec.';
+          const smTxt = document.createElement('span');
+          smTxt.textContent = 'smooth';
+          smLbl.append(smCb, smTxt);
+          smCb.addEventListener('change', () => {
+            seg.smooth = smCb.checked;
+            _rebuildKfWidget();
+            _refreshTotalLabel();
           });
 
-          const eaLbl = document.createElement('span');
-          eaLbl.textContent = 'ease';
-          const ea = document.createElement('select');
-          ea.style.fontSize = '11px';
-          for (const name of ['linear', 'cubic', 'quintic'] as Ease[]) {
-            const opt = document.createElement('option');
-            opt.value = name; opt.textContent = name;
-            if (_seg[i].ease === name) opt.selected = true;
-            ea.append(opt);
-          }
-          ea.addEventListener('change', () => { _seg[i].ease = ea.value as Ease; });
+          const easeSel = _easeSelect(seg.ease, (e) => { seg.ease = e; _saveLocal(); });
 
-          const insertBtn = _smallBtn('+', 'insert a keyframe here (current view)');
+          sRow.append(smLbl);
+
+          if (seg.smooth) {
+            const vInp = document.createElement('input');
+            vInp.type = 'number'; vInp.step = '0.1';
+            vInp.value = String(seg.speed);
+            vInp.className = 'spectre-input num-sm';
+            vInp.title = 'V — speed (segment time = arc length / V)';
+            vInp.addEventListener('change', () => {
+              const v = +vInp.value;
+              if (Number.isFinite(v) && v > 0) {
+                seg.speed = v;
+                _rebuildKfWidget();
+                _refreshTotalLabel();
+              }
+            });
+            const rInp = document.createElement('input');
+            rInp.type = 'number'; rInp.step = '0.1';
+            rInp.value = String(seg.rho);
+            rInp.className = 'spectre-input num-sm';
+            rInp.title = 'ρ — zoom-vs-pan tradeoff (paper recommends √2)';
+            rInp.addEventListener('change', () => {
+              const v = +rInp.value;
+              if (Number.isFinite(v) && v > 0) {
+                seg.rho = v;
+                _rebuildKfWidget();
+                _refreshTotalLabel();
+              }
+            });
+
+            const a = _kf[i], b = _kf[i + 1];
+            const p = _vanWijkPath(
+              [a.centerX, a.centerY], a.pixelScale,
+              [b.centerX, b.centerY], b.pixelScale,
+              seg.rho, _vwRefWidth(),
+            );
+            const auto = document.createElement('span');
+            auto.className = 'spectre-mono';
+            auto.textContent = `${(p.S / seg.speed).toFixed(2)} s  (S=${p.S.toFixed(2)})`;
+
+            sRow.append(_label('V'), vInp, _label('ρ'), rInp, _label('ease'), easeSel, auto);
+          } else {
+            const dur = document.createElement('input');
+            dur.type = 'number'; dur.step = '0.1';
+            dur.value = String(seg.sec);
+            dur.className = 'spectre-input num-sm';
+            dur.addEventListener('change', () => {
+              const v = +dur.value;
+              if (Number.isFinite(v) && v > 0) seg.sec = v;
+              _refreshTotalLabel();
+            });
+            sRow.append(_label('sec'), dur, _label('ease'), easeSel);
+          }
+
+          // Spacer + insert button at right end.
+          const div = document.createElement('hr');
+          div.className = 'spectre-divider';
+          const insertBtn = _btn('+ insert', 'icon', 'insert a keyframe here (current view)');
           insertBtn.addEventListener('click', () => {
             _kf.splice(i + 1, 0, viewerState.getView());
-            _seg.splice(i + 1, 0, { sec: 1, ease: 'linear' });
-            // Halve the existing segment's duration so total time is preserved.
-            _seg[i].sec = Math.max(0.1, _seg[i].sec / 2);
-            _seg[i + 1].sec = _seg[i].sec;
+            _seg.splice(i + 1, 0, {
+              smooth: seg.smooth,
+              sec: 1, ease: seg.ease,
+              speed: seg.speed, rho: seg.rho,
+            });
+            seg.sec = Math.max(0.1, seg.sec / 2);
+            _seg[i + 1].sec = seg.sec;
             _rebuildKfWidget();
+            _refreshTotalLabel();
           });
+          sRow.append(div, insertBtn);
 
-          sRow.append(arrow, durLbl, dur, eaLbl, ea, insertBtn);
-          _kfContainer.append(sRow);
+          segWrap.append(sRow);
+          _kfContainer.append(segWrap);
         }
       }
 
-      // Append-keyframe button at the bottom.
+      // Append-keyframe button.
       const tail = document.createElement('div');
-      tail.style.display = 'flex';
-      tail.style.gap = '6px';
-      tail.style.paddingLeft = '34px';
-      const appendBtn = _smallBtn('+ append keyframe (current view)');
+      tail.className = 'spectre-row';
+      tail.style.marginTop = '4px';
+      const appendBtn = _btn('+ append keyframe', '', 'append a keyframe at the current view');
       appendBtn.addEventListener('click', () => {
         _kf.push(viewerState.getView());
-        _seg.push({ sec: 2, ease: 'linear' });
+        const prev = _seg[_seg.length - 1];
+        _seg.push(prev
+          ? { smooth: prev.smooth, sec: 2, ease: prev.ease, speed: prev.speed, rho: prev.rho }
+          : { smooth: false, sec: 2, ease: 'linear', speed: _DEFAULT_SPEED, rho: _DEFAULT_RHO });
         _rebuildKfWidget();
+        _refreshTotalLabel();
       });
       tail.append(appendBtn);
       _kfContainer.append(tail);
     }
     _rebuildKfWidget();
 
-    // ─── Render-action row ────────────────────────────────────────────
-    function _numInput(label: string, value: number, w = '64px') {
+    // ─── Render config + actions ──────────────────────────────────────
+    function _numInput(label: string, value: number, cls = 'num') {
       const wrap = document.createElement('label');
-      wrap.style.display = 'inline-flex';
-      wrap.style.gap = '4px';
-      wrap.style.alignItems = 'center';
-      const span = document.createElement('span'); span.textContent = label;
+      wrap.className = 'spectre-checkbox';
+      const span = document.createElement('span');
+      span.className = 'spectre-label';
+      span.textContent = label;
       const inp = document.createElement('input');
       inp.type = 'number'; inp.value = String(value);
-      inp.style.width = w; inp.style.fontFamily = 'var(--mono, monospace)';
-      inp.style.fontSize = '11px'; inp.style.padding = '2px 4px';
+      inp.className = `spectre-input ${cls}`.trim();
       wrap.append(span, inp);
       return { wrap, inp };
     }
 
-    const _w    = _numInput('w',     1280);
-    const _h    = _numInput('h',      720);
-    const _fps  = _numInput('fps',     30);
-    const _qp   = _numInput('qp',      24);
-    const _samp = _numInput('samples',  1);
+    const _w    = _numInput('w',     1280, 'num-md');
+    const _h    = _numInput('h',      720, 'num-md');
+    const _fps  = _numInput('fps',     30, 'num-sm');
+    const _qp   = _numInput('qp',      24, 'num-sm');
+    const _samp = _numInput('samples',  1, 'num-sm');
+    for (const i of [_w, _h, _fps, _qp, _samp]) {
+      i.inp.addEventListener('change', () => _saveLocal());
+    }
+
+    // Live-updating total-trajectory-time label.
+    const _totalLabel = document.createElement('span');
+    _totalLabel.className = 'spectre-mono';
+    function _refreshTotalLabel(): void {
+      const t = _trajectoryTotalSec();
+      _totalLabel.textContent = `total: ${t.toFixed(2)} s`;
+      // Almost every keyframe / segment mutation calls this; the
+      // exceptions are patched explicitly below.
+      _saveLocal();
+    }
 
     // fit  — captures everything the live canvas showed (extra context on
     //        the off-axis if the capture aspect differs).
     // fill — content stays at its live on-screen size; if capture aspect
     //        differs, the off-axis gets cropped vs. live.
     const _fitWrap = document.createElement('label');
-    _fitWrap.style.display = 'inline-flex';
-    _fitWrap.style.gap = '4px';
-    _fitWrap.style.alignItems = 'center';
+    _fitWrap.className = 'spectre-checkbox';
     const _fitSpan = document.createElement('span');
+    _fitSpan.className = 'spectre-label';
     _fitSpan.textContent = 'frame';
     const _fitSel = document.createElement('select');
-    _fitSel.style.fontSize = '11px';
+    _fitSel.className = 'spectre-select';
     for (const mode of ['fill', 'fit']) {
       const o = document.createElement('option');
       o.value = mode; o.textContent = mode;
       _fitSel.append(o);
     }
+    _fitSel.addEventListener('change', () => _saveLocal());
     _fitWrap.append(_fitSpan, _fitSel);
 
     // Cull-pad slider: extra viewport padding (CSS pixels) before the
-    // walker tests each cell against the AABB. Higher = let through more
-    // off-screen geometry → less chance of background bleeding in at the
-    // viewport edges, at the cost of a larger cell count and slower walks.
-    // Default 0 keeps live interaction at current speed; bump it during
-    // a recording session if you spot blanks.
+    // walker tests each cell against the AABB.
     const _cullWrap = document.createElement('label');
-    _cullWrap.style.display = 'inline-flex';
-    _cullWrap.style.gap = '4px';
-    _cullWrap.style.alignItems = 'center';
+    _cullWrap.className = 'spectre-checkbox';
     const _cullLabel = document.createElement('span');
+    _cullLabel.className = 'spectre-label';
     _cullLabel.textContent = 'cull pad';
     const _cullSlider = document.createElement('input');
     _cullSlider.type = 'range';
     _cullSlider.min = '0'; _cullSlider.max = '500'; _cullSlider.step = '5';
     _cullSlider.value = '0';
-    _cullSlider.style.width = '120px';
+    _cullSlider.className = 'spectre-cull-slider';
     const _cullVal = document.createElement('span');
-    _cullVal.textContent = '0 px';
-    _cullVal.style.fontFamily = 'var(--mono, monospace)';
+    _cullVal.className = 'spectre-mono';
     _cullVal.style.minWidth = '44px';
+    _cullVal.textContent = '0 px';
     _cullSlider.addEventListener('input', () => {
       const v = +_cullSlider.value;
       cullState.padPx = v;
       _cullVal.textContent = `${v} px`;
-      // Live-rebuild so the user can see the effect at the current zoom.
       repackInstances();
       viewerState.requestFrame();
+      _saveLocal();
     });
     _cullWrap.append(_cullLabel, _cullSlider, _cullVal);
 
     // ─── Save / load entire config (palette + keyframes + video opts) ──
     function _gatherConfig() {
       return {
-        palette: { seed: paletteState.seed },
+        version: 3,
+        palette: { seed: paletteState.seed, hex: { ...paletteState.hex } },
         keyframes: _kf.map((k) => ({
           centerX: k.centerX, centerY: k.centerY, pixelScale: k.pixelScale,
         })),
-        segments: _seg.map((s) => ({ sec: s.sec, ease: s.ease })),
+        segments: _seg.map((s) => ({
+          smooth: s.smooth, sec: s.sec, ease: s.ease,
+          speed: s.speed, rho: s.rho,
+        })),
         video: {
           width:    +_w.inp.value,
           height:   +_h.inp.value,
@@ -2068,6 +2855,17 @@
         // displayed value reflects the loaded seed.
         const seedInput = document.getElementById('spectre-palette-seed-input') as HTMLInputElement | null;
         if (seedInput) seedInput.value = String(paletteState.seed);
+      }
+      if (cfg.palette?.hex && typeof cfg.palette.hex === 'object') {
+        for (const label of Object.keys(cfg.palette.hex)) {
+          const v = cfg.palette.hex[label];
+          if (typeof v === 'string' && /^#[0-9a-f]{6}$/i.test(v)) {
+            paletteState.setHex(label, v);
+          }
+        }
+      }
+      if (cfg.palette) {
+        (window as any)._spectreSyncSwatches?.();
         // Trigger a fresh repack so the new colours land.
         viewerState.onViewChange?.(viewerState);
       }
@@ -2079,14 +2877,51 @@
           });
         }
       }
+      // Determine v2 motion defaults once so we can broadcast them onto
+      // each segment when migrating a v2 config (where smooth/V/ρ/ease
+      // were global).
+      const v2Smooth = cfg.version === 2 && cfg.motion?.useVanWijk === true;
+      const v2Speed = cfg.version === 2 && Number.isFinite(+cfg.motion?.speed) && +cfg.motion.speed > 0
+        ? +cfg.motion.speed : _DEFAULT_SPEED;
+      const v2Rho = cfg.version === 2 && Number.isFinite(+cfg.motion?.rho) && +cfg.motion.rho > 0
+        ? +cfg.motion.rho : _DEFAULT_RHO;
+      const v2EaseRaw = cfg.version === 2 ? (cfg.motion?.ease ?? cfg.motion?.globalEase) : null;
+      const v2Ease: Ease = (v2EaseRaw === 'linear' || v2EaseRaw === 'sinusoidal'
+                          || v2EaseRaw === 'cubic'  || v2EaseRaw === 'quintic')
+        ? v2EaseRaw : 'quintic';
       if (Array.isArray(cfg.segments) && cfg.segments.length === _kf.length - 1) {
         _seg.length = 0;
         for (const s of cfg.segments) {
-          _seg.push({
-            sec: +s.sec,
-            ease: (s.ease === 'linear' || s.ease === 'cubic' || s.ease === 'quintic')
-              ? s.ease : 'linear',
-          });
+          const ease: Ease = (s.ease === 'linear' || s.ease === 'sinusoidal'
+                            || s.ease === 'cubic'  || s.ease === 'quintic')
+            ? s.ease : 'linear';
+          if (cfg.version === 3) {
+            _seg.push({
+              smooth: !!s.smooth,
+              sec: Number.isFinite(+s.sec) ? +s.sec : 2,
+              ease,
+              speed: Number.isFinite(+s.speed) && +s.speed > 0 ? +s.speed : _DEFAULT_SPEED,
+              rho:   Number.isFinite(+s.rho)   && +s.rho   > 0 ? +s.rho   : _DEFAULT_RHO,
+            });
+          } else if (cfg.version === 2) {
+            // v2: per-segment sec + ease, plus globally-defined motion.
+            _seg.push({
+              smooth: v2Smooth,
+              sec: Number.isFinite(+s.sec) ? +s.sec : 2,
+              ease: v2Smooth ? v2Ease : ease,
+              speed: v2Speed,
+              rho: v2Rho,
+            });
+          } else {
+            // v1: legacy only.
+            _seg.push({
+              smooth: false,
+              sec: Number.isFinite(+s.sec) ? +s.sec : 2,
+              ease,
+              speed: _DEFAULT_SPEED,
+              rho: _DEFAULT_RHO,
+            });
+          }
         }
       }
       if (cfg.video) {
@@ -2105,12 +2940,43 @@
         }
       }
       _rebuildKfWidget();
+      _refreshTotalLabel();
       viewerState.requestFrame();
     }
-    const _saveBtn = document.createElement('button');
-    _saveBtn.textContent = 'Save config';
-    _saveBtn.style.padding = '4px 10px';
-    _saveBtn.style.fontSize = '11px';
+
+    // ─── localStorage persistence ─────────────────────────────────────
+    // Auto-save the config on every mutation (debounced) and restore on
+    // page load. The user's manual Save / Load buttons remain for
+    // sharing or backups; this just keeps your in-progress work alive
+    // across page reloads without you having to think about it.
+    const _LS_KEY = 'spectre-infinite-config-v1';
+    let _isLoading = false;
+    let _saveTimer: any = null;
+    function _saveLocal(): void {
+      if (_isLoading) return;
+      if (_saveTimer != null) clearTimeout(_saveTimer);
+      _saveTimer = setTimeout(() => {
+        _saveTimer = null;
+        try {
+          localStorage.setItem(_LS_KEY, JSON.stringify(_gatherConfig()));
+        } catch (_e) { /* private mode / quota / disabled */ }
+      }, 250);
+    }
+    function _loadLocal(): boolean {
+      try {
+        const raw = localStorage.getItem(_LS_KEY);
+        if (!raw) return false;
+        const cfg = JSON.parse(raw);
+        _isLoading = true;
+        try { _applyConfig(cfg); } finally { _isLoading = false; }
+        return true;
+      } catch (_e) { return false; }
+    }
+    // Cross-cell trigger so the palette-controls cell can save without
+    // a direct cell-to-cell function reference.
+    (window as any)._spectreSaveLocal = _saveLocal;
+
+    const _saveBtn = _btn('Save config');
     _saveBtn.addEventListener('click', () => {
       const cfg = _gatherConfig();
       const blob = new Blob([JSON.stringify(cfg, null, 2)], { type: 'application/json' });
@@ -2120,10 +2986,7 @@
       document.body.appendChild(a); a.click(); a.remove();
       setTimeout(() => URL.revokeObjectURL(url), 5000);
     });
-    const _loadBtn = document.createElement('button');
-    _loadBtn.textContent = 'Load config';
-    _loadBtn.style.padding = '4px 10px';
-    _loadBtn.style.fontSize = '11px';
+    const _loadBtn = _btn('Load config');
     const _loadInput = document.createElement('input');
     _loadInput.type = 'file';
     _loadInput.accept = 'application/json,.json';
@@ -2144,21 +3007,54 @@
     });
     _loadBtn.addEventListener('click', () => _loadInput.click());
 
-    const _btn = document.createElement('button');
-    _btn.textContent = 'Render mp4';
-    _btn.style.padding = '4px 10px';
-    _btn.style.fontFamily = 'var(--sans-serif)';
-    _btn.style.fontSize = '11px';
+    // ─── Run (preview) ─────────────────────────────────────────────────
+    // Animates the trajectory live in the viewport canvas using
+    // requestAnimationFrame, ignoring `samples` (no supersampling) and
+    // skipping the encoder. Useful for previewing the keyframe sequence
+    // before committing to a long render. Click again to stop.
+    let _previewRaf: number | null = null;
+    const _runBtn = _btn('Run', 'primary');
+    function _stopPreview(): void {
+      if (_previewRaf != null) {
+        cancelAnimationFrame(_previewRaf);
+        _previewRaf = null;
+      }
+      _runBtn.textContent = 'Run';
+    }
+    _runBtn.addEventListener('click', () => {
+      if (_previewRaf != null) { _stopPreview(); return; }
+      if (_kf.length < 2) { _status.textContent = 'need ≥2 keyframes'; return; }
+      const totalSec = _trajectoryTotalSec();
+      if (!(totalSec > 0)) { _status.textContent = 'zero-length trajectory'; return; }
+      _runBtn.textContent = 'Stop';
+      const t0 = performance.now();
+      const tick = () => {
+        const sec = (performance.now() - t0) / 1000;
+        const frac = sec / totalSec;
+        if (frac >= 1) {
+          viewerState.setView(_kf[_kf.length - 1]);
+          _previewRaf = null;
+          _runBtn.textContent = 'Run';
+          _status.textContent = 'preview done';
+          return;
+        }
+        viewerState.setView(_viewAt(frac));
+        _status.textContent = `preview ${(sec).toFixed(2)} / ${totalSec.toFixed(2)} s`;
+        _previewRaf = requestAnimationFrame(tick);
+      };
+      _previewRaf = requestAnimationFrame(tick);
+    });
+
+    const _renderBtn = _btn('Render mp4', 'primary');
 
     const _status = document.createElement('span');
-    _status.style.fontFamily = 'var(--mono, monospace)';
-    _status.style.fontSize = '11px';
+    _status.className = 'spectre-mono';
     _status.style.minWidth = '160px';
 
     let _busy = false;
-    _btn.addEventListener('click', async () => {
+    _renderBtn.addEventListener('click', async () => {
       if (_busy) return;
-      _busy = true; _btn.disabled = true;
+      _busy = true; _renderBtn.disabled = true;
       _status.textContent = 'rendering…';
       try {
         const bytes = await _recordVideo({
@@ -2183,25 +3079,49 @@
         _status.textContent = 'error: ' + (e as Error).message;
         console.error(e);
       } finally {
-        _busy = false; _btn.disabled = false;
+        _busy = false; _renderBtn.disabled = false;
       }
     });
 
-    const _actionRow = document.createElement('div');
-    _actionRow.style.display = 'flex';
-    _actionRow.style.gap = '8px';
-    _actionRow.style.alignItems = 'center';
-    _actionRow.style.flexWrap = 'wrap';
-    _actionRow.style.margin = '8px 0';
-    _actionRow.style.fontFamily = 'var(--sans-serif)';
-    _actionRow.style.fontSize = '11px';
-    _actionRow.append(
-      _w.wrap, _h.wrap, _fps.wrap, _qp.wrap, _samp.wrap, _fitWrap, _cullWrap,
-      _saveBtn, _loadBtn, _loadInput,
-      _btn, _status,
+    // Two cards under the trajectory editor: render parameters above,
+    // action buttons below.
+    const _renderCard = document.createElement('div');
+    _renderCard.className = 'spectre-card';
+    const _renderHead = document.createElement('div');
+    _renderHead.className = 'spectre-section-head';
+    const _renderH = document.createElement('h4');
+    _renderH.textContent = 'render';
+    _renderHead.append(_renderH);
+    _renderHead.append(_totalLabel);
+    _totalLabel.classList.add('meta');
+    const _renderConfigRow = document.createElement('div');
+    _renderConfigRow.className = 'spectre-row';
+    _renderConfigRow.append(
+      _w.wrap, _h.wrap, _fps.wrap, _qp.wrap, _samp.wrap,
+      _fitWrap, _cullWrap,
     );
+    const _renderActionsRow = document.createElement('div');
+    _renderActionsRow.className = 'spectre-row';
+    _renderActionsRow.append(
+      _saveBtn, _loadBtn, _loadInput,
+      _runBtn, _renderBtn, _status,
+    );
+    _renderCard.append(_renderHead, _renderConfigRow, _renderActionsRow);
+    // Restore previous session if present. This calls _applyConfig
+    // which rebuilds the keyframe widget and refreshes the total label.
+    _loadLocal();
+    _refreshTotalLabel();
 
+    // Refresh the total label whenever the renderer's view changes — in
+    // particular when the canvas resizes, which is when viewerState.pixelWidth
+    // first becomes nonzero and the van Wijk reference width is established.
+    const _origOnViewChangeForTotal = viewerState.onViewChange;
+    viewerState.onViewChange = function (this: any, ...args: any[]) {
+      _origOnViewChangeForTotal?.apply(this, args);
+      _refreshTotalLabel();
+    };
+
+    display(_renderCard);
     display(_kfContainer);
-    display(_actionRow);
   </script>
 </notebook>


### PR DESCRIPTION
## Summary

A sibling notebook to `aperiodic-monotile/index.html` that lets the user zoom out arbitrarily on the Spectre aperiodic monotile tiling. Supertiles are generated on demand to cover the view; tiles that shrink below ~56 px collapse into earcut polygon meshes.

- Deterministic upward-extension chain via `superRules.Delta[1]` (Δ→Δ self-similar slot) — the whole infinite tiling is one rooted tree, so tile lookup is `O(log_{2.5}(world_size))` regardless of how far the camera has wandered.
- View-driven walker with frustum culling. Steady-state walks are 1–6 ms across all zoom levels (extension level 1–12+), well under the 16 ms frame budget.
- Boundary polygons simplified to 16 verts via Visvalingam-Whyatt, then dilated 1.025× around their centroid to hide sub-pixel gaps from FP-precision drift.
- Above sub-level 5 the walker reuses a cached low-level polygon scaled by the cell's radius ratio, keeping the cost of new substitution levels O(1) instead of walking ~9^N leaves.
- HSL channel encoding for color: hue from the ancestor at viewLevel, saturation from viewLevel+1, lightness from viewLevel+2 — three substitution scales drive three perceptual axes simultaneously, so coarse, medium, and fine structure all stay visible at deep zoom.

Lives at `/notebooks/aperiodic-monotile/infinite/` once merged. Two new files; no edits to the existing notebook.

## Test plan

- [ ] Open `/notebooks/aperiodic-monotile/infinite/`, confirm the cluster fills the canvas at default zoom
- [ ] Mouse-wheel and pinch zoom out continuously for ~15 seconds; FPS stays smooth, no lockups
- [ ] Zoom back in and pan around; aggregates seamlessly hand off to leaves
- [ ] At deep zoom (extension level 8+) confirm both small-scale and medium/large-scale supertile structure are visible (HSL channels working)
- [ ] No black streaks/gaps between aggregate polygons at any zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)