### PR TITLE
Pin suncalc dependency to version 1.9.0

### DIFF
--- a/src/notebooks/denali/index.html
+++ b/src/notebooks/denali/index.html
@@ -344,7 +344,7 @@
   </script>
 
   <script id="controls" type="module">
-    import SunCalc from 'npm:suncalc';
+    import SunCalc from 'npm:suncalc@1.9.0';
     import { createSunCalendar } from './lib/sun-calendar.js';
 
     const controlsContainer = html`<div class="terrain-controls"></div>`;

--- a/src/notebooks/line-sweep-terrain-lighting/index.html
+++ b/src/notebooks/line-sweep-terrain-lighting/index.html
@@ -1892,7 +1892,7 @@
   <script id="70" type="module">
     import { createTileViewer } from "./tile-viewer.js";
     import { expandable } from "./lib/expandable.js";
-    import SunCalc from "npm:suncalc";
+    import SunCalc from "npm:suncalc@1.9.0";
     import { createSunCalendar } from "./lib/sun-calendar.js";
     import { solarTimeQuantities } from "./solar-time.js";
   </script>


### PR DESCRIPTION
## Summary
This PR pins the `suncalc` npm package to a specific version (1.9.0) across two notebooks to ensure consistent behavior and prevent unexpected breaking changes from future releases.

## Changes
- Updated `suncalc` import in `src/notebooks/denali/index.html` from `'npm:suncalc'` to `'npm:suncalc@1.9.0'`
- Updated `suncalc` import in `src/notebooks/line-sweep-terrain-lighting/index.html` from `"npm:suncalc"` to `"npm:suncalc@1.9.0"`

## Details
Both notebooks use the SunCalc library for solar calculations (sun position, timing, etc.). By pinning to version 1.9.0, we ensure reproducible builds and prevent potential issues from incompatible future versions of the library.

https://claude.ai/code/session_016uG7N5NjuLnrnTyrtsi9q5