### PR TITLE
Color elevation profiles by slope; tap routes to toggle them

### DIFF
--- a/src/notebooks/denali/elevation-profile.js
+++ b/src/notebooks/denali/elevation-profile.js
@@ -26,6 +26,18 @@ function niceInterval(range, targetTicks) {
   return nice * pow;
 }
 
+// Slope magnitude (in percent) -> CSS color string. Green for gentle, through
+// yellow/orange/red for steep, clamped at SLOPE_MAX for the legend ramp.
+const SLOPE_MAX = 35;
+function slopeColor(slopePct) {
+  const t = Math.min(1, Math.abs(slopePct) / SLOPE_MAX);
+  // Hue 120 (green) -> 0 (red); darken slightly at the top end so very-steep
+  // sections read distinctly from merely-steep.
+  const hue = 120 * (1 - t);
+  const lightness = 50 - 12 * t;
+  return `hsl(${hue.toFixed(1)}, 78%, ${lightness.toFixed(1)}%)`;
+}
+
 export class ElevationProfile {
   constructor() {
     this._panel = null;
@@ -47,6 +59,9 @@ export class ElevationProfile {
   /** Callback invoked with the hovered point ({mercatorX, mercatorY, elevation, distanceM}) or null. */
   set onHover(fn) { this._onHover = fn; }
 
+  /** Callback invoked with the active layer id (or null) whenever it changes. */
+  set onActiveChange(fn) { this._onActiveChange = fn; }
+
   createDOM() {
     const panel = document.createElement('div');
     panel.className = 'elevation-profile-panel';
@@ -57,6 +72,19 @@ export class ElevationProfile {
     const title = document.createElement('span');
     title.className = 'elevation-profile-title';
     header.appendChild(title);
+
+    // Compact slope-color legend. The gradient is generated from slopeColor()
+    // sampled at fixed stops so the chart and legend stay in sync.
+    const legend = document.createElement('div');
+    legend.className = 'elevation-profile-legend';
+    const stops = [0, 5, 10, 15, 20, 25, 30, 35];
+    const css = stops.map((s, i) => `${slopeColor(s)} ${(i / (stops.length - 1) * 100).toFixed(1)}%`).join(', ');
+    legend.innerHTML = `
+      <span class="elevation-profile-legend-label">0%</span>
+      <span class="elevation-profile-legend-bar" style="background:linear-gradient(to right, ${css})"></span>
+      <span class="elevation-profile-legend-label">${SLOPE_MAX}%+</span>
+    `;
+    header.appendChild(legend);
 
     const closeBtn = document.createElement('button');
     closeBtn.className = 'elevation-profile-close';
@@ -87,12 +115,14 @@ export class ElevationProfile {
   }
 
   show(layerId, title, data, lineColor) {
+    const prev = this._layerId;
     this._layerId = layerId;
     this._lineColor = lineColor;
     this._title.textContent = title;
     this._computeDistances(data);
     this._panel.classList.add('visible');
     this._scheduleDraw();
+    if (prev !== layerId) this._onActiveChange?.(layerId);
   }
 
   update(data) {
@@ -102,14 +132,18 @@ export class ElevationProfile {
   }
 
   hide() {
+    const prev = this._layerId;
     this._panel.classList.remove('visible');
     this._layerId = null;
     this._distances = null;
     this._elevations = null;
     this._coords = null;
     this._segmentBreaks = null;
+    this._segmentSlopes = null;
+    this._vertexSlopes = null;
     this._hoverIndex = -1;
     this._onHover?.(null);
+    if (prev !== null) this._onActiveChange?.(null);
   }
 
   get activeLayerId() {
@@ -127,6 +161,8 @@ export class ElevationProfile {
       this._elevations = null;
       this._coords = null;
       this._segmentBreaks = null;
+      this._segmentSlopes = null;
+      this._vertexSlopes = null;
       return;
     }
     const allDist = [];
@@ -158,6 +194,68 @@ export class ElevationProfile {
     this._elevations = allElev;
     this._coords = allCoords;
     this._segmentBreaks = breaks;
+    this._computeSlopes();
+  }
+
+  // Compute per-segment slope (dElev/dDist as a fraction) smoothed over a
+  // small distance window so per-vertex noise doesn't dominate the coloring.
+  // Segments with non-positive or unloaded elevations get NaN so the renderer
+  // can skip them (matching the existing zero-elevation gap handling).
+  _computeSlopes() {
+    const dist = this._distances;
+    const elev = this._elevations;
+    if (!dist || dist.length < 2) {
+      this._segmentSlopes = null;
+      this._vertexSlopes = null;
+      return;
+    }
+    const n = dist.length;
+    const rawSlopes = new Float64Array(n - 1);
+    const midDist = new Float64Array(n - 1);
+    for (let i = 0; i < n - 1; i++) {
+      const e1 = elev[i];
+      const e2 = elev[i + 1];
+      const dd = dist[i + 1] - dist[i];
+      midDist[i] = (dist[i] + dist[i + 1]) * 0.5;
+      if (dd <= 0 || !(e1 > 0) || !(e2 > 0)) {
+        rawSlopes[i] = NaN;
+      } else {
+        rawSlopes[i] = (e2 - e1) / dd;
+      }
+    }
+
+    // Centered moving-average smoothing with a ~80m window. Walking outward
+    // until the window is exceeded keeps the cost linear amortized.
+    const HALF_WINDOW = 40;
+    const smoothed = new Float64Array(n - 1);
+    for (let i = 0; i < n - 1; i++) {
+      if (isNaN(rawSlopes[i])) { smoothed[i] = NaN; continue; }
+      let sum = rawSlopes[i], cnt = 1;
+      for (let j = i + 1; j < n - 1; j++) {
+        if (midDist[j] - midDist[i] > HALF_WINDOW) break;
+        if (!isNaN(rawSlopes[j])) { sum += rawSlopes[j]; cnt++; }
+      }
+      for (let j = i - 1; j >= 0; j--) {
+        if (midDist[i] - midDist[j] > HALF_WINDOW) break;
+        if (!isNaN(rawSlopes[j])) { sum += rawSlopes[j]; cnt++; }
+      }
+      smoothed[i] = sum / cnt;
+    }
+    this._segmentSlopes = smoothed;
+
+    // Per-vertex slope = average of adjacent segment slopes (one-sided at ends).
+    const vSlopes = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      const a = i > 0 ? smoothed[i - 1] : NaN;
+      const b = i < n - 1 ? smoothed[i] : NaN;
+      const va = isNaN(a) ? null : a;
+      const vb = isNaN(b) ? null : b;
+      if (va == null && vb == null) vSlopes[i] = NaN;
+      else if (va == null) vSlopes[i] = vb;
+      else if (vb == null) vSlopes[i] = va;
+      else vSlopes[i] = (va + vb) * 0.5;
+    }
+    this._vertexSlopes = vSlopes;
   }
 
   _scheduleDraw() {
@@ -230,7 +328,6 @@ export class ElevationProfile {
     const g = Math.round(lc[1] * 255);
     const b = Math.round(lc[2] * 255);
     const strokeColor = `rgb(${r},${g},${b})`;
-    const fillColor = `rgba(${r},${g},${b},0.3)`;
 
     // Gridlines
     ctx.font = '10px system-ui, sans-serif';
@@ -291,42 +388,46 @@ export class ElevationProfile {
     ctx.rect(marginLeft, marginTop, plotW, plotH);
     ctx.clip();
 
-    let inRun = false;
-    // Fill
-    ctx.fillStyle = fillColor;
-    for (let i = 0; i < distances.length; i++) {
-      const e = elevations[i];
-      if (e > 0) {
-        const px = xScale(distances[i]);
-        const py = yScale(e * M_TO_FT);
-        if (!inRun) {
-          ctx.beginPath();
-          ctx.moveTo(px, yScale(yMinFt));
-          ctx.lineTo(px, py);
-          inRun = true;
-        } else {
-          ctx.lineTo(px, py);
-        }
-      } else {
-        if (inRun) {
-          // Close the fill to the bottom
-          const prevPx = xScale(distances[i - 1]);
-          ctx.lineTo(prevPx, yScale(yMinFt));
-          ctx.closePath();
-          ctx.fill();
-          inRun = false;
-        }
+    // Per-segment fill colored by slope. Each segment renders as a quad
+    // (baseline-left, top-left, top-right, baseline-right) with a horizontal
+    // gradient interpolating between the two vertex-slope colors so the
+    // coloring reads continuously across the chart.
+    const segSlopes = this._segmentSlopes;
+    const vSlopes = this._vertexSlopes;
+    const yBaseline = yScale(yMinFt);
+    if (segSlopes) {
+      for (let i = 0; i < distances.length - 1; i++) {
+        const e1 = elevations[i];
+        const e2 = elevations[i + 1];
+        const dd = distances[i + 1] - distances[i];
+        if (!(e1 > 0) || !(e2 > 0) || dd <= 0) continue;
+        if (isNaN(segSlopes[i])) continue;
+
+        const x1 = xScale(distances[i]);
+        const x2 = xScale(distances[i + 1]);
+        const y1 = yScale(e1 * M_TO_FT);
+        const y2 = yScale(e2 * M_TO_FT);
+
+        const s1 = isNaN(vSlopes[i]) ? segSlopes[i] : vSlopes[i];
+        const s2 = isNaN(vSlopes[i + 1]) ? segSlopes[i] : vSlopes[i + 1];
+        const c1 = slopeColor(s1 * 100);
+        const c2 = slopeColor(s2 * 100);
+        const grad = ctx.createLinearGradient(x1, 0, x2, 0);
+        grad.addColorStop(0, c1);
+        grad.addColorStop(1, c2);
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.moveTo(x1, yBaseline);
+        ctx.lineTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.lineTo(x2, yBaseline);
+        ctx.closePath();
+        ctx.fill();
       }
-    }
-    if (inRun) {
-      const lastPx = xScale(distances[distances.length - 1]);
-      ctx.lineTo(lastPx, yScale(yMinFt));
-      ctx.closePath();
-      ctx.fill();
     }
 
     // Stroke the top edge
-    inRun = false;
+    let inRun = false;
     ctx.strokeStyle = strokeColor;
     ctx.lineWidth = 1.5;
     for (let i = 0; i < distances.length; i++) {
@@ -380,7 +481,9 @@ export class ElevationProfile {
         // Tooltip
         const elevFt = Math.round(e * M_TO_FT).toLocaleString();
         const distMi = (distances[hi] * M_TO_MI).toFixed(2);
-        const text = `${elevFt} ft  /  ${distMi} mi`;
+        const slope = this._vertexSlopes ? this._vertexSlopes[hi] : NaN;
+        const slopeStr = isNaN(slope) ? '' : `  /  ${(slope * 100 >= 0 ? '+' : '')}${(slope * 100).toFixed(1)}%`;
+        const text = `${elevFt} ft  /  ${distMi} mi${slopeStr}`;
         ctx.font = '11px system-ui, sans-serif';
         const tm = ctx.measureText(text);
         const tw = tm.width + 10;

--- a/src/notebooks/denali/index.html
+++ b/src/notebooks/denali/index.html
@@ -254,6 +254,33 @@
 
     viewer.on('render', updateHoverDot);
 
+    // Toggle the elevation profile for a line layer.
+    function toggleElevationProfile(layerId) {
+      if (elevationProfile.activeLayerId === layerId) {
+        elevationProfile.hide();
+        return;
+      }
+      const layer = viewer.getLayer(layerId);
+      const data = viewer.getLayerElevationProfile(layerId);
+      if (!layer || !data) return;
+      elevationProfile.show(layerId, layerId, data, layer.paint['line-color']);
+    }
+
+    // Mountain-icon buttons in the layer panel reflect the active profile.
+    // The panel is rebuilt on layer add/delete, so we track current buttons
+    // in a Map and refresh their .active class whenever the profile changes.
+    const profileToggleButtons = new Map();
+    elevationProfile.onActiveChange = (activeId) => {
+      for (const [id, btn] of profileToggleButtons) {
+        btn.classList.toggle('active', id === activeId);
+      }
+    };
+
+    // Tapping a route on the map toggles its elevation profile. The viewer
+    // emits 'linetap' only when the pointer release stays inside its dead
+    // zone, so plain pan/orbit gestures don't trigger this.
+    viewer.on('linetap', (hit) => toggleElevationProfile(hit.id));
+
     const container = html`<div style="position: relative">`;
     container.appendChild(canvas);
     container.appendChild(elevationLabel);
@@ -418,6 +445,7 @@
 
     function rebuildLayerPanel() {
       layerList.innerHTML = '';
+      profileToggleButtons.clear();
 
       // Imagery row (no expandable props, just eye toggle)
       const imgRow = html`<div class="layer-row">
@@ -452,6 +480,18 @@
 
         row.appendChild(html`<span class="layer-name">${entry.id}</span>`);
 
+        if (entry.type === 'line') {
+          const profileToggle = html`<button class="layer-profile-toggle" title="Toggle elevation profile"></button>`;
+          profileToggle.innerHTML = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"><path d="M1.5 13 L5.5 6 L8 9.5 L10.5 5.5 L14.5 13 Z"/></svg>`;
+          if (elevationProfile.activeLayerId === entry.id) profileToggle.classList.add('active');
+          profileToggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            toggleElevationProfile(entry.id);
+          });
+          row.appendChild(profileToggle);
+          profileToggleButtons.set(entry.id, profileToggle);
+        }
+
         const del = html`<button class="layer-delete" title="Remove layer">&times;</button>`;
         del.addEventListener('click', () => {
           viewer.removeLayer(entry.id);
@@ -484,11 +524,7 @@
           });
           props.appendChild(dlBtn);
           const profBtn = html`<button class="layer-download-btn">Elevation profile</button>`;
-          profBtn.addEventListener('click', () => {
-            const data = viewer.getLayerElevationProfile(id);
-            if (!data) return;
-            elevationProfile.show(id, entry.id, data, paint['line-color']);
-          });
+          profBtn.addEventListener('click', () => toggleElevationProfile(id));
           props.appendChild(profBtn);
         } else if (entry.type === 'circle') {
           addColorProp(props, 'Fill', paint['circle-color'], v => viewer.setLayerPaint(id, 'circle-color', v));
@@ -1471,6 +1507,22 @@ I mean, let's be clear. This is a totally half-baked one-off ad hoc renderer. It
       .layer-delete:hover {
         color: #d32f2f;
       }
+      .layer-profile-toggle {
+        background: none;
+        border: none;
+        padding: 2px;
+        cursor: pointer;
+        color: #888;
+        border-radius: 3px;
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+      }
+      .layer-profile-toggle:hover { background: #eee; color: #444; }
+      .layer-profile-toggle.active { color: #1976d2; }
+      html[data-dark] .layer-profile-toggle { color: #888; }
+      html[data-dark] .layer-profile-toggle:hover { background: rgba(255,255,255,0.08); color: #ddd; }
+      html[data-dark] .layer-profile-toggle.active { color: #64b5f6; }
       .layer-props {
         display: flex;
         flex-direction: column;
@@ -1681,6 +1733,24 @@ I mean, let's be clear. This is a totally half-baked one-off ad hoc renderer. It
         align-items: center;
         justify-content: center;
       }
+      .elevation-profile-legend {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        font-family: system-ui, sans-serif;
+        font-size: 10px;
+        color: #666;
+        flex-shrink: 0;
+      }
+      .elevation-profile-legend-bar {
+        display: inline-block;
+        width: 64px;
+        height: 8px;
+        border-radius: 2px;
+        border: 1px solid rgba(0,0,0,0.15);
+      }
+      html[data-dark] .elevation-profile-legend { color: #aaa; }
+      html[data-dark] .elevation-profile-legend-bar { border-color: rgba(255,255,255,0.2); }
       .elevation-profile-close:hover {
         background: #e0e0e0;
       }

--- a/src/notebooks/denali/mapviewer/terrain-viewer.js
+++ b/src/notebooks/denali/mapviewer/terrain-viewer.js
@@ -20,6 +20,19 @@ import { CollisionManager } from './interaction/collision-manager.js';
 import { WorkerPool } from './workers/worker-pool.ts';
 import { LightingManager } from './lighting/lighting-manager.js';
 
+function segmentDistanceSq(px, py, ax, ay, bx, by) {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  let t = lenSq > 0 ? ((px - ax) * dx + (py - ay) * dy) / lenSq : 0;
+  if (t < 0) t = 0; else if (t > 1) t = 1;
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  const ex = px - cx;
+  const ey = py - cy;
+  return ex * ex + ey * ey;
+}
+
 export class TerrainMap extends EventEmitter {
   /**
    * Create a TerrainMap instance. Use the async factory `TerrainMap.create()`.
@@ -286,6 +299,46 @@ export class TerrainMap extends EventEmitter {
     this._invProjView = new Float64Array(16);
 
     this.camera.rotateStartCallback = (clientX, clientY) => this._hitTest(clientX, clientY);
+
+    // Pointer-tap detection for picking line layers. We track each pointer's
+    // down position + timestamp and only fire a tap on pointerup if motion
+    // stayed inside the dead zone and the total duration was short. The
+    // 'drawing' canvas class (set by the notebook's pen tool) suppresses
+    // tap-picking so route-drawing clicks don't double-fire.
+    this._pickPointers = new Map();
+    this._pickDeadZonePx = 6;
+    this._pickMaxDurationMs = 500;
+    this._onPickPointerDown = (e) => {
+      if (this.canvas.classList.contains('drawing')) return;
+      // Only the primary mouse button; touch + pen have button === 0 too.
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+      this._pickPointers.set(e.pointerId, {
+        x: e.clientX, y: e.clientY, t: performance.now(),
+      });
+    };
+    this._onPickPointerUp = (e) => {
+      const down = this._pickPointers.get(e.pointerId);
+      if (!down) return;
+      this._pickPointers.delete(e.pointerId);
+      if (this.canvas.classList.contains('drawing')) return;
+      const dx = e.clientX - down.x;
+      const dy = e.clientY - down.y;
+      if (dx * dx + dy * dy > this._pickDeadZonePx * this._pickDeadZonePx) return;
+      if (performance.now() - down.t > this._pickMaxDurationMs) return;
+      const hit = this.pickLineLayer(e.clientX, e.clientY);
+      if (hit) {
+        this.emit('linetap', {
+          ...hit,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          originalEvent: e,
+        });
+      }
+    };
+    this._onPickPointerCancel = (e) => { this._pickPointers.delete(e.pointerId); };
+    canvas.addEventListener('pointerdown', this._onPickPointerDown);
+    canvas.addEventListener('pointerup', this._onPickPointerUp);
+    canvas.addEventListener('pointercancel', this._onPickPointerCancel);
 
     // Watch for container resizes so the canvas always tracks its layout size
     this._needsCanvasResize = true;
@@ -815,6 +868,76 @@ export class TerrainMap extends EventEmitter {
   }
 
   /**
+   * Hit-test screen coordinates against visible line layers.
+   *
+   * Projects each polyline's cached world vertices through the most recent
+   * projectionView matrix and returns the layer whose nearest segment is
+   * within `tolerance` CSS pixels of (clientX, clientY). Returns the best
+   * match across all visible line layers, or null.
+   *
+   * @param {number} clientX
+   * @param {number} clientY
+   * @param {{ tolerance?: number }} [opts] tolerance in CSS pixels (default 8)
+   * @returns {{ id: string, polylineIndex: number, segmentIndex: number, distancePx: number } | null}
+   */
+  pickLineLayer(clientX, clientY, opts = {}) {
+    const tolerance = opts.tolerance != null ? opts.tolerance : 8;
+    const rect = this.canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    const px = clientX - rect.left;
+    const py = clientY - rect.top;
+    const w = rect.width, h = rect.height;
+    const m = this._lastProjView;
+
+    let bestDist = Infinity;
+    let bestHit = null;
+
+    for (const entry of this._layerManager._lineLayers) {
+      if (!entry.visible) continue;
+      const layer = entry.layer;
+      const data = layer._positionData;
+      const polylines = layer._polylines;
+      if (!data || !polylines || polylines.length === 0) continue;
+
+      // Tolerance grows with the line's drawn width so wider routes stay
+      // pickable even if the click lands at the visible edge.
+      const halfWidth = ((layer._lineWidth || 0) + (layer._borderWidth || 0)) * 0.5;
+      const segTol = Math.max(tolerance, halfWidth + 3);
+      const segTolSq = segTol * segTol;
+
+      for (let pi = 0; pi < polylines.length; pi++) {
+        const poly = polylines[pi];
+        const off = poly.offset;
+        let prevSx = 0, prevSy = 0, prevValid = false;
+        for (let i = 0; i < poly.count; i++) {
+          const idx = (off + i) * 4;
+          const wx = data[idx];
+          const wy = data[idx + 1];
+          const wz = data[idx + 2];
+          const cx = m[0] * wx + m[4] * wy + m[8] * wz + m[12];
+          const cy = m[1] * wx + m[5] * wy + m[9] * wz + m[13];
+          const cw = m[3] * wx + m[7] * wy + m[11] * wz + m[15];
+          let sx = 0, sy = 0, valid = false;
+          if (cw > 0) {
+            sx = (cx / cw * 0.5 + 0.5) * w;
+            sy = (1 - (cy / cw * 0.5 + 0.5)) * h;
+            valid = true;
+          }
+          if (i > 0 && valid && prevValid) {
+            const dSq = segmentDistanceSq(px, py, prevSx, prevSy, sx, sy);
+            if (dSq < segTolSq && dSq < bestDist) {
+              bestDist = dSq;
+              bestHit = { id: entry.id, polylineIndex: pi, segmentIndex: i - 1, distancePx: Math.sqrt(dSq) };
+            }
+          }
+          prevSx = sx; prevSy = sy; prevValid = valid;
+        }
+      }
+    }
+    return bestHit;
+  }
+
+  /**
    * Query terrain elevation at a Mercator coordinate.
    * Searches the current render list for the highest-zoom terrain tile covering (mx, my).
    * With imagery-driven rendering, each render tile carries a terrain tile reference;
@@ -914,6 +1037,9 @@ export class TerrainMap extends EventEmitter {
   destroy() {
     this._running = false;
     clearTimeout(this._hashUpdateTimer);
+    this.canvas.removeEventListener('pointerdown', this._onPickPointerDown);
+    this.canvas.removeEventListener('pointerup', this._onPickPointerUp);
+    this.canvas.removeEventListener('pointercancel', this._onPickPointerCancel);
     this._collisionManager.destroy();
     this._frustumOverlay.destroy();
     this._resizeObserver.disconnect();


### PR DESCRIPTION
The elevation profile fill is now colored by a smoothed slope derivative
(green to red across 0%-35%+) so steep sections read at a glance. The
profile header shows a matching gradient legend, and the hover tooltip
includes the local grade.

Each line layer in the layer panel grows a mountain-icon button that
toggles its elevation profile directly, instead of requiring the user to
expand the layer's properties first. The button reflects the currently
active profile via an .active class kept in sync by an onActiveChange
callback on ElevationProfile.

Tapping a route on the map now emits a 'linetap' event on the map
instance and the notebook subscribes to toggle the corresponding
profile. pickLineLayer projects each visible polyline's cached world
positions to screen and returns the closest segment within a width-aware
tolerance. The pointerdown/pointerup pair tracks per-pointer position
and timestamp; a tap only fires when motion stays inside a 6px dead
zone and the press is shorter than 500ms, so orbit/pan gestures don't
trigger it. Pick handling is suppressed while the pen tool is active
(canvas .drawing class).