### PR TITLE
Refactor warmup loop to separate hull pushes from shadow deposits

### DIFF
--- a/src/notebooks/denali/mapviewer/lighting/sweep-core.js
+++ b/src/notebooks/denali/mapviewer/lighting/sweep-core.js
@@ -450,21 +450,80 @@ export function sweepCore(opts) {
       }
     } else if (hasHorizon) {
       const warmStart = cxEntry - WARMUP_STEPS;
-      for (let cx = warmStart; cx < cxEntry; cx++) {
+
+      // Parent-rate hull pushes: place hull entries at parent pixel centres
+      // (cxP = parentScale*(k+parentCenterOffset) − warmupMarginX) so that
+      // the bilinear formula gives hxf = k exactly (or hyf = k for swap).
+      // An exact integer index means fx = 0 (or fy = 0), collapsing the
+      // bilinear to a 1-D linear interp in the cross-ray axis at fixed
+      // along-ray column k — no pixel k+1 is touched. Without this, a
+      // comp-rate integer step at cx = −1 gives hxf = 127.25 for
+      // parentScale = 2, which blends in 25 % of parent pixel 128 (centred
+      // 1 child pixel inside the comp tile). If the comp tile has high
+      // terrain near its left edge that 25 % contribution inflates the hull
+      // entry and casts a false shadow on the first comp rows even when the
+      // sun is clearly above the outside terrain.
+      const firstK = Math.max(
+        0,
+        Math.ceil(
+          (warmStart + warmupMarginX) / parentScale - parentCenterOffset,
+        ),
+      );
+      const lastK =
+        Math.ceil(
+          (cxEntry + warmupMarginX) / parentScale - parentCenterOffset,
+        ) - 1;
+      for (let k = firstK; k <= lastK; k++) {
+        const cxP = parentScale * (k + parentCenterOffset) - warmupMarginX;
+        const yP = b + slope * cxP;
+        let oxfP = swap ? yP : cxP;
+        let oyfP = swap ? cxP : yP;
+        if (flipX) oxfP = W - 1 - oxfP;
+        if (flipY) oyfP = H - 1 - oyfP;
+        const hxfP = (oxfP + warmupMarginX) * invParentScale - parentCenterOffset;
+        const hyfP = (oyfP + warmupMarginY) * invParentScale - parentCenterOffset;
+        const hxiP = Math.floor(hxfP);
+        const hyiP = Math.floor(hyfP);
+        if (hxiP < 0 || hxiP + 1 >= HN) continue;
+        if (hyiP < 0 || hyiP + 1 >= HN) continue;
+        const fxP = hxfP - hxiP;
+        const fyP = hyfP - hyiP;
+        const h00P = horizon[hyiP * HN + hxiP];
+        const h10P = horizon[hyiP * HN + hxiP + 1];
+        const h01P = horizon[(hyiP + 1) * HN + hxiP];
+        const h11P = horizon[(hyiP + 1) * HN + hxiP + 1];
+        const hWP =
+          (1 - fxP) * (1 - fyP) * h00P +
+          fxP * (1 - fyP) * h10P +
+          (1 - fxP) * fyP * h01P +
+          fxP * fyP * h11P;
+        if (horizonTouched) {
+          const tBit = b >= 0 ? 1 : 2;
+          horizonTouched[hyiP * HN + hxiP] |= tBit;
+          horizonTouched[hyiP * HN + hxiP + 1] |= tBit;
+          horizonTouched[(hyiP + 1) * HN + hxiP] |= tBit;
+          horizonTouched[(hyiP + 1) * HN + hxiP + 1] |= tBit;
+        }
+        pushHull(cxP, hWP);
+      }
+
+      // Comp-rate edge-straddle deposits: for rays entering the canonical
+      // view from the top (b < 0, cxEntry > 0), pixels at cx ∈ [0, cxEntry)
+      // are only visited here — the main pass starts at cxEntry and never
+      // revisits them. Deposit their shadow contribution using the hull
+      // already populated by the parent-rate loop. No hull push here.
+      for (let cx = Math.max(warmStart, 0); cx < cxEntry; cx++) {
         const y = b + slope * cx;
+        const yi = Math.floor(y);
+        const fy = y - yi;
+        const yj = yi + 1;
+        const loIn = yi >= 0 && yi < viewH;
+        const hiIn = yj >= 0 && yj < viewH;
+        if (!loIn && !hiIn) continue;
         let oxf = swap ? y : cx;
         let oyf = swap ? cx : y;
         if (flipX) oxf = W - 1 - oxf;
         if (flipY) oyf = H - 1 - oyf;
-        // Elevations are defined at pixel centres. See the derivation
-        // of `warmupMargin` / `parentCenterOffset` above: this is the
-        // pixel-centre-preserving child→horizon map, generalised to
-        // parentScale = 2^dz. Without the `-parentCenterOffset` term,
-        // the hull entry pushed from the last warmup step at canonical
-        // cx = −1 would carry a height sampled from a half-parent-
-        // pixel-earlier physical position, producing a slope at the
-        // first comp pixel that's off by a pixel — and a faint
-        // shadow band along tile edges in LSAO.
         const hxf = (oxf + warmupMarginX) * invParentScale - parentCenterOffset;
         const hyf = (oyf + warmupMarginY) * invParentScale - parentCenterOffset;
         const hxi = Math.floor(hxf);
@@ -482,45 +541,11 @@ export function sweepCore(opts) {
           fx * (1 - fy2) * h10 +
           (1 - fx) * fy2 * h01 +
           fx * fy2 * h11;
-        if (horizonTouched) {
-          const tBit = b >= 0 ? 1 : 2;
-          horizonTouched[hyi * HN + hxi] |= tBit;
-          horizonTouched[hyi * HN + hxi + 1] |= tBit;
-          horizonTouched[(hyi + 1) * HN + hxi] |= tBit;
-          horizonTouched[(hyi + 1) * HN + hxi + 1] |= tBit;
-        }
-
-        // Deposit the edge-straddle contribution. This fires only at
-        // the few cx positions near the tile boundary where the ray's
-        // yj (or yi) is back in [0, viewH) AND cx is itself in the
-        // canonical view range [0, viewW). The cx guard matters
-        // because `toOrig` doesn't bounds-check its inputs — under
-        // a flipX/flipY sweep, a negative canonical cx maps through
-        // `W - 1 - cx` into an `ox > W − 1` that still produces a
-        // numerically valid (but physically meaningless) output index
-        // once the `oy*W + ox` is computed, which would deposit the
-        // ray's shadow into a wrap-around pixel on the opposite side
-        // of the tile. The main pass doesn't hit this because its
-        // cx iterator is already clamped to [cxEntry, viewW).
-        //
-        // `computeBit` must be called before the hull push, so it
-        // scans the hull *without* the current sample — matching
-        // the main pass's ordering.
-        const inView = cx >= 0 && cx < viewW;
-        const yi = Math.floor(y);
-        const fy = y - yi;
-        const yj = yi + 1;
-        const loIn = yi >= 0 && yi < viewH;
-        const hiIn = yj >= 0 && yj < viewH;
-        if (inView && (loIn || hiIn)) {
-          if (updateTargetPx) updateTargetPx(cx, loIn ? yi : yj);
-          const bit = computeBit(cx, hW);
-          const contrib = bit * weight;
-          if (loIn) out[toOrig(cx, yi)] += (1 - fy) * contrib;
-          if (hiIn) out[toOrig(cx, yj)] += fy * contrib;
-        }
-
-        pushHull(cx, hW);
+        if (updateTargetPx) updateTargetPx(cx, loIn ? yi : yj);
+        const bit = computeBit(cx, hW);
+        const contrib = bit * weight;
+        if (loIn) out[toOrig(cx, yi)] += (1 - fy) * contrib;
+        if (hiIn) out[toOrig(cx, yj)] += fy * contrib;
       }
     }
 

--- a/src/notebooks/denali/mapviewer/lighting/webgpu-pipelines.js
+++ b/src/notebooks/denali/mapviewer/lighting/webgpu-pipelines.js
@@ -280,20 +280,28 @@ function warmupBlock(prewarm, mode, lsaoFalloff) {
       let warmStart: i32 = cxEntry - WARMUP_STEPS;
       let hN: i32 = i32(u.horizonN);
       if (hN > 0) {
-        for (var cxw: i32 = warmStart; cxw < cxEntry; cxw = cxw + 1) {
-          let yw = f32(b) + u.slope * f32(cxw);
-          var ox_f: f32 = f32(cxw);
+        // Parent-rate hull pushes: place hull entries at parent pixel
+        // centres so hx_f = k exactly (or hy_f = k for swap), collapsing
+        // the bilinear to a 1-D cross-axis lerp with no along-ray bleed
+        // from the first parent pixel inside the comp tile. Matches the
+        // CPU sweep-core.js fix — see comments there for the derivation.
+        let firstK: i32 = max(
+          0,
+          i32(ceil(
+            (f32(warmStart) + warmupMarginX) * u.invParentScale - u.parentCenterOffset
+          ))
+        );
+        let lastK: i32 = i32(ceil(
+          (f32(cxEntry) + warmupMarginX) * u.invParentScale - u.parentCenterOffset
+        )) - 1;
+        for (var k: i32 = firstK; k <= lastK; k = k + 1) {
+          let cxF: f32 = parentScaleF * (f32(k) + u.parentCenterOffset) - warmupMarginX;
+          let yw: f32 = f32(b) + u.slope * cxF;
+          var ox_f: f32 = cxF;
           var oy_f: f32 = yw;
-          if (u.swap != 0u) { ox_f = yw; oy_f = f32(cxw); }
+          if (u.swap != 0u) { ox_f = yw; oy_f = cxF; }
           if (u.flipX != 0u) { ox_f = (Wf - 1.0) - ox_f; }
           if (u.flipY != 0u) { oy_f = (Hf - 1.0) - oy_f; }
-          // Child→horizon bilinear alignment, generalised to
-          // parentScale = 2^dz. Elevations live at pixel centres, so
-          // sampling at child pixel ox_f's centre maps to horizon
-          // pixel (ox_f + warmupMargin)*invParentScale -
-          // parentCenterOffset. See sweep-core.js for the full
-          // derivation; using Wf instead of warmupMarginX here was
-          // the tile-boundary-artifact bug at parentScale > 2.
           let hx_f: f32 = (ox_f + warmupMarginX) * u.invParentScale - u.parentCenterOffset;
           let hy_f: f32 = (oy_f + warmupMarginY) * u.invParentScale - u.parentCenterOffset;
           let hx_i: i32 = i32(floor(hx_f));
@@ -311,39 +319,6 @@ function warmupBlock(prewarm, mode, lsaoFalloff) {
             fx * (1.0 - fy2) * h10 +
             (1.0 - fx) * fy2 * h01 +
             fx * fy2 * h11;
-
-          // Deposit the edge-straddle contribution for any output row
-          // this warmup step lands on. Gated on cxw being in the
-          // canonical view range [0, viewW) — under a flipX/flipY
-          // sweep, negative canonical cx would pass through toOrig's
-          // (W - 1 - cx) and produce a numerically valid (but wrap-
-          // around) output index, depositing the ray's shadow into
-          // pixels on the wrong side of the tile. The main pass
-          // doesn't hit this because its cx iterator is already
-          // clamped to [cxEntry, viewW).
-          let inViewW: bool = cxw >= 0 && cxw < i32(u.viewW);
-          let yiw: i32 = i32(floor(yw));
-          let fyw: f32 = yw - f32(yiw);
-          let yjw: i32 = yiw + 1;
-          let loInW: bool = yiw >= 0 && yiw < i32(u.viewH);
-          let hiInW: bool = yjw >= 0 && yjw < i32(u.viewH);
-          if (inViewW && (loInW || hiInW)) {
-            let hRay: f32 = hW;
-            let cx: i32 = cxw;
-            let targetRow: i32 = select(yjw, yiw, loInW);
-            let pxSize = targetPxSize(cx, targetRow);
-            let dStep = pxSize * sqrt(1.0 + u.slope * u.slope);
-            let epsH = 0.5 * pxSize * u.tanAlt;
-            let invTwoEps = select(0.0, 1.0 / (2.0 * epsH), epsH > 0.0);
-            ${kernel}
-            let contribW = bit * u.weight;
-            let depLoW = u32(round((1.0 - fyw) * contribW * u.fpScale));
-            let depHiW = u32(round(fyw * contribW * u.fpScale));
-            if (loInW) { atomicAdd(&shadow[toOrig(cxw, yiw)], depLoW); }
-            if (hiInW) { atomicAdd(&shadow[toOrig(cxw, yjw)], depHiW); }
-          }
-
-          let cxF = f32(cxw);
           loop {
             if (hullPtr < 1) { break; }
             let ax = hullCx[hullPtr - 1];
@@ -357,6 +332,54 @@ function warmupBlock(prewarm, mode, lsaoFalloff) {
           hullPtr = min(hullPtr + 1, hullMax);
           hullCx[hullPtr] = cxF;
           hullH[hullPtr] = hW;
+        }
+
+        // Comp-rate edge-straddle deposits: fill shadow values for
+        // pixels at cx ∈ [0, cxEntry) that only the warmup visits.
+        // Hull is already populated by the parent-rate loop; no push.
+        for (var cxw: i32 = max(warmStart, 0); cxw < cxEntry; cxw = cxw + 1) {
+          let yw = f32(b) + u.slope * f32(cxw);
+          let yiw: i32 = i32(floor(yw));
+          let fyw: f32 = yw - f32(yiw);
+          let yjw: i32 = yiw + 1;
+          let loInW: bool = yiw >= 0 && yiw < i32(u.viewH);
+          let hiInW: bool = yjw >= 0 && yjw < i32(u.viewH);
+          if (!loInW && !hiInW) { continue; }
+          var ox_f: f32 = f32(cxw);
+          var oy_f: f32 = yw;
+          if (u.swap != 0u) { ox_f = yw; oy_f = f32(cxw); }
+          if (u.flipX != 0u) { ox_f = (Wf - 1.0) - ox_f; }
+          if (u.flipY != 0u) { oy_f = (Hf - 1.0) - oy_f; }
+          let hx_f: f32 = (ox_f + warmupMarginX) * u.invParentScale - u.parentCenterOffset;
+          let hy_f: f32 = (oy_f + warmupMarginY) * u.invParentScale - u.parentCenterOffset;
+          let hx_i: i32 = i32(floor(hx_f));
+          let hy_i: i32 = i32(floor(hy_f));
+          if (hx_i < 0 || hx_i + 1 >= hN) { continue; }
+          if (hy_i < 0 || hy_i + 1 >= hN) { continue; }
+          let fx: f32 = hx_f - f32(hx_i);
+          let fy2: f32 = hy_f - f32(hy_i);
+          let h00: f32 = horizon[hy_i * hN + hx_i];
+          let h10: f32 = horizon[hy_i * hN + hx_i + 1];
+          let h01: f32 = horizon[(hy_i + 1) * hN + hx_i];
+          let h11: f32 = horizon[(hy_i + 1) * hN + hx_i + 1];
+          let hW: f32 =
+            (1.0 - fx) * (1.0 - fy2) * h00 +
+            fx * (1.0 - fy2) * h10 +
+            (1.0 - fx) * fy2 * h01 +
+            fx * fy2 * h11;
+          let hRay: f32 = hW;
+          let cx: i32 = cxw;
+          let targetRow: i32 = select(yjw, yiw, loInW);
+          let pxSize = targetPxSize(cx, targetRow);
+          let dStep = pxSize * sqrt(1.0 + u.slope * u.slope);
+          let epsH = 0.5 * pxSize * u.tanAlt;
+          let invTwoEps = select(0.0, 1.0 / (2.0 * epsH), epsH > 0.0);
+          ${kernel}
+          let contribW = bit * u.weight;
+          let depLoW = u32(round((1.0 - fyw) * contribW * u.fpScale));
+          let depHiW = u32(round(fyw * contribW * u.fpScale));
+          if (loInW) { atomicAdd(&shadow[toOrig(cxw, yiw)], depLoW); }
+          if (hiInW) { atomicAdd(&shadow[toOrig(cxw, yjw)], depHiW); }
         }
       }
     }

--- a/src/notebooks/line-sweep-terrain-lighting/sweep-core.js
+++ b/src/notebooks/line-sweep-terrain-lighting/sweep-core.js
@@ -441,21 +441,80 @@ export function sweepCore(opts) {
       }
     } else if (hasHorizon) {
       const warmStart = cxEntry - WARMUP_STEPS;
-      for (let cx = warmStart; cx < cxEntry; cx++) {
+
+      // Parent-rate hull pushes: place hull entries at parent pixel centres
+      // (cxP = parentScale*(k+parentCenterOffset) − warmupMarginX) so that
+      // the bilinear formula gives hxf = k exactly (or hyf = k for swap).
+      // An exact integer index means fx = 0 (or fy = 0), collapsing the
+      // bilinear to a 1-D linear interp in the cross-ray axis at fixed
+      // along-ray column k — no pixel k+1 is touched. Without this, a
+      // comp-rate integer step at cx = −1 gives hxf = 127.25 for
+      // parentScale = 2, which blends in 25 % of parent pixel 128 (centred
+      // 1 child pixel inside the comp tile). If the comp tile has high
+      // terrain near its left edge that 25 % contribution inflates the hull
+      // entry and casts a false shadow on the first comp rows even when the
+      // sun is clearly above the outside terrain.
+      const firstK = Math.max(
+        0,
+        Math.ceil(
+          (warmStart + warmupMarginX) / parentScale - parentCenterOffset,
+        ),
+      );
+      const lastK =
+        Math.ceil(
+          (cxEntry + warmupMarginX) / parentScale - parentCenterOffset,
+        ) - 1;
+      for (let k = firstK; k <= lastK; k++) {
+        const cxP = parentScale * (k + parentCenterOffset) - warmupMarginX;
+        const yP = b + slope * cxP;
+        let oxfP = swap ? yP : cxP;
+        let oyfP = swap ? cxP : yP;
+        if (flipX) oxfP = W - 1 - oxfP;
+        if (flipY) oyfP = H - 1 - oyfP;
+        const hxfP = (oxfP + warmupMarginX) * invParentScale - parentCenterOffset;
+        const hyfP = (oyfP + warmupMarginY) * invParentScale - parentCenterOffset;
+        const hxiP = Math.floor(hxfP);
+        const hyiP = Math.floor(hyfP);
+        if (hxiP < 0 || hxiP + 1 >= HN) continue;
+        if (hyiP < 0 || hyiP + 1 >= HN) continue;
+        const fxP = hxfP - hxiP;
+        const fyP = hyfP - hyiP;
+        const h00P = horizon[hyiP * HN + hxiP];
+        const h10P = horizon[hyiP * HN + hxiP + 1];
+        const h01P = horizon[(hyiP + 1) * HN + hxiP];
+        const h11P = horizon[(hyiP + 1) * HN + hxiP + 1];
+        const hWP =
+          (1 - fxP) * (1 - fyP) * h00P +
+          fxP * (1 - fyP) * h10P +
+          (1 - fxP) * fyP * h01P +
+          fxP * fyP * h11P;
+        if (horizonTouched) {
+          const tBit = b >= 0 ? 1 : 2;
+          horizonTouched[hyiP * HN + hxiP] |= tBit;
+          horizonTouched[hyiP * HN + hxiP + 1] |= tBit;
+          horizonTouched[(hyiP + 1) * HN + hxiP] |= tBit;
+          horizonTouched[(hyiP + 1) * HN + hxiP + 1] |= tBit;
+        }
+        pushHull(cxP, hWP);
+      }
+
+      // Comp-rate edge-straddle deposits: for rays entering the canonical
+      // view from the top (b < 0, cxEntry > 0), pixels at cx ∈ [0, cxEntry)
+      // are only visited here — the main pass starts at cxEntry and never
+      // revisits them. Deposit their shadow contribution using the hull
+      // already populated by the parent-rate loop. No hull push here.
+      for (let cx = Math.max(warmStart, 0); cx < cxEntry; cx++) {
         const y = b + slope * cx;
+        const yi = Math.floor(y);
+        const fy = y - yi;
+        const yj = yi + 1;
+        const loIn = yi >= 0 && yi < viewH;
+        const hiIn = yj >= 0 && yj < viewH;
+        if (!loIn && !hiIn) continue;
         let oxf = swap ? y : cx;
         let oyf = swap ? cx : y;
         if (flipX) oxf = W - 1 - oxf;
         if (flipY) oyf = H - 1 - oyf;
-        // Elevations are defined at pixel centres. See the derivation
-        // of `warmupMargin` / `parentCenterOffset` above: this is the
-        // pixel-centre-preserving child→horizon map, generalised to
-        // parentScale = 2^dz. Without the `-parentCenterOffset` term,
-        // the hull entry pushed from the last warmup step at canonical
-        // cx = −1 would carry a height sampled from a half-parent-
-        // pixel-earlier physical position, producing a slope at the
-        // first comp pixel that's off by a pixel — and a faint
-        // shadow band along tile edges in LSAO.
         const hxf = (oxf + warmupMarginX) * invParentScale - parentCenterOffset;
         const hyf = (oyf + warmupMarginY) * invParentScale - parentCenterOffset;
         const hxi = Math.floor(hxf);
@@ -473,45 +532,11 @@ export function sweepCore(opts) {
           fx * (1 - fy2) * h10 +
           (1 - fx) * fy2 * h01 +
           fx * fy2 * h11;
-        if (horizonTouched) {
-          const tBit = b >= 0 ? 1 : 2;
-          horizonTouched[hyi * HN + hxi] |= tBit;
-          horizonTouched[hyi * HN + hxi + 1] |= tBit;
-          horizonTouched[(hyi + 1) * HN + hxi] |= tBit;
-          horizonTouched[(hyi + 1) * HN + hxi + 1] |= tBit;
-        }
-
-        // Deposit the edge-straddle contribution. This fires only at
-        // the few cx positions near the tile boundary where the ray's
-        // yj (or yi) is back in [0, viewH) AND cx is itself in the
-        // canonical view range [0, viewW). The cx guard matters
-        // because `toOrig` doesn't bounds-check its inputs — under
-        // a flipX/flipY sweep, a negative canonical cx maps through
-        // `W - 1 - cx` into an `ox > W − 1` that still produces a
-        // numerically valid (but physically meaningless) output index
-        // once the `oy*W + ox` is computed, which would deposit the
-        // ray's shadow into a wrap-around pixel on the opposite side
-        // of the tile. The main pass doesn't hit this because its
-        // cx iterator is already clamped to [cxEntry, viewW).
-        //
-        // `computeBit` must be called before the hull push, so it
-        // scans the hull *without* the current sample — matching
-        // the main pass's ordering.
-        const inView = cx >= 0 && cx < viewW;
-        const yi = Math.floor(y);
-        const fy = y - yi;
-        const yj = yi + 1;
-        const loIn = yi >= 0 && yi < viewH;
-        const hiIn = yj >= 0 && yj < viewH;
-        if (inView && (loIn || hiIn)) {
-          if (updateTargetPx) updateTargetPx(cx, loIn ? yi : yj);
-          const bit = computeBit(cx, hW);
-          const contrib = bit * weight;
-          if (loIn) out[toOrig(cx, yi)] += (1 - fy) * contrib;
-          if (hiIn) out[toOrig(cx, yj)] += fy * contrib;
-        }
-
-        pushHull(cx, hW);
+        if (updateTargetPx) updateTargetPx(cx, loIn ? yi : yj);
+        const bit = computeBit(cx, hW);
+        const contrib = bit * weight;
+        if (loIn) out[toOrig(cx, yi)] += (1 - fy) * contrib;
+        if (hiIn) out[toOrig(cx, yj)] += fy * contrib;
       }
     }
 

--- a/src/notebooks/line-sweep-terrain-lighting/webgpu-pipelines.js
+++ b/src/notebooks/line-sweep-terrain-lighting/webgpu-pipelines.js
@@ -280,20 +280,28 @@ function warmupBlock(prewarm, mode, lsaoFalloff) {
       let warmStart: i32 = cxEntry - WARMUP_STEPS;
       let hN: i32 = i32(u.horizonN);
       if (hN > 0) {
-        for (var cxw: i32 = warmStart; cxw < cxEntry; cxw = cxw + 1) {
-          let yw = f32(b) + u.slope * f32(cxw);
-          var ox_f: f32 = f32(cxw);
+        // Parent-rate hull pushes: place hull entries at parent pixel
+        // centres so hx_f = k exactly (or hy_f = k for swap), collapsing
+        // the bilinear to a 1-D cross-axis lerp with no along-ray bleed
+        // from the first parent pixel inside the comp tile. Matches the
+        // CPU sweep-core.js fix — see comments there for the derivation.
+        let firstK: i32 = max(
+          0,
+          i32(ceil(
+            (f32(warmStart) + warmupMarginX) * u.invParentScale - u.parentCenterOffset
+          ))
+        );
+        let lastK: i32 = i32(ceil(
+          (f32(cxEntry) + warmupMarginX) * u.invParentScale - u.parentCenterOffset
+        )) - 1;
+        for (var k: i32 = firstK; k <= lastK; k = k + 1) {
+          let cxF: f32 = parentScaleF * (f32(k) + u.parentCenterOffset) - warmupMarginX;
+          let yw: f32 = f32(b) + u.slope * cxF;
+          var ox_f: f32 = cxF;
           var oy_f: f32 = yw;
-          if (u.swap != 0u) { ox_f = yw; oy_f = f32(cxw); }
+          if (u.swap != 0u) { ox_f = yw; oy_f = cxF; }
           if (u.flipX != 0u) { ox_f = (Wf - 1.0) - ox_f; }
           if (u.flipY != 0u) { oy_f = (Hf - 1.0) - oy_f; }
-          // Child→horizon bilinear alignment, generalised to
-          // parentScale = 2^dz. Elevations live at pixel centres, so
-          // sampling at child pixel ox_f's centre maps to horizon
-          // pixel (ox_f + warmupMargin)*invParentScale -
-          // parentCenterOffset. See sweep-core.js for the full
-          // derivation; using Wf instead of warmupMarginX here was
-          // the tile-boundary-artifact bug at parentScale > 2.
           let hx_f: f32 = (ox_f + warmupMarginX) * u.invParentScale - u.parentCenterOffset;
           let hy_f: f32 = (oy_f + warmupMarginY) * u.invParentScale - u.parentCenterOffset;
           let hx_i: i32 = i32(floor(hx_f));
@@ -311,39 +319,6 @@ function warmupBlock(prewarm, mode, lsaoFalloff) {
             fx * (1.0 - fy2) * h10 +
             (1.0 - fx) * fy2 * h01 +
             fx * fy2 * h11;
-
-          // Deposit the edge-straddle contribution for any output row
-          // this warmup step lands on. Gated on cxw being in the
-          // canonical view range [0, viewW) — under a flipX/flipY
-          // sweep, negative canonical cx would pass through toOrig's
-          // (W - 1 - cx) and produce a numerically valid (but wrap-
-          // around) output index, depositing the ray's shadow into
-          // pixels on the wrong side of the tile. The main pass
-          // doesn't hit this because its cx iterator is already
-          // clamped to [cxEntry, viewW).
-          let inViewW: bool = cxw >= 0 && cxw < i32(u.viewW);
-          let yiw: i32 = i32(floor(yw));
-          let fyw: f32 = yw - f32(yiw);
-          let yjw: i32 = yiw + 1;
-          let loInW: bool = yiw >= 0 && yiw < i32(u.viewH);
-          let hiInW: bool = yjw >= 0 && yjw < i32(u.viewH);
-          if (inViewW && (loInW || hiInW)) {
-            let hRay: f32 = hW;
-            let cx: i32 = cxw;
-            let targetRow: i32 = select(yjw, yiw, loInW);
-            let pxSize = targetPxSize(cx, targetRow);
-            let dStep = pxSize * sqrt(1.0 + u.slope * u.slope);
-            let epsH = 0.5 * pxSize * u.tanAlt;
-            let invTwoEps = select(0.0, 1.0 / (2.0 * epsH), epsH > 0.0);
-            ${kernel}
-            let contribW = bit * u.weight;
-            let depLoW = u32(round((1.0 - fyw) * contribW * u.fpScale));
-            let depHiW = u32(round(fyw * contribW * u.fpScale));
-            if (loInW) { atomicAdd(&shadow[toOrig(cxw, yiw)], depLoW); }
-            if (hiInW) { atomicAdd(&shadow[toOrig(cxw, yjw)], depHiW); }
-          }
-
-          let cxF = f32(cxw);
           loop {
             if (hullPtr < 1) { break; }
             let ax = hullCx[hullPtr - 1];
@@ -357,6 +332,54 @@ function warmupBlock(prewarm, mode, lsaoFalloff) {
           hullPtr = min(hullPtr + 1, hullMax);
           hullCx[hullPtr] = cxF;
           hullH[hullPtr] = hW;
+        }
+
+        // Comp-rate edge-straddle deposits: fill shadow values for
+        // pixels at cx ∈ [0, cxEntry) that only the warmup visits.
+        // Hull is already populated by the parent-rate loop; no push.
+        for (var cxw: i32 = max(warmStart, 0); cxw < cxEntry; cxw = cxw + 1) {
+          let yw = f32(b) + u.slope * f32(cxw);
+          let yiw: i32 = i32(floor(yw));
+          let fyw: f32 = yw - f32(yiw);
+          let yjw: i32 = yiw + 1;
+          let loInW: bool = yiw >= 0 && yiw < i32(u.viewH);
+          let hiInW: bool = yjw >= 0 && yjw < i32(u.viewH);
+          if (!loInW && !hiInW) { continue; }
+          var ox_f: f32 = f32(cxw);
+          var oy_f: f32 = yw;
+          if (u.swap != 0u) { ox_f = yw; oy_f = f32(cxw); }
+          if (u.flipX != 0u) { ox_f = (Wf - 1.0) - ox_f; }
+          if (u.flipY != 0u) { oy_f = (Hf - 1.0) - oy_f; }
+          let hx_f: f32 = (ox_f + warmupMarginX) * u.invParentScale - u.parentCenterOffset;
+          let hy_f: f32 = (oy_f + warmupMarginY) * u.invParentScale - u.parentCenterOffset;
+          let hx_i: i32 = i32(floor(hx_f));
+          let hy_i: i32 = i32(floor(hy_f));
+          if (hx_i < 0 || hx_i + 1 >= hN) { continue; }
+          if (hy_i < 0 || hy_i + 1 >= hN) { continue; }
+          let fx: f32 = hx_f - f32(hx_i);
+          let fy2: f32 = hy_f - f32(hy_i);
+          let h00: f32 = horizon[hy_i * hN + hx_i];
+          let h10: f32 = horizon[hy_i * hN + hx_i + 1];
+          let h01: f32 = horizon[(hy_i + 1) * hN + hx_i];
+          let h11: f32 = horizon[(hy_i + 1) * hN + hx_i + 1];
+          let hW: f32 =
+            (1.0 - fx) * (1.0 - fy2) * h00 +
+            fx * (1.0 - fy2) * h10 +
+            (1.0 - fx) * fy2 * h01 +
+            fx * fy2 * h11;
+          let hRay: f32 = hW;
+          let cx: i32 = cxw;
+          let targetRow: i32 = select(yjw, yiw, loInW);
+          let pxSize = targetPxSize(cx, targetRow);
+          let dStep = pxSize * sqrt(1.0 + u.slope * u.slope);
+          let epsH = 0.5 * pxSize * u.tanAlt;
+          let invTwoEps = select(0.0, 1.0 / (2.0 * epsH), epsH > 0.0);
+          ${kernel}
+          let contribW = bit * u.weight;
+          let depLoW = u32(round((1.0 - fyw) * contribW * u.fpScale));
+          let depHiW = u32(round(fyw * contribW * u.fpScale));
+          if (loInW) { atomicAdd(&shadow[toOrig(cxw, yiw)], depLoW); }
+          if (hiInW) { atomicAdd(&shadow[toOrig(cxw, yjw)], depHiW); }
         }
       }
     }


### PR DESCRIPTION
## Summary

Refactors the warmup loop in the sweep-core algorithms to separate two distinct operations: parent-rate hull pushes and comp-rate shadow deposits. This improves code clarity and fixes a subtle sampling artifact at tile boundaries when using multi-level hierarchies (parentScale > 2).

## Changes

- **Separate parent-rate hull population**: Introduces a new loop that pushes hull entries at parent pixel centres (using parent-scale coordinates `k`) rather than child-scale coordinates. This ensures the bilinear interpolation formula produces exact integer indices (`hxf = k`), collapsing the bilinear to a 1-D linear interpolation with no unwanted blending from adjacent parent pixels.

- **Move shadow deposits to dedicated loop**: Moves the edge-straddle shadow contribution deposits to a separate second loop that iterates over comp-rate coordinates. This loop uses the hull already populated by the parent-rate loop without pushing new entries.

- **Remove redundant bounds checks**: Eliminates the `inView` guard in the shadow deposit loop by moving the loop start to `Math.max(warmStart, 0)`, which implicitly ensures `cx >= 0`. The upper bound `cx < cxEntry` is already guaranteed by the loop condition.

- **Improve early exit logic**: Adds an early `continue` when both `loIn` and `hiIn` are false, avoiding unnecessary horizon sampling and computation.

## Implementation Details

The key insight is that at parentScale > 2, sampling at child-scale integer positions (e.g., `cx = -1`) produces fractional horizon indices (e.g., `hxf = 127.25` for parentScale = 2). This 25% blend from the next parent pixel can inflate hull entries and cast false shadows. By sampling at parent pixel centres instead, we guarantee `hxf` is an exact integer, eliminating cross-axis blending and the associated artifacts.

The refactoring applies consistently across:
- `src/notebooks/denali/mapviewer/lighting/sweep-core.js`
- `src/notebooks/line-sweep-terrain-lighting/sweep-core.js`
- `src/notebooks/denali/mapviewer/lighting/webgpu-pipelines.js`
- `src/notebooks/line-sweep-terrain-lighting/webgpu-pipelines.js`

https://claude.ai/code/session_01BEjqLDPmoEnQYDCCWU8XZq