### PR TITLE
Slope-shaded line layers (opt-in, enabled on West Buttress)

### DIFF
--- a/src/notebooks/denali/index.html
+++ b/src/notebooks/denali/index.html
@@ -80,7 +80,8 @@
             'line-width': 6,
             'line-border-color': '#ffffffcc',
             'line-border-width': 1,
-            'atmosphere-opacity': 0.5
+            'atmosphere-opacity': 0.5,
+            'line-slope-shading': true
           }
         },
         {
@@ -433,6 +434,7 @@
       const row = html`<div class="layer-prop"><label>${label}</label><input type="color" class="layer-color" value="${hexFromColor(currentColor)}"></div>`;
       row.querySelector('input').addEventListener('input', (e) => onChange(e.target.value));
       container.appendChild(row);
+      return row;
     }
 
     function addRangeProp(container, label, value, min, max, step, onChange) {
@@ -441,6 +443,16 @@
       const span = row.querySelector('.layer-prop-value');
       input.addEventListener('input', () => { span.textContent = input.value; onChange(Number(input.value)); });
       container.appendChild(row);
+      return row;
+    }
+
+    function addCheckboxProp(container, label, checked, onChange) {
+      const row = html`<div class="layer-prop"><label>${label}</label><input type="checkbox" class="layer-checkbox"></div>`;
+      const input = row.querySelector('input');
+      input.checked = !!checked;
+      input.addEventListener('change', () => onChange(input.checked));
+      container.appendChild(row);
+      return row;
     }
 
     function rebuildLayerPanel() {
@@ -506,10 +518,19 @@
         const paint = entry.paint;
 
         if (entry.type === 'line') {
-          addColorProp(props, 'Color', paint['line-color'], v => viewer.setLayerPaint(id, 'line-color', v));
+          const colorRow = addColorProp(props, 'Color', paint['line-color'], v => viewer.setLayerPaint(id, 'line-color', v));
           addColorProp(props, 'Border', paint['line-border-color'], v => viewer.setLayerPaint(id, 'line-border-color', v));
           addRangeProp(props, 'Width', paint['line-width'], 1, 12, 0.5, v => viewer.setLayerPaint(id, 'line-width', v));
           addRangeProp(props, 'Border width', paint['line-border-width'], 0, 6, 0.5, v => viewer.setLayerPaint(id, 'line-border-width', v));
+          const setColorRowEnabled = (enabled) => {
+            colorRow.classList.toggle('layer-prop-disabled', !enabled);
+            colorRow.querySelector('input').disabled = !enabled;
+          };
+          setColorRowEnabled(!paint['line-slope-shading']);
+          addCheckboxProp(props, 'Slope shading', paint['line-slope-shading'], v => {
+            viewer.setLayerPaint(id, 'line-slope-shading', v);
+            setColorRowEnabled(!v);
+          });
           const dlBtn = html`<button class="layer-download-btn">Download GeoJSON</button>`;
           dlBtn.addEventListener('click', () => {
             const geojson = viewer.getLayerGeoJSON(id);
@@ -1551,6 +1572,8 @@ But let's be clear, this is a totally half-baked one-off ad hoc renderer. It use
         font-size: 11px;
         font-variant-numeric: tabular-nums;
       }
+      .layer-prop-disabled { opacity: 0.45; pointer-events: none; }
+      .layer-prop input[type="checkbox"] { margin: 0; cursor: pointer; }
       .layer-color {
         width: 24px;
         height: 20px;

--- a/src/notebooks/denali/mapviewer/layers/layer-manager.ts
+++ b/src/notebooks/denali/mapviewer/layers/layer-manager.ts
@@ -149,6 +149,7 @@ export class LayerManager {
           'line-border-color': e.layer._borderColor,
           'line-width': e.layer._lineWidth,
           'line-border-width': e.layer._borderWidth,
+          'line-slope-shading': !!e.layer._slopeShading,
         },
       });
     }
@@ -234,6 +235,7 @@ export class LayerManager {
       else if (property === 'line-border-color') l._borderColor = color;
       else if (property === 'line-width') l._lineWidth = value;
       else if (property === 'line-border-width') l._borderWidth = value;
+      else if (property === 'line-slope-shading') l.setSlopeShading(value);
       this._onDirty();
       return;
     }

--- a/src/notebooks/denali/mapviewer/layers/line-layer.js
+++ b/src/notebooks/denali/mapviewer/layers/line-layer.js
@@ -9,6 +9,11 @@ export { parseColor };
 // (0.5*AA_WIDTH on each side of the visible edge in sdf units).
 const AA_WIDTH = 1.0;
 
+// Slope range (in percent grade) for the green→red HSL ramp. Must match
+// SLOPE_MAX in elevation-profile.js so the legend and the on-terrain line
+// stay in sync.
+const SLOPE_MAX_PCT = 35.0;
+
 const lineVertexShaderBody = /* wgsl */`
 @group(1) @binding(0) var<storage, read> positions: array<vec4f>;
 
@@ -22,25 +27,33 @@ struct LineUniforms {
   exaggeration: f32,
   atmosphereOpacity: f32,
   depthOffset: f32,
-  _p2: f32, _p3: f32,
+  slopeShadingEnabled: f32,
+  _p3: f32,
 };
 @group(2) @binding(0) var<uniform> line: LineUniforms;
 
+// Per-vertex varyings forwarded to the fragment shader's getColor().
+// 'slope' carries the smoothed signed grade fraction (rise/run); it's
+// always present but only consumed when slopeShadingEnabled > 0.5.
 struct Vertex {
   position: vec4f,
   width: f32,
   anchor: vec3f,
+  slope: f32,
 }
 
 fn getVertex(index: u32) -> Vertex {
   let p = positions[index];
-  var clip = line.projectionView * p;
+  // p.w carries the per-vertex slope (the storage buffer is repurposed —
+  // the homogeneous coordinate is always 1.0 conceptually). Project with
+  // an explicit 1.0 so slope-shading layers don't degenerate.
+  var clip = line.projectionView * vec4f(p.xyz, 1.0);
   clip.z += line.depthOffset * clip.w;
   // Geometric width passed to the lib (device px). Allocates space for
   // the central stroke, the halo (one halo width — see fragment), and a
   // 0.5*AA fade.
   let geomWidthDev = (line.lineWidth + line.borderWidth + 0.5 * ${AA_WIDTH.toFixed(4)}) * line.pixelRatio;
-  return Vertex(clip, geomWidthDev, p.xyz);
+  return Vertex(clip, geomWidthDev, p.xyz, p.w);
 }
 `;
 
@@ -59,11 +72,39 @@ struct LineUniforms {
   pixelRatio: f32,
   exaggeration: f32,
   atmosphereOpacity: f32,
-  _p1: f32, _p2: f32, _p3: f32,
+  _p1: f32,
+  slopeShadingEnabled: f32,
+  _p3: f32,
 };
 
 fn srgbToLinear(c: vec3<f32>) -> vec3<f32> {
   return pow(c, vec3<f32>(2.2));
+}
+
+// HSL → sRGB. Mirrors CSS hsl() so it matches the elevation-profile legend.
+fn hslToRgb(h: f32, s: f32, l: f32) -> vec3f {
+  let c = (1.0 - abs(2.0 * l - 1.0)) * s;
+  let hp = h / 60.0;
+  let hpMod2 = hp - 2.0 * floor(hp * 0.5);
+  let x = c * (1.0 - abs(hpMod2 - 1.0));
+  var rgb1: vec3f = vec3f(0.0);
+  if (hp < 1.0)      { rgb1 = vec3f(c, x, 0.0); }
+  else if (hp < 2.0) { rgb1 = vec3f(x, c, 0.0); }
+  else if (hp < 3.0) { rgb1 = vec3f(0.0, c, x); }
+  else if (hp < 4.0) { rgb1 = vec3f(0.0, x, c); }
+  else if (hp < 5.0) { rgb1 = vec3f(x, 0.0, c); }
+  else               { rgb1 = vec3f(c, 0.0, x); }
+  return rgb1 + vec3f(l - 0.5 * c);
+}
+
+// Smoothed signed grade fraction → sRGB. Same hue/lightness curve as
+// elevation-profile.js slopeColor() so the legend and the on-terrain line
+// agree exactly.
+fn slopeToColor(slope: f32) -> vec3f {
+  let t = clamp(abs(slope) * 100.0 / ${SLOPE_MAX_PCT.toFixed(1)}, 0.0, 1.0);
+  let hue = 120.0 * (1.0 - t);
+  let lightness = 0.50 - 0.12 * t;
+  return hslToRgb(hue, 0.78, lightness);
 }
 
 fn applyAtmosphereLine(color: vec3<f32>, world_pos: vec3<f32>) -> vec3<f32> {
@@ -86,7 +127,7 @@ fn applyAtmosphereLine(color: vec3<f32>, world_pos: vec3<f32>) -> vec3<f32> {
   return color * T + inscatter * (vec3<f32>(1.0) - T);
 }
 
-fn getColor(lineCoord: vec2f, anchor: vec3f) -> vec4f {
+fn getColor(lineCoord: vec2f, anchor: vec3f, slope: f32) -> vec4f {
   let aaDev = ${AA_WIDTH.toFixed(4)} * line.pixelRatio;
   let halfAa = 0.5 * aaDev;
   let lineDev = line.lineWidth * line.pixelRatio;
@@ -99,7 +140,14 @@ fn getColor(lineCoord: vec2f, anchor: vec3f) -> vec4f {
   // Stroke → halo color transition centered on the stroke/halo boundary.
   let t = smoothstep(lineDev - halfAa, lineDev + halfAa, sdf);
 
-  let lineLinear = srgbToLinear(line.lineColor.rgb);
+  // The stroke is either the layer's uniform line color or a slope-derived
+  // ramp; the halo always uses the configured border color so the line
+  // stays legible against bright/dark terrain regardless of shading mode.
+  var lineRgb = line.lineColor.rgb;
+  if (line.slopeShadingEnabled > 0.5) {
+    lineRgb = slopeToColor(slope);
+  }
+  let lineLinear = srgbToLinear(lineRgb);
   let borderLinear = srgbToLinear(line.borderColor.rgb);
   var linear = mix(lineLinear, borderLinear, t);
   var alpha = mix(line.lineColor.a, line.borderColor.a, t);
@@ -134,6 +182,7 @@ export class LineLayer {
     this._lineWidth = paint['line-width'] || 3;
     this._borderWidth = paint['line-border-width'] || 0;
     this._atmosphereOpacity = paint['atmosphere-opacity'] != null ? paint['atmosphere-opacity'] : 1.0;
+    this._slopeShading = !!paint['line-slope-shading'];
 
     this._gpuLines = null;
     this._positionBuffer = null;
@@ -142,6 +191,7 @@ export class LineLayer {
     this._polylines = [];
     this._positionData = null;
     this._cachedElevations = null; // raw elevation in meters per vertex
+    this._cachedSlopes = null;     // smoothed signed grade fraction per vertex
     this._elevationsDirty = true;
     this._lastExaggeration = -1;
     this._positionsDirty = true;
@@ -200,6 +250,7 @@ export class LineLayer {
     });
     this._positionData = new Float32Array(totalVerts * 4);
     this._cachedElevations = new Float32Array(totalVerts); // raw meters
+    this._cachedSlopes = new Float32Array(totalVerts);     // grade fraction
 
     // Create per-polyline bind groups (group 1) with 256-byte aligned offsets
     let offset = 0;
@@ -235,6 +286,92 @@ export class LineLayer {
 
   invalidateElevations() {
     this._elevationsDirty = true;
+  }
+
+  // Recompute per-vertex slope (signed grade fraction) for every polyline,
+  // using a length-weighted average rise/run over a ~150m window. Matches
+  // the elevation-profile smoothing so the on-terrain coloring and the
+  // profile read the same numbers. Called only when slope shading is on
+  // and elevation data has changed.
+  _recomputeSlopes() {
+    if (!this._cachedSlopes) return;
+    const elevs = this._cachedElevations;
+    const slopes = this._cachedSlopes;
+    const HALF_WINDOW = 75; // meters
+    const EARTH_RADIUS_M = 6371000;
+    const TO_RAD = Math.PI / 180;
+
+    for (const polyline of this._polylines) {
+      const coords = polyline.feature.coordinates;
+      const off = polyline.offset;
+      const n = polyline.count;
+      if (n < 2) {
+        for (let i = 0; i < n; i++) slopes[off + i] = 0;
+        continue;
+      }
+
+      // Cumulative haversine distance along this polyline. Mercator coords
+      // are converted to lon/lat first so the slope is computed against
+      // true horizontal ground distance rather than Mercator-distorted units.
+      const cumDist = new Float64Array(n);
+      for (let i = 1; i < n; i++) {
+        const a = coords[i - 1], b = coords[i];
+        const lon1 = a.mercatorX * 360 - 180;
+        const lon2 = b.mercatorX * 360 - 180;
+        const lat1 = Math.atan(Math.sinh(Math.PI * (1 - 2 * a.mercatorY))) * 180 / Math.PI;
+        const lat2 = Math.atan(Math.sinh(Math.PI * (1 - 2 * b.mercatorY))) * 180 / Math.PI;
+        const dLat = (lat2 - lat1) * TO_RAD;
+        const dLon = (lon2 - lon1) * TO_RAD;
+        const s2 = Math.sin(dLat / 2) ** 2 +
+          Math.cos(lat1 * TO_RAD) * Math.cos(lat2 * TO_RAD) * Math.sin(dLon / 2) ** 2;
+        cumDist[i] = cumDist[i - 1] + 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(s2));
+      }
+
+      const rises = new Float64Array(n - 1);
+      const runs = new Float64Array(n - 1);
+      const midDist = new Float64Array(n - 1);
+      for (let i = 0; i < n - 1; i++) {
+        const e1 = elevs[off + i];
+        const e2 = elevs[off + i + 1];
+        const run = cumDist[i + 1] - cumDist[i];
+        runs[i] = run;
+        midDist[i] = (cumDist[i] + cumDist[i + 1]) * 0.5;
+        rises[i] = (run > 0 && e1 > 0 && e2 > 0) ? (e2 - e1) : NaN;
+      }
+
+      const segS = new Float64Array(n - 1);
+      for (let i = 0; i < n - 1; i++) {
+        if (isNaN(rises[i])) { segS[i] = NaN; continue; }
+        let rise = 0, run = 0;
+        for (let j = i; j < n - 1; j++) {
+          if (midDist[j] - midDist[i] > HALF_WINDOW) break;
+          if (!isNaN(rises[j])) { rise += rises[j]; run += runs[j]; }
+        }
+        for (let j = i - 1; j >= 0; j--) {
+          if (midDist[i] - midDist[j] > HALF_WINDOW) break;
+          if (!isNaN(rises[j])) { rise += rises[j]; run += runs[j]; }
+        }
+        segS[i] = run > 0 ? rise / run : NaN;
+      }
+
+      for (let i = 0; i < n; i++) {
+        const a = i > 0 ? segS[i - 1] : NaN;
+        const b = i < n - 1 ? segS[i] : NaN;
+        let s;
+        if (isNaN(a) && isNaN(b)) s = 0;
+        else if (isNaN(a)) s = b;
+        else if (isNaN(b)) s = a;
+        else s = (a + b) * 0.5;
+        slopes[off + i] = s;
+      }
+    }
+  }
+
+  setSlopeShading(enabled) {
+    const next = !!enabled;
+    if (this._slopeShading === next) return;
+    this._slopeShading = next;
+    this._positionsDirty = true;
   }
 
   prepare(projectionView, canvasW, canvasH, pixelRatio, exaggeration, globalElevScale) {
@@ -277,24 +414,28 @@ export class LineLayer {
 
     // Rebuild world positions when elevations, exaggeration, or global scale change
     if (this._positionsDirty || exaggeration !== this._lastExaggeration || globalElevScale !== this._lastGlobalElevScale) {
+      if (this._slopeShading) this._recomputeSlopes();
       const data = this._positionData;
       const elevs = this._cachedElevations;
+      const slopes = this._cachedSlopes;
+      const slopeShading = this._slopeShading;
       for (const polyline of this._polylines) {
         for (let i = 0; i < polyline.count; i++) {
           const coord = polyline.feature.coordinates[i];
           const elev = elevs[polyline.offset + i];
+          const slope = slopeShading ? slopes[polyline.offset + i] : 0;
           const idx = (polyline.offset + i) * 4;
 
           if (elev == null || elev <= 0) {
             data[idx] = coord.mercatorX;
             data[idx + 1] = 0;
             data[idx + 2] = coord.mercatorY;
-            data[idx + 3] = 1.0;
+            data[idx + 3] = slope;
           } else {
             data[idx] = coord.mercatorX;
             data[idx + 1] = (elev + 3) * globalElevScale * exaggeration;
             data[idx + 2] = coord.mercatorY;
-            data[idx + 3] = 1.0;
+            data[idx + 3] = slope;
           }
         }
       }
@@ -321,6 +462,7 @@ export class LineLayer {
     uniforms[27] = exaggeration;                           // exaggeration
     uniforms[28] = this._atmosphereOpacity;                // atmosphereOpacity
     uniforms[29] = this._depthOffset;                      // depthOffset
+    uniforms[30] = this._slopeShading ? 1 : 0;             // slopeShadingEnabled
     this._device.queue.writeBuffer(this._uniformBuffer, 0, uniforms);
 
     this._canvasW = canvasW;
@@ -348,6 +490,7 @@ export class LineLayer {
     this._polylines = [];
     this._positionData = null;
     this._cachedElevations = null;
+    this._cachedSlopes = null;
     this._elevationCarryover = elevationCarryover || null;
     this._elevationsDirty = true;
     this._positionsDirty = true;


### PR DESCRIPTION
## Summary

Adds an opt-in `'line-slope-shading'` paint property to line layers, using the same green→red HSL ramp as the elevation-profile legend so the chart and the on-terrain line agree exactly.

- Per-vertex slope is computed in `LineLayer` with a length-weighted ~150 m window (sum of rises / sum of runs across the window) and packed into the existing position buffer's `.w` slot — no new buffers, no library changes.
- The vertex struct gains a `slope: f32` varying; the fragment shader runs an inline HSL→sRGB conversion mirroring CSS `hsl()` so the colors track the legend exactly. `SLOPE_MAX_PCT = 35` is shared between shader and JS.
- `LayerManager.getLayers()` / `setLayerPaint()` expose `'line-slope-shading'` like any other paint property.
- Layer panel gets a "Slope shading" checkbox; when checked, the line-color picker is greyed out (the stroke color comes from slope). Border color stays active so the halo keeps doing its legibility job.
- Enabled on the West Buttress feature only. The FKT and drawn paths keep their uniform colors.

## Test plan

- [ ] Load the Denali notebook; West Buttress route renders with a green→red slope gradient that visually matches the elevation profile.
- [ ] Open the layer panel, expand West Buttress; "Slope shading" is checked, "Color" row is greyed out. Uncheck it — line returns to uniform blue, color picker reactivates.
- [ ] Toggle slope shading on the FKT layer manually — should work symmetrically.
- [ ] Drawn paths and other lines render as before (uniform color).
- [ ] As tiles load, the slope-shaded line refines smoothly without flicker.

https://claude.ai/code/session_01Dr39txiWAF1huhnSD5jyV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr39txiWAF1huhnSD5jyV2)_