### PR TITLE
Retry transient tile fetch failures on mobile

### DIFF
--- a/src/notebooks/denali/mapviewer/lighting/lighting-manager.js
+++ b/src/notebooks/denali/mapviewer/lighting/lighting-manager.js
@@ -203,6 +203,14 @@ export class LightingManager {
       shadowInflight: false,
       shadowDirty: false,
       abortController: null,
+      // Zoom of the source that last wrote to this.texture via
+      // _tryFillFromAncestor's blit, or null if no blit has happened yet.
+      // _tryFillFromAncestor uses this to refuse downgrade blits — without
+      // this guard the cascade after a coarse-tile bake could replace
+      // higher-resolution upsampled data with much coarser data whenever
+      // the previous (closer) source had been evicted or had its `baked`
+      // flag flipped back to false by onSunChanged.
+      blitSourceZ: null,
     };
     this.tiles.set(key, state);
     this._tryFillFromAncestor(state);
@@ -220,6 +228,12 @@ export class LightingManager {
     while (pz >= 0) {
       const parent = this.tiles.get(`${pz}/${px}/${py}`);
       if (parent && parent.baked && parent.texture) {
+        // The walk goes deepest-zoom first, so this is the closest baked
+        // ancestor in `this.tiles`. If the descendant already holds blit
+        // data from a strictly closer source, this candidate is a
+        // downgrade — keep what we have. Same-zoom passes through so a
+        // shadow rebake on the same source can refresh the descendant.
+        if (state.blitSourceZ != null && pz < state.blitSourceZ) return false;
         const dz = state.z - pz;
         const scale = 1 << dz;
         const quadX = state.x & (scale - 1);
@@ -227,6 +241,7 @@ export class LightingManager {
         this._runUpsamplePass(parent.texture, state.texture, state.compN,
           quadX / scale, quadY / scale, 1 / scale);
         this.tileManager.attachShading(state.z, state.x, state.y, state.view);
+        state.blitSourceZ = pz;
         return true;
       }
       pz--;

--- a/src/notebooks/denali/mapviewer/lighting/lighting-manager.js
+++ b/src/notebooks/denali/mapviewer/lighting/lighting-manager.js
@@ -227,11 +227,35 @@ export class LightingManager {
         this._runUpsamplePass(parent.texture, state.texture, state.compN,
           quadX / scale, quadY / scale, 1 / scale);
         this.tileManager.attachShading(state.z, state.x, state.y, state.view);
-        return;
+        return true;
       }
       pz--;
       px >>= 1;
       py >>= 1;
+    }
+    return false;
+  }
+
+  // After a bake (static or shadow) writes to `source.texture`, any unbaked
+  // descendant whose own bake hasn't landed yet should re-pull from the
+  // ancestor chain — `source` may now be the closest baked tile available
+  // and the descendant's shading texture was either empty (cold start, no
+  // ancestor at allocate time) or stamped from a further-back ancestor.
+  // `_tryFillFromAncestor` re-walks the chain and is a no-op when a closer
+  // baked ancestor already provided data; for the cases we care about
+  // (cold-start cascade after the first bake completes, zoom-in where the
+  // freshly arrived parent is now closer than any earlier blit source)
+  // it picks `source` and re-blits, then re-attaches the shading view.
+  _cascadeToDescendants(source) {
+    for (const state of this.tiles.values()) {
+      if (state === source) continue;
+      if (state.baked) continue;       // own bake authoritative
+      if (state.staticInflight) continue; // about to overwrite anyway
+      const dz = state.z - source.z;
+      if (dz <= 0) continue;
+      if ((state.x >> dz) !== source.x) continue;
+      if ((state.y >> dz) !== source.y) continue;
+      this._tryFillFromAncestor(state);
     }
   }
 
@@ -535,6 +559,7 @@ export class LightingManager {
       s.baked = true;
       this.tileManager.attachShading(s.z, s.x, s.y, s.view);
       if (this.onShadingReady) this.onShadingReady(s.z, s.x, s.y);
+      this._cascadeToDescendants(s);
     }).catch((err) => {
       const s = this.tiles.get(key);
       // Only clear inflight if this is still the current bake; otherwise
@@ -594,6 +619,10 @@ export class LightingManager {
         { width: compN, height: compN, depthOrArrayLayers: 1 },
       );
       if (this.onShadingReady) this.onShadingReady(s.z, s.x, s.y);
+      // The shadow rebake replaced the shadow channel with new sun-relative
+      // data; descendant tiles still showing this tile's pre-rebake shadows
+      // (via _tryFillFromAncestor) need a fresh blit to pick the new ones up.
+      this._cascadeToDescendants(s);
     }).catch((err) => {
       const s = this.tiles.get(key);
       if (s) s.shadowInflight = false;

--- a/src/notebooks/denali/mapviewer/terrain-viewer.js
+++ b/src/notebooks/denali/mapviewer/terrain-viewer.js
@@ -1079,6 +1079,12 @@ export class TerrainMap extends EventEmitter {
     this.camera.destroy();
     this._layerManager.destroyAll();
     this._lightingManager.destroy();
+    this._tileManager.destroy();
+    if (this._imageryTileCache && this._imageryTileCache.layers) {
+      for (const layer of this._imageryTileCache.layers) {
+        if (layer.imageryManager && layer.imageryManager.destroy) layer.imageryManager.destroy();
+      }
+    }
     this._workerPool.destroy();
     this._gpu.destroy();
   }

--- a/src/notebooks/denali/mapviewer/tiles/imagery-manager.ts
+++ b/src/notebooks/denali/mapviewer/tiles/imagery-manager.ts
@@ -20,6 +20,9 @@ export class ImageryManager {
   pending: Map<string, Promise<void>>;
   abortControllers: Map<string, AbortController>;
   failed: Set<string>;
+  // Keys whose last fetch failed transiently (5xx, network error); holds
+  // the setTimeout id until the backoff expires and the request is re-pushed.
+  _retryTimers: Map<string, ReturnType<typeof setTimeout>>;
   consumers: Map<string, Set<string>>;
   terrainToSat: Map<string, Set<string>>;
   activeRequests: number;
@@ -27,6 +30,7 @@ export class ImageryManager {
   onTileLoaded: ((sz: number, sx: number, sy: number) => void) | null;
   bounds: ImageryBounds | null;
   private _settings: any;
+  private _onOnline: (() => void) | null = null;
 
   constructor({ tileUrl, settings = null }: {
     tileUrl?: (z: number, x: number, y: number) => string;
@@ -37,6 +41,7 @@ export class ImageryManager {
     this.pending = new Map();
     this.abortControllers = new Map();
     this.failed = new Set();
+    this._retryTimers = new Map();
     this.consumers = new Map();
     this.terrainToSat = new Map();
     this.activeRequests = 0;
@@ -44,6 +49,10 @@ export class ImageryManager {
     this.onTileLoaded = null;
     this.bounds = null;
     this._settings = settings;
+    if (typeof window !== 'undefined' && window.addEventListener) {
+      this._onOnline = () => this._wakeAllRetries();
+      window.addEventListener('online', this._onOnline);
+    }
   }
 
   setBounds(bounds: ImageryBounds): void {
@@ -80,6 +89,9 @@ export class ImageryManager {
     satSet.add(key);
 
     if (this.fetched.has(key) || this.failed.has(key) || this.pending.has(key)) return;
+    // A transient failure is waiting out its backoff; the retry timer will
+    // re-push when it expires.
+    if (this._retryTimers.has(key)) return;
 
     if (this.bounds && this._isOutOfBounds(z, x, y)) {
       this.failed.add(key);
@@ -161,22 +173,80 @@ export class ImageryManager {
     }
   }
 
+  // Schedule a retry for a transient failure. Mobile networks routinely
+  // produce 5xx / TypeError on fetch; the old behavior of marking the key
+  // permanently failed left imagery tiles blank with no recovery path since
+  // _onSatelliteTileLoaded only fires on success.
+  _scheduleRetry(z: number, x: number, y: number, key: string): void {
+    if (this._retryTimers.has(key)) return;
+    const timer = setTimeout(() => {
+      this._retryTimers.delete(key);
+      if (this.fetched.has(key) || this.failed.has(key) || this.pending.has(key)) return;
+      // If every consumer was released during the backoff, drop the retry —
+      // we'd waste a fetch on a tile no one wants.
+      const consumers = this.consumers.get(key);
+      if (!consumers || consumers.size === 0) return;
+      this.requestQueue.push({ z, x, y, key });
+      this._processQueue();
+    }, 3000);
+    this._retryTimers.set(key, timer);
+  }
+
+  _wakeAllRetries(): void {
+    for (const [key, timer] of this._retryTimers) {
+      clearTimeout(timer);
+      if (this.fetched.has(key) || this.failed.has(key) || this.pending.has(key)) continue;
+      const consumers = this.consumers.get(key);
+      if (!consumers || consumers.size === 0) continue;
+      const [zStr, xStr, yStr] = key.split('/');
+      this.requestQueue.push({ z: +zStr, x: +xStr, y: +yStr, key });
+    }
+    this._retryTimers.clear();
+    this._processQueue();
+  }
+
   async _loadTile(z: number, x: number, y: number, key: string, signal: AbortSignal): Promise<void> {
+    let response: Response;
     try {
       const url = this.tileUrl(z, x, y);
-      const response = await fetch(url, { signal });
-      if (!response.ok) {
-        this.failed.add(key);
+      response = await fetch(url, { signal });
+    } catch (e: any) {
+      if (e && e.name === 'AbortError') return;
+      // Network-layer error (offline, DNS, reset). Transient.
+      this._scheduleRetry(z, x, y, key);
+      return;
+    }
+    if (!response.ok) {
+      if (response.status >= 500) {
+        // Server failure — usually transient.
+        this._scheduleRetry(z, x, y, key);
         return;
       }
+      // 4xx: tile is authoritatively missing or forbidden. Permanent.
+      this.failed.add(key);
+      return;
+    }
+    try {
       const blob = await response.blob();
       const bitmap = await createImageBitmap(blob);
       this.fetched.set(key, bitmap);
 
       if (this.onTileLoaded) this.onTileLoaded(z, x, y);
     } catch (e: any) {
-      if (e.name === 'AbortError') return;
-      this.failed.add(key);
+      if (e && e.name === 'AbortError') return;
+      // Body stream / decode failure — treat as transient. The OS or radio
+      // can interrupt downloads mid-stream and the next attempt usually
+      // succeeds.
+      this._scheduleRetry(z, x, y, key);
+    }
+  }
+
+  destroy(): void {
+    for (const timer of this._retryTimers.values()) clearTimeout(timer);
+    this._retryTimers.clear();
+    if (this._onOnline && typeof window !== 'undefined' && window.removeEventListener) {
+      window.removeEventListener('online', this._onOnline);
+      this._onOnline = null;
     }
   }
 }

--- a/src/notebooks/denali/mapviewer/tiles/imagery-tile-cache.js
+++ b/src/notebooks/denali/mapviewer/tiles/imagery-tile-cache.js
@@ -7,6 +7,14 @@
 
 const CANVAS_SIZE = 512;
 
+// Mid-gray placeholder for tiles that have no real bitmap data and no
+// composited ancestor to fall back on. After the shader's srgbToLinear
+// converts it (~0.21 linear) and lighting/atmosphere are applied, this
+// reads as "neutral overcast terrain" — much closer to the eventual
+// imagery than the WebGPU zero-init black, which produced the
+// "dark with atmosphere only" look reported on mobile.
+const PLACEHOLDER_GRAY = 0.5;
+
 export class ImageryTileCache {
   /**
    * @param {GPUDevice} device
@@ -22,9 +30,139 @@ export class ImageryTileCache {
     this.entries = new Map(); // key -> entry
     this.onUpdate = null;
 
+    this._initUpsamplePipeline();
+
     for (const layer of layers) {
       layer.imageryManager.onTileLoaded = (sz, sx, sy) => this._onSatelliteTileLoaded(layer, sz, sx, sy);
     }
+  }
+
+  // Mirrors LightingManager's upsample pipeline: a fullscreen-triangle
+  // textured-blit that copies a sub-region of a source texture into a
+  // destination texture at a given UV offset and scale. Used to seed new
+  // imagery entries from an already-composited ancestor entry so newly
+  // created child tiles render parent imagery upsampled in place of black.
+  _initUpsamplePipeline() {
+    const wgsl = /* wgsl */`
+      struct VsOut {
+        @builtin(position) pos: vec4<f32>,
+        @location(0) uv: vec2<f32>,
+      };
+
+      struct Params {
+        uv_offset: vec2<f32>,
+        uv_scale: vec2<f32>,
+      };
+
+      @group(0) @binding(0) var srcTex: texture_2d<f32>;
+      @group(0) @binding(1) var srcSampler: sampler;
+      @group(0) @binding(2) var<uniform> params: Params;
+
+      @vertex
+      fn vs(@builtin(vertex_index) idx: u32) -> VsOut {
+        var pos = array<vec2<f32>, 3>(
+          vec2<f32>(-1.0, -1.0),
+          vec2<f32>( 3.0, -1.0),
+          vec2<f32>(-1.0,  3.0),
+        );
+        var uvs = array<vec2<f32>, 3>(
+          vec2<f32>(0.0, 1.0),
+          vec2<f32>(2.0, 1.0),
+          vec2<f32>(0.0, -1.0),
+        );
+        var out: VsOut;
+        out.pos = vec4<f32>(pos[idx], 0.0, 1.0);
+        out.uv = uvs[idx];
+        return out;
+      }
+
+      @fragment
+      fn fs(in: VsOut) -> @location(0) vec4<f32> {
+        let src_uv = params.uv_offset + in.uv * params.uv_scale;
+        return textureSample(srcTex, srcSampler, src_uv);
+      }
+    `;
+    const module = this.device.createShaderModule({ code: wgsl });
+    this._upsamplePipeline = this.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: { module, entryPoint: 'vs' },
+      fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm' }] },
+      primitive: { topology: 'triangle-list' },
+    });
+    this._upsampleSampler = this.device.createSampler({
+      magFilter: 'linear',
+      minFilter: 'linear',
+    });
+    this._upsampleUniformBuf = this.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+  }
+
+  _runUpsamplePass(srcTex, dstTex, uvOffsetX, uvOffsetY, uvScale) {
+    this.device.queue.writeBuffer(
+      this._upsampleUniformBuf, 0,
+      new Float32Array([uvOffsetX, uvOffsetY, uvScale, uvScale]),
+    );
+    const bindGroup = this.device.createBindGroup({
+      layout: this._upsamplePipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: srcTex.createView() },
+        { binding: 1, resource: this._upsampleSampler },
+        { binding: 2, resource: { buffer: this._upsampleUniformBuf } },
+      ],
+    });
+    const encoder = this.device.createCommandEncoder({ label: 'imagery.upsample' });
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [{
+        view: dstTex.createView(),
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: 0, g: 0, b: 0, a: 1 },
+      }],
+    });
+    pass.setPipeline(this._upsamplePipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+    this.device.queue.submit([encoder.finish()]);
+  }
+
+  _clearTextureToGray(texture) {
+    const encoder = this.device.createCommandEncoder({ label: 'imagery.clearGray' });
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture.createView(),
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: PLACEHOLDER_GRAY, g: PLACEHOLDER_GRAY, b: PLACEHOLDER_GRAY, a: 1.0 },
+      }],
+    });
+    pass.end();
+    this.device.queue.submit([encoder.finish()]);
+  }
+
+  // Walk up the ancestor chain to find the closest entry that already has
+  // content, and blit its corresponding quadrant into the new entry's
+  // texture. Mirrors LightingManager._tryFillFromAncestor. Returns true
+  // if any ancestor was found.
+  _blitFromAncestorEntry(entry) {
+    const { iz, ix, iy } = entry;
+    for (let dz = 1; dz <= iz; dz++) {
+      const pz = iz - dz;
+      const px = ix >> dz;
+      const py = iy >> dz;
+      const parent = this.entries.get(this._key(pz, px, py));
+      if (parent && parent.hasContent) {
+        const scale = 1 << dz;
+        const quadX = ix & (scale - 1);
+        const quadY = iy & (scale - 1);
+        this._runUpsamplePass(parent.texture, entry.texture,
+          quadX / scale, quadY / scale, 1 / scale);
+        return true;
+      }
+    }
+    return false;
   }
 
   _key(z, x, y) {
@@ -93,12 +231,27 @@ export class ImageryTileCache {
     };
     this.entries.set(key, entry);
 
+    // Seed the texture with the best placeholder available before any
+    // network round-trip. Ancestor blit produces a smoothly upsampled view
+    // of the parent imagery in the right spatial location; the gray fill
+    // is a fallback when the cache has no ancestor (cold start). Either
+    // way the tile renders as something visually coherent immediately,
+    // instead of falling through the renderer's "no imagery" branch which
+    // — combined with hillshade and atmosphere — produced the near-black
+    // tiles reported on mobile. Real bitmap data overwrites the placeholder
+    // via _recomposite.
+    if (!this._blitFromAncestorEntry(entry)) {
+      this._clearTextureToGray(texture);
+    }
+    entry.hasContent = true;
+
     // Request satellite tiles from each layer
     for (const ld of layerData) {
       ld.imageryManager.requestTile(ld.satZ, ld.satX, ld.satY, key);
     }
 
-    // Composite what's available now
+    // Composite what's available now (overwrites the placeholder if any
+    // bitmap or bitmap-level ancestor has already loaded).
     this._recomposite(entry);
   }
 

