### PR TITLE
Render elevation-profile hover marker via WebGPU

### DIFF
--- a/src/notebooks/denali/index.html
+++ b/src/notebooks/denali/index.html
@@ -219,40 +219,24 @@
       if (data) elevationProfile.update(data);
     });
 
-    const profileHoverDot = html`<div class="profile-hover-dot"></div>`;
-    let hoverPoint = null;
-
-    function updateHoverDot() {
-      if (!hoverPoint) {
-        profileHoverDot.style.display = 'none';
-        return;
-      }
-      const p = viewer.projectMercator(hoverPoint.mercatorX, hoverPoint.mercatorY, hoverPoint.elevation);
-      if (!p) {
-        profileHoverDot.style.display = 'none';
-        return;
-      }
-      profileHoverDot.style.display = 'block';
-      profileHoverDot.style.left = `${p.x}px`;
-      profileHoverDot.style.top = `${p.y}px`;
-    }
-
+    // The on-map hover marker for the elevation profile is rendered via
+    // WebGPU (see HoverMarker), so it's intrinsically clipped to the map
+    // canvas and lives in the same render pass as the rest of the map.
     elevationProfile.onHover = (point) => {
-      hoverPoint = point;
-      if (point) {
-        const id = elevationProfile.activeLayerId;
-        const layer = id && viewer.getLayer(id);
-        const lc = layer?.paint?.['line-color'];
-        if (lc) {
-          const r = Math.round(lc[0] * 255), g = Math.round(lc[1] * 255), b = Math.round(lc[2] * 255);
-          profileHoverDot.style.background = `rgb(${r},${g},${b})`;
-        }
-        viewer.triggerRedraw();
+      if (!point) {
+        viewer.setHoverPoint(null);
+        return;
       }
-      updateHoverDot();
+      const id = elevationProfile.activeLayerId;
+      const layer = id && viewer.getLayer(id);
+      const lc = layer?.paint?.['line-color'] || [1, 0.53, 0, 1];
+      viewer.setHoverPoint({
+        mercatorX: point.mercatorX,
+        mercatorY: point.mercatorY,
+        elevation: point.elevation,
+        color: lc,
+      });
     };
-
-    viewer.on('render', updateHoverDot);
 
     // Toggle the elevation profile for a line layer.
     function toggleElevationProfile(layerId) {
@@ -287,7 +271,6 @@
     container.appendChild(slopeLegend);
     container.appendChild(viewer.attribution);
     container.appendChild(profilePanel);
-    container.appendChild(profileHoverDot);
 
     const memoryWidget = createMemoryWidget(viewer.memoryTracker);
     // Hidden by default — toggled from the Debug section in the controls.
@@ -1758,21 +1741,6 @@ But let's be clear, this is a totally half-baked one-off ad hoc renderer. It use
         flex: 1;
         width: 100%;
         min-height: 0;
-      }
-
-      .profile-hover-dot {
-        position: absolute;
-        width: 12px;
-        height: 12px;
-        margin: -6px 0 0 -6px;
-        border-radius: 50%;
-        background: #ff8800;
-        border: 2px solid #fff;
-        box-shadow: 0 0 4px rgba(0,0,0,0.5);
-        pointer-events: none;
-        display: none;
-        z-index: 4;
-        will-change: left, top;
       }
 
       .aspect-rose path,

--- a/src/notebooks/denali/mapviewer/rendering/hover-marker.js
+++ b/src/notebooks/denali/mapviewer/rendering/hover-marker.js
@@ -1,0 +1,151 @@
+// Single-instance circle drawn at an arbitrary mercator + elevation point.
+// Used as the on-map marker for elevation-profile hover. Rendering through
+// WebGPU (rather than an HTML overlay) means the marker is intrinsically
+// clipped to the map canvas, lives in the same render pass as the rest of
+// the map, and travels with the camera without any reprojection plumbing.
+//
+// Reuses the existing circle shaders + vertex attribute layout from
+// CircleLayer; the only differences are: a single mutable instance, no
+// terrain elevation query (the caller supplies the elevation so the dot
+// sits exactly on the line being hovered), and always-on-top depth.
+
+import { circleVertexShader, circleFragmentShader } from '../shaders/circle.js';
+
+// Per-instance: worldPos(3f) + radius(1f) + fillColor(4f) + strokeColor(4f) + strokeWidth(1f) + opacity(1f)
+const INSTANCE_FLOATS = 14;
+const INSTANCE_BYTES = INSTANCE_FLOATS * 4;
+// Uniform: mat4(64) + vec2(8) + f32(4) + f32(4) + f32(4) + pad(12) = 96 bytes
+const UNIFORM_BYTES = 96;
+
+export class HoverMarker {
+  constructor() {
+    this._device = null;
+    this._pipeline = null;
+    this._uniformBuffer = null;
+    this._uniformBindGroup = null;
+    this._instanceBuffer = null;
+    this._instanceData = new Float32Array(INSTANCE_FLOATS);
+    this._uniformData = new Float32Array(UNIFORM_BYTES / 4);
+    this._point = null;       // { mercatorX, mercatorY, elevation, color: [r,g,b,a?] }
+    this._radius = 6;
+    this._strokeWidth = 2;
+    this._strokeColor = [1, 1, 1, 1];
+  }
+
+  init(device, globalUniformBGL, format) {
+    this._device = device;
+
+    const circleUniformBGL = device.createBindGroupLayout({
+      entries: [{
+        binding: 0,
+        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+        buffer: { type: 'uniform' },
+      }],
+    });
+
+    this._uniformBuffer = device.createBuffer({
+      size: UNIFORM_BYTES,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this._uniformBindGroup = device.createBindGroup({
+      layout: circleUniformBGL,
+      entries: [{ binding: 0, resource: { buffer: this._uniformBuffer } }],
+    });
+
+    this._instanceBuffer = device.createBuffer({
+      size: INSTANCE_BYTES,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+
+    const vertexModule = device.createShaderModule({ code: circleVertexShader });
+    const fragmentModule = device.createShaderModule({ code: circleFragmentShader });
+    const pipelineLayout = device.createPipelineLayout({
+      bindGroupLayouts: [globalUniformBGL, circleUniformBGL],
+    });
+
+    this._pipeline = device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {
+        module: vertexModule,
+        entryPoint: 'vs_circle',
+        buffers: [{
+          arrayStride: INSTANCE_BYTES,
+          stepMode: 'instance',
+          attributes: [
+            { format: 'float32x3', offset: 0,  shaderLocation: 0 },
+            { format: 'float32',   offset: 12, shaderLocation: 1 },
+            { format: 'float32x4', offset: 16, shaderLocation: 2 },
+            { format: 'float32x4', offset: 32, shaderLocation: 3 },
+            { format: 'float32',   offset: 48, shaderLocation: 4 },
+            { format: 'float32',   offset: 52, shaderLocation: 5 },
+          ],
+        }],
+      },
+      fragment: {
+        module: fragmentModule,
+        entryPoint: 'fs_circle',
+        targets: [{
+          format,
+          blend: {
+            color: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+            alpha: { srcFactor: 'one',       dstFactor: 'one-minus-src-alpha', operation: 'add' },
+          },
+        }],
+      },
+      primitive: { topology: 'triangle-list' },
+      // Always-on-top: the marker matches the existing HTML overlay's
+      // behavior (visible even when the underlying route is occluded by
+      // intervening terrain). The render pass still clips to the canvas
+      // bounds, which is the whole point of moving off the DOM.
+      depthStencil: { format: 'depth32float', depthWriteEnabled: false, depthCompare: 'always' },
+    });
+  }
+
+  setPoint(point) {
+    this._point = point;
+  }
+
+  isActive() {
+    return this._point != null;
+  }
+
+  prepare(projectionView, canvasW, canvasH, pixelRatio, exaggeration, globalElevScale) {
+    if (!this._point) return;
+    const { mercatorX, mercatorY, elevation, color } = this._point;
+    const wx = mercatorX;
+    const wy = (elevation || 0) * globalElevScale * exaggeration;
+    const wz = mercatorY;
+
+    const d = this._instanceData;
+    d[0] = wx; d[1] = wy; d[2] = wz;
+    d[3] = this._radius;
+    d[4] = color[0]; d[5] = color[1]; d[6] = color[2]; d[7] = color[3] != null ? color[3] : 1;
+    d[8] = this._strokeColor[0]; d[9] = this._strokeColor[1]; d[10] = this._strokeColor[2]; d[11] = this._strokeColor[3];
+    d[12] = this._strokeWidth;
+    d[13] = 1.0;
+    this._device.queue.writeBuffer(this._instanceBuffer, 0, d);
+
+    const u = this._uniformData;
+    u.set(projectionView, 0);
+    u[16] = canvasW;
+    u[17] = canvasH;
+    u[18] = pixelRatio;
+    u[19] = exaggeration;
+    u[20] = 1.0; // atmosphere opacity — same scattering treatment as regular circles
+    this._device.queue.writeBuffer(this._uniformBuffer, 0, u);
+  }
+
+  draw(pass, globalUniformBindGroup) {
+    if (!this._point) return;
+    pass.setPipeline(this._pipeline);
+    pass.setBindGroup(0, globalUniformBindGroup);
+    pass.setBindGroup(1, this._uniformBindGroup);
+    pass.setVertexBuffer(0, this._instanceBuffer);
+    pass.draw(6, 1);
+  }
+
+  destroy() {
+    if (this._uniformBuffer) this._uniformBuffer.destroy();
+    if (this._instanceBuffer) this._instanceBuffer.destroy();
+  }
+}

--- a/src/notebooks/denali/mapviewer/rendering/terrain-renderer.ts
+++ b/src/notebooks/denali/mapviewer/rendering/terrain-renderer.ts
@@ -65,6 +65,7 @@ export class TerrainRenderer {
     textLayers: any[];
     frustumOverlay: any;
     collisionManager: any;
+    hoverMarker?: any;
     pixelRatio: number;
     sunTerrainVisibility: number;
   }) {
@@ -72,7 +73,7 @@ export class TerrainRenderer {
       canvas, camera, settings, renderList, tileManager, imageryTileCache, lightingManager,
       exaggeration, globalElevScale,
       lineLayers, circleLayers, textLayers,
-      frustumOverlay, collisionManager, pixelRatio,
+      frustumOverlay, collisionManager, hoverMarker, pixelRatio,
       sunTerrainVisibility,
     } = params;
 
@@ -246,6 +247,10 @@ export class TerrainRenderer {
     for (const entry of textLayers) {
       if (entry.visible) entry.layer.draw(pass);
     }
+
+    // Hover marker (single circle) sits on top of feature layers so it
+    // stays visible even when a route is partially occluded by terrain.
+    if (hoverMarker) hoverMarker.draw(pass, gpu.globalUniformBindGroup);
 
     // Collision debug bounding boxes
     if (settings.showCollisionBoxes) {

--- a/src/notebooks/denali/mapviewer/terrain-viewer.js
+++ b/src/notebooks/denali/mapviewer/terrain-viewer.js
@@ -2,6 +2,7 @@ import { EventEmitter } from './core/event-emitter.ts';
 import { GPUContext } from './rendering/gpu-context.ts';
 import { SkyRenderer } from './rendering/sky-renderer.ts';
 import { TerrainRenderer } from './rendering/terrain-renderer.ts';
+import { HoverMarker } from './rendering/hover-marker.js';
 import { LayerManager } from './layers/layer-manager.ts';
 import { createCameraController } from './camera/camera-controller.js';
 import { tilesetToMercatorBounds, tileUrlFromTemplate, lonToMercatorX, latToMercatorY } from './tiles/tile-math.js';
@@ -234,6 +235,9 @@ export class TerrainMap extends EventEmitter {
     this._frustumOverlay = new FrustumOverlay(device, format, this._pixelRatio, createGPULines);
     this._collisionManager = new CollisionManager(device, format);
     this._collisionManager.onWake = () => { this._renderDirty = true; };
+
+    this._hoverMarker = new HoverMarker();
+    this._hoverMarker.init(device, gpu.globalUniformBGL, format);
 
     this._workerPool = new WorkerPool(
       () => new Worker(new URL('./workers/tile-decode.worker.ts', import.meta.url), { type: 'module' }),
@@ -476,9 +480,22 @@ export class TerrainMap extends EventEmitter {
       textLayers: this._layerManager._textLayers,
       frustumOverlay: this._frustumOverlay,
       collisionManager: this._collisionManager,
+      hoverMarker: this._hoverMarker,
       pixelRatio: this._pixelRatio,
       sunTerrainVisibility: this._computeSunTerrainVisibility(),
     });
+  }
+
+  /**
+   * Set or clear the on-map hover marker shown for the elevation-profile
+   * hover position. Pass null to hide. The marker is rendered via WebGPU
+   * inside the map canvas, so it's intrinsically clipped to the map bounds.
+   *
+   * @param {{mercatorX: number, mercatorY: number, elevation: number, color: number[]} | null} point
+   */
+  setHoverPoint(point) {
+    this._hoverMarker.setPoint(point);
+    this.triggerRedraw();
   }
 
   /**
@@ -736,6 +753,9 @@ export class TerrainMap extends EventEmitter {
     }
 
     this._layerManager.prepareLayers(projectionView, canvas.width, canvas.height, this._pixelRatio, this._currentExaggeration, this._globalElevScale);
+    if (this._hoverMarker.isActive()) {
+      this._hoverMarker.prepare(projectionView, canvas.width, canvas.height, this._pixelRatio, this._currentExaggeration, this._globalElevScale);
+    }
 
     this.emit('elevationrefine');
 
@@ -1042,6 +1062,7 @@ export class TerrainMap extends EventEmitter {
     this.canvas.removeEventListener('pointercancel', this._onPickPointerCancel);
     this._collisionManager.destroy();
     this._frustumOverlay.destroy();
+    this._hoverMarker.destroy();
     this._resizeObserver.disconnect();
     this.camera.destroy();
     this._layerManager.destroyAll();


### PR DESCRIPTION
## Summary

Replaces the HTML `.profile-hover-dot` overlay with a WebGPU-rendered single-instance circle drawn inside the map's render pass. The HTML dot was positioned absolutely against the map container without overflow clipping, so when the projected point fell outside the map widget the dot would render elsewhere on the page.

- New `HoverMarker` class under `mapviewer/rendering/`, reusing the existing circle vertex/fragment shaders and attribute layout from `CircleLayer`. Single mutable instance, elevation supplied by the caller (so the dot sits exactly on the line being hovered — no terrain re-query), and `depthCompare: 'always'` so it stays visible when the route is behind terrain (matching the prior HTML overlay's behavior).
- `TerrainMap.setHoverPoint(point | null)` is the public API. The notebook plumbs the elevation-profile `onHover` callback straight into it, picking up the active layer's `line-color` so the dot tracks the route's color.
- Removed the HTML element, its CSS rule, and the per-frame `updateHoverDot` reprojection — the GPU draws against the current `projectionView` directly.

Because rendering goes through the canvas, the marker is intrinsically clipped to the map widget — no more dots showing up in the article.

## Test plan

- [ ] Open the Denali notebook, show an elevation profile, hover across it: dot follows the route inside the map.
- [ ] Drag profile hover to a position whose projection falls outside the map widget — dot does not escape the canvas (used to leak into the page).
- [ ] Pan/orbit while hovering — dot tracks correctly with the camera.
- [ ] Toggle multiple routes' profiles — dot color matches the active route's `line-color`.
- [ ] Leave the profile (mouseleave) — dot disappears.

https://claude.ai/code/session_01Dr39txiWAF1huhnSD5jyV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr39txiWAF1huhnSD5jyV2)_