### PR TITLE
Add redirect generation script for old indexed URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "vite -c vite.config.js",
-    "build": "vite build -c vite.config.js && node scripts/copy-meta-images.js && node scripts/generate-rss.js && node scripts/generate-sitemap.js"
+    "build": "vite build -c vite.config.js && node scripts/copy-meta-images.js && node scripts/generate-rss.js && node scripts/generate-sitemap.js && node scripts/generate-redirects.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generate-redirects.js
+++ b/scripts/generate-redirects.js
@@ -1,0 +1,90 @@
+import { writeFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, "..");
+const WWW_DIR = join(ROOT_DIR, "www");
+
+const SITE_URL = "https://rreusser.github.io";
+
+// Old (pre-rewrite) URL paths that Google still has indexed but that now 404.
+// Each entry produces a static stub at www/<from>/index.html with a meta-refresh,
+// JS redirect, and rel=canonical pointing at the new URL. Google treats this as
+// a soft 301 and consolidates link equity onto the canonical destination.
+const redirects = [
+  ["/a-series-of-unfortunate-things-i-programmed-one-time/", "/notebooks/a-series-of-unfortunate-things-i-programmed-one-time/"],
+  ["/aligning-3d-scans/", "/notebooks/aligning-3d-scans/"],
+  ["/boys-surface/", "/sketches/boys-surface/"],
+  ["/calabi-yau/", "/sketches/calabi-yau/"],
+  ["/caustics/", "/sketches/caustics/"],
+  ["/continuum-gravity/", "/sketches/continuum-gravity/"],
+  ["/cubic-roots/", "/sketches/cubic-roots/"],
+  ["/domain-coloring-with-scaling/", "/sketches/domain-coloring-with-scaling/"],
+  ["/erosion/", "/sketches/erosion/"],
+  ["/fibonacci-sphere/", "/sketches/fibonacci-sphere/"],
+  ["/flamms-paraboloid/", "/sketches/flamms-paraboloid/"],
+  ["/gray-scott-reaction-diffusion/", "/sketches/gray-scott-reaction-diffusion/"],
+  ["/ikeda/", "/sketches/ikeda/"],
+  ["/iterative-closest-point/", "/sketches/iterative-closest-point/"],
+  ["/joukowsky-airfoil/", "/sketches/joukowsky-airfoil/"],
+  ["/karman-trefftz-airfoil/", "/sketches/karman-trefftz-airfoil/"],
+  ["/kuramoto-sivashinsky/", "/sketches/kuramoto-sivashinsky/"],
+  ["/lamb-wave-dispersion/", "/sketches/lamb-wave-dispersion/"],
+  ["/line-integral-convolution/", "/sketches/line-integral-convolution/"],
+  ["/multiscale-turing-pattern-gallery/", "/notebooks/multi-scale-turing-pattern-gallery-1/"],
+  ["/multiscale-turing-pattern-gallery-2/", "/notebooks/multi-scale-turing-pattern-gallery-2/"],
+  ["/multiscale-turing-patterns/", "/sketches/multiscale-turing-patterns/"],
+  ["/nose-hoover-attractor/", "/sketches/nose-hoover-attractor/"],
+  ["/potential-flow/", "/sketches/potential-flow/"],
+  ["/random-polynomial-roots/", "/sketches/random-polynomial-roots/"],
+  ["/rule-30/", "/sketches/rule-30/"],
+  ["/schwarzschild-spacetime/", "/sketches/schwarzschild-spacetime/"],
+  ["/smooth-life/", "/sketches/smooth-life/"],
+  ["/spherical-harmonics/", "/sketches/spherical-harmonics/"],
+  ["/things-i-learned-the-hard-way-using-react-native/", "/notebooks/things-i-learned-the-hard-way-using-react-native/"],
+  ["/ueda-attractor/", "/sketches/ueda-attractor/"],
+  ["/vortex-sdf/", "/sketches/vortex-sdf/"],
+];
+
+function htmlFor(targetUrl) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Redirecting…</title>
+  <link rel="canonical" href="${targetUrl}" />
+  <meta http-equiv="refresh" content="0; url=${targetUrl}" />
+  <script>window.location.replace(${JSON.stringify(targetUrl)});</script>
+</head>
+<body>
+  <p>This page has moved to <a href="${targetUrl}">${targetUrl}</a>.</p>
+</body>
+</html>
+`;
+}
+
+async function main() {
+  const seen = new Set();
+  for (const [from, to] of redirects) {
+    if (!from.startsWith("/") || !from.endsWith("/")) {
+      throw new Error(`Redirect 'from' must start and end with /: ${from}`);
+    }
+    if (!to.startsWith("/") || !to.endsWith("/")) {
+      throw new Error(`Redirect 'to' must start and end with /: ${to}`);
+    }
+    if (seen.has(from)) {
+      throw new Error(`Duplicate redirect 'from': ${from}`);
+    }
+    seen.add(from);
+    const fromDir = join(WWW_DIR, from);
+    await mkdir(fromDir, { recursive: true });
+    await writeFile(join(fromDir, "index.html"), htmlFor(`${SITE_URL}${to}`), "utf8");
+  }
+  console.log(`Generated ${redirects.length} redirect stubs in ${WWW_DIR}`);
+}
+
+main().catch((err) => {
+  console.error("Error generating redirects:", err);
+  process.exit(1);
+});

--- a/scripts/generate-redirects.js
+++ b/scripts/generate-redirects.js
@@ -37,6 +37,7 @@ const redirects = [
   ["/multiscale-turing-patterns/", "/sketches/multiscale-turing-patterns/"],
   ["/nose-hoover-attractor/", "/sketches/nose-hoover-attractor/"],
   ["/potential-flow/", "/sketches/potential-flow/"],
+  ["/projects/", "/notebooks/"],
   ["/random-polynomial-roots/", "/sketches/random-polynomial-roots/"],
   ["/rule-30/", "/sketches/rule-30/"],
   ["/schwarzschild-spacetime/", "/sketches/schwarzschild-spacetime/"],

--- a/src/notebooks/boys-surface/index.html
+++ b/src/notebooks/boys-surface/index.html
@@ -20,7 +20,7 @@ import { interval } from './lib/range-slider.js';
   </script>
 
   <script id="intro" type="text/markdown">
-An implementation of [Boy's surface](https://en.wikipedia.org/wiki/Boy%27s_surface), an immersion of the real projective plane in three-dimensional Euclidean space. The parameterization is based on a formula by Robert Bryant and Rob Kusner. This is a WebGPU port of [an earlier version](https://rreusser.github.io/boys-surface/).
+An implementation of [Boy's surface](https://en.wikipedia.org/wiki/Boy%27s_surface), an immersion of the real projective plane in three-dimensional Euclidean space. The parameterization is based on a formula by Robert Bryant and Rob Kusner. This is a WebGPU port of [an earlier version](https://rreusser.github.io/sketches/boys-surface/).
   </script>
 
   <script id="gpu-context" type="text/x-typescript">


### PR DESCRIPTION
## Summary
This PR adds a build-time script to generate static HTML redirect stubs for old pre-rewrite URLs that are still indexed by search engines. These redirects use meta-refresh, JavaScript fallback, and canonical links to soft-redirect users and consolidate SEO link equity to the new URLs.

## Key Changes
- **New script**: `scripts/generate-redirects.js` - Generates static HTML redirect stubs at build time for 33 old URL paths that now 404
  - Creates `www/<old-path>/index.html` files with meta-refresh redirects
  - Includes JavaScript fallback for browsers with meta-refresh disabled
  - Sets canonical link headers to help Google consolidate link equity
  - Validates redirect entries (must start/end with `/`, no duplicates)
  
- **Build integration**: Updated `package.json` build script to run the redirect generator after other build steps

- **Documentation fix**: Updated Boy's surface notebook to reference the new sketch URL path instead of the old root-level URL

## Implementation Details
- The script uses Node.js built-in `fs/promises` and `path` modules for file operations
- Generates 33 redirect stubs covering old project, sketch, and notebook URLs
- Each redirect HTML includes three mechanisms for maximum compatibility:
  1. `<meta http-equiv="refresh">` for basic browser support
  2. JavaScript `window.location.replace()` for meta-refresh disabled scenarios
  3. Fallback `<a>` link for users with JS disabled
  4. `<link rel="canonical">` for search engine consolidation

https://claude.ai/code/session_014tddFBgnu84tY9scD3MzHX