--- a/src/notebooks/denali/mapviewer/tiles/tile-manager.js
+++ b/src/notebooks/denali/mapviewer/tiles/tile-manager.js
@@ -83,7 +83,12 @@ export class TileManager {
     this._settings = settings;
     this.cache = new Map(); // key -> { texture, bindGroup, lastUsed }
     this.pending = new Map(); // key -> AbortController
-    this.failed = new Set(); // keys that 404'd (tile doesn't exist)
+    this.failed = new Set(); // keys that 404'd (tile doesn't exist — permanent)
+    // Keys whose last fetch failed transiently (5xx, network error). Holds
+    // the setTimeout id until the backoff expires; mobile networks routinely
+    // produce these and the old behavior of conflating them with 404 left
+    // tiles permanently blank.
+    this._retryTimers = new Map(); // key -> setTimeout id while backoff is in effect
     this.activeRequests = 0;
     this.requestQueue = [];
     this.bindGroupLayout = null; // set by main.js
@@ -96,6 +101,14 @@ export class TileManager {
     // coverage pass; null disables sorting (pure FIFO). Coordinates are
     // mercator world (X=east, Y=up, Z=south); tile centers use Y=0.
     this._cameraPos = null;
+
+    // Wake all suspended retries when the device comes back online — fetch
+    // failures during an offline interval are otherwise stuck waiting for
+    // their individual backoffs to expire one by one.
+    if (typeof window !== 'undefined' && window.addEventListener) {
+      this._onOnline = () => this._wakeAllRetries();
+      window.addEventListener('online', this._onOnline);
+    }
   }
 
   // Called by selectImageryTiles each coverage pass so the request queue
@@ -234,6 +247,9 @@ export class TileManager {
     const key = this._key(z, x, y);
     this.wantedKeys.add(key);
     if (this.cache.has(key) || this.pending.has(key) || this.failed.has(key)) return;
+    // A transient failure is currently waiting out its backoff — the timer
+    // will fire onTileResolved when it expires and coverage will re-request.
+    if (this._retryTimers.has(key)) return;
 
     if (this.bounds && this._isOutOfBounds(z, x, y)) {
       this.failed.add(key);
@@ -301,16 +317,59 @@ export class TileManager {
     return dx * dx + dy * dy + dz * dz;
   }
 
+  // Schedule a retry for a transient failure (5xx, network error, body
+  // stream interruption). Mobile radios commonly produce these and the old
+  // behavior — conflating them with a 404 by marking the key permanently
+  // failed — left whole regions of the map blank with no recovery path.
+  // The fixed 3s backoff (cleared when the device returns online) keeps
+  // throughput bounded without giving up on the tile.
+  _scheduleRetry(z, x, y, key) {
+    if (this._retryTimers.has(key)) return;
+    const timer = setTimeout(() => {
+      this._retryTimers.delete(key);
+      if (this.cache.has(key) || this.failed.has(key) || this.pending.has(key)) return;
+      // Fire onTileResolved so terrain-viewer marks coverage dirty and the
+      // next frame re-requests the tile if it's still wanted. Re-pushing
+      // directly here would bypass the wantedKeys check and waste fetches
+      // on tiles that have scrolled out of view.
+      if (this.onTileResolved) this.onTileResolved(z, x, y);
+    }, 3000);
+    this._retryTimers.set(key, timer);
+  }
+
+  _wakeAllRetries() {
+    for (const [key, timer] of this._retryTimers) {
+      clearTimeout(timer);
+      const [zStr, xStr, yStr] = key.split('/');
+      if (this.onTileResolved) this.onTileResolved(+zStr, +xStr, +yStr);
+    }
+    this._retryTimers.clear();
+  }
+
   async _loadTile(z, x, y, key, signal) {
+    let response;
     try {
       const url = this.tileUrl(z, x, y);
-      const response = await fetch(url, { signal });
-      if (!response.ok) {
-        this.failed.add(key);
-        this._cacheFlatTile(key);
-        if (this.onTileResolved) this.onTileResolved(z, x, y);
+      response = await fetch(url, { signal });
+    } catch (e) {
+      if (e && e.name === 'AbortError') return;
+      // Network-layer error (no DNS, connection reset, offline). Transient.
+      this._scheduleRetry(z, x, y, key);
+      return;
+    }
+    if (!response.ok) {
+      if (response.status >= 500) {
+        // Server failure — usually transient (load shedding, gateway timeout).
+        this._scheduleRetry(z, x, y, key);
         return;
       }
+      // 4xx: tile is authoritatively missing or forbidden. Permanent.
+      this.failed.add(key);
+      this._cacheFlatTile(key);
+      if (this.onTileResolved) this.onTileResolved(z, x, y);
+      return;
+    }
+    try {
       const blob = await response.blob();
       const bitmap = await createImageBitmap(blob, { colorSpaceConversion: 'none' });
 
@@ -388,10 +447,12 @@ export class TileManager {
 
       if (this.onTileResolved) this.onTileResolved(z, x, y);
     } catch (e) {
-      if (e.name === 'AbortError') return;
-      this.failed.add(key);
-      this._cacheFlatTile(key);
-      if (this.onTileResolved) this.onTileResolved(z, x, y);
+      if (e && e.name === 'AbortError') return;
+      // Body stream interruption or createImageBitmap rejection — usually
+      // transient on mobile (the OS may abort fetches mid-stream under
+      // memory pressure or radio handoff). Schedule a retry rather than
+      // permanently failing the tile.
+      this._scheduleRetry(z, x, y, key);
     }
   }
 
@@ -519,5 +580,14 @@ export class TileManager {
   beginFrame() {
     this.requestQueue = [];
     this.wantedKeys = new Set();
+  }
+
+  destroy() {
+    for (const timer of this._retryTimers.values()) clearTimeout(timer);
+    this._retryTimers.clear();
+    if (this._onOnline && typeof window !== 'undefined' && window.removeEventListener) {
+      window.removeEventListener('online', this._onOnline);
+      this._onOnline = null;
+    }
   }
 }

--- a/src/notebooks/denali/mapviewer/tiles/tile-manager.js
+++ b/src/notebooks/denali/mapviewer/tiles/tile-manager.js
@@ -165,6 +165,11 @@ export class TileManager {
   attachShading(z, x, y, shadingView) {
     const entry = this.cache.get(this._key(z, x, y));
     if (!entry || entry.isFlat) return;
+    // Skip the bind-group rebuild when the view is unchanged — the cascade
+    // from a bake completion may re-attach the same state.view repeatedly
+    // (the texture content changed, but the view didn't), and there's no
+    // need to allocate a fresh bind group in that case.
+    if (entry.shadingView === shadingView) return;
     entry.shadingView = shadingView;
     entry.bindGroup = this._createTileBindGroup(entry.texture, shadingView);
   }


### PR DESCRIPTION
TileManager and ImageryManager treated every fetch failure — HTTP 5xx,
network TypeError, mid-stream aborts — the same as a 404, marking the
key permanently failed. On mobile, radio handoffs and memory-pressure
fetch aborts hit this path often, leaving tiles permanently blank with
no recovery: terrain tiles cached as flat poisoned the coverage cascade
and skipped the lighting bake, while imagery entries never received the
notification that would let them recomposite to an ancestor fallback.

Distinguish 4xx (authoritatively permanent) from 5xx and network errors
(transient) and schedule a 3s retry for the latter. An 'online' listener
wakes all suspended retries when the device returns from an offline
interval. TileManager fires onTileResolved when the backoff expires so
coverage re-evaluates whether the tile is still wanted; ImageryManager
re-pushes directly if any consumer remains.