### PR TITLE
Fix tile seam artifacts by sampling horizon ring at boundaries

### DIFF
--- a/src/notebooks/line-sweep-terrain-lighting/sweep-core.js
+++ b/src/notebooks/line-sweep-terrain-lighting/sweep-core.js
@@ -279,6 +279,39 @@ export function sweepCore(opts) {
     }
   }
 
+  // Bilinear horizon sample at an arbitrary canonical (cx, cy), or null
+  // when there's no horizon or the position falls outside the ring.
+  //
+  // Used by the main pass for rays that straddle the tile boundary in
+  // the cross-ray axis (yi = −1 or yj = viewH): the row just outside
+  // the tile used to clamp to the edge row's elevation, which disagrees
+  // with the neighbouring tile's view of the same ray and drew a
+  // constant seam line along every tile's downstream edge — independent
+  // of parent resolution, and dominant at low sun where the hard-mode
+  // smoothing window epsH is only a few metres. The ring covers all
+  // four sides of the comp tile, so sample it instead.
+  const sampleHorizonAt = (cx, cy) => {
+    if (!hasHorizon) return null;
+    let oxf = swap ? cy : cx;
+    let oyf = swap ? cx : cy;
+    if (flipX) oxf = W - 1 - oxf;
+    if (flipY) oyf = H - 1 - oyf;
+    const hxf = (oxf + warmupMarginX) * invParentScale - parentCenterOffset;
+    const hyf = (oyf + warmupMarginY) * invParentScale - parentCenterOffset;
+    const hxi = Math.floor(hxf);
+    const hyi = Math.floor(hyf);
+    if (hxi < 0 || hxi + 1 >= HN) return null;
+    if (hyi < 0 || hyi + 1 >= HN) return null;
+    const fx = hxf - hxi;
+    const fy = hyf - hyi;
+    return (
+      (1 - fx) * (1 - fy) * horizon[hyi * HN + hxi] +
+      fx * (1 - fy) * horizon[hyi * HN + hxi + 1] +
+      (1 - fx) * fy * horizon[(hyi + 1) * HN + hxi] +
+      fx * fy * horizon[(hyi + 1) * HN + hxi + 1]
+    );
+  };
+
   // Mode-specific shadow bit at (cx, hRay) against the current hull.
   // Called from both the warmup's tile-edge deposit and the main pass
   // so they share one kernel per mode. Closes over the per-scanline
@@ -553,8 +586,18 @@ export function sweepCore(opts) {
       const iLo = loIn ? toOrig(cx, yi) : -1;
       const iHi = hiIn ? toOrig(cx, yj) : -1;
 
-      const hLo = loIn ? elev[iLo] : elev[iHi];
-      const hHi = hiIn ? elev[iHi] : hLo;
+      // Ray height. When one of the two bracketing rows is outside the
+      // view, prefer the horizon ring's estimate of the actual terrain
+      // there over clamping to the edge row — see sampleHorizonAt.
+      let hLo = loIn ? elev[iLo] : elev[iHi];
+      let hHi = hiIn ? elev[iHi] : hLo;
+      if (!loIn) {
+        const hOut = sampleHorizonAt(cx, yi);
+        if (hOut !== null) hLo = hOut;
+      } else if (!hiIn) {
+        const hOut = sampleHorizonAt(cx, yj);
+        if (hOut !== null) hHi = hOut;
+      }
       const hRay = (1 - f) * hLo + f * hHi;
 
       if (updateTargetPx) updateTargetPx(cx, loIn ? yi : yj);

--- a/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
+++ b/src/notebooks/line-sweep-terrain-lighting/tile-viewer.js
@@ -22,7 +22,8 @@
 //                      has moved since last submission. Clears the
 //                      shared atomic shadow buffer, runs one hard-
 //                      shadow sweep per visible tile (with parent-
-//                      tile prewarm assembled from 4 z-1 neighbours),
+//                      tile prewarm assembled from 4 (z − parentDZ)
+//                      parents),
 //                      then fullscreen alpha-blits the result into
 //                      the tile texture's A channel. RGB is preserved
 //                      via `writeMask: GPUColorWrite.ALPHA`.
@@ -324,13 +325,18 @@ export function createTileViewer(opts) {
     // resolution. `dz = 2` gives 5×5 coverage at quarter-res; `dz = 1`
     // is the original 3×3-tile / half-res behavior.
     //
-    // Default `null` selects a zoom-adaptive dz that keeps the warmup
-    // ring covering a roughly constant *physical* radius (~40 km)
-    // regardless of zoom. As you zoom in past z ≈ 11 the comp tile
-    // shrinks faster than terrain steepness, so a fixed `dz = 2` stops
-    // reaching the blockers that actually shadow into the tile; the
-    // auto formula bumps `dz` by 1 every zoom past z = 11 to compensate.
-    // Pass a number to override.
+    // Default `null` selects dz = 2 wherever the pyramid allows it
+    // (dz = 1 right above minZoom). dz is deliberately capped at 2: the
+    // seam error at a tile's sun-facing edges is dominated by how well
+    // the ring resolves blockers just across the boundary, and that
+    // error grows roughly linearly with 2^dz — at dz ≥ 3 the near
+    // field degrades so much that the ring is barely better than no
+    // prewarm at all within a parent texel of the seam. The price of
+    // the cap is warmup reach: the ring spans W·2^dz/2 child pixels
+    // (~5 km at z = 14), so very long low-sun shadows from terrain
+    // beyond that are truncated. Extending reach without wrecking the
+    // near field would take a second, coarser far-field ring, not a
+    // bigger dz. Pass a number to override.
     parentDZ = null,
   } = opts;
 
@@ -360,14 +366,13 @@ export function createTileViewer(opts) {
     { type: "module" },
   );
 
-  // The warmup ring's physical reach is (W/2) · parentScale · pxSize_comp,
-  // and pxSize_comp halves per zoom — so a fixed parentDZ shrinks the
-  // reach geometrically. Pin reach at ~40 km (covers a 7 km blocker at
-  // ~10° sun altitude), bumping parentDZ by 1 per zoom past z=11. The
-  // explicit `parentDZ` constructor opt overrides this if set.
+  // Auto parentDZ: always 2 when the pyramid has a level there, 1 just
+  // above minZoom. Never more — a coarser ring resolves the blockers
+  // immediately across the tile seam so poorly that the sun-facing
+  // seam line gets *worse* with every extra level (see the constructor
+  // opt comment for the reach trade-off this accepts).
   function pickAutoParentDZ(z) {
-    const dz = Math.max(2, z - 9);
-    return Math.max(1, Math.min(dz, z - minZoom));
+    return Math.max(1, Math.min(2, z - minZoom));
   }
   let currentParentDZ = -1;
   let parentScale = 1;

--- a/src/notebooks/line-sweep-terrain-lighting/webgpu-pipelines.js
+++ b/src/notebooks/line-sweep-terrain-lighting/webgpu-pipelines.js
@@ -159,6 +159,41 @@ const HELPERS_WGSL = /* wgsl */ `
     let lat: f32 = atan(sinh(nMerc));
     return u.eqPxSizeM * cos(lat);
   }
+
+  // Bilinear horizon sample at an arbitrary canonical (cx, cy).
+  // Returns vec2(height, 1.0), or vec2(0, 0) when there's no horizon
+  // bound (horizonN == 0, e.g. the non-prewarm stub buffer) or the
+  // position falls outside the ring. Mirrors sweep-core.js
+  // sampleHorizonAt: used by the main loop for rays straddling the
+  // tile boundary in the cross-ray axis, where clamping to the edge
+  // row used to draw a constant seam line along downstream tile edges.
+  fn sampleHorizonAt(cxF: f32, cyF: f32) -> vec2<f32> {
+    let hN: i32 = i32(u.horizonN);
+    if (hN <= 0) { return vec2<f32>(0.0, 0.0); }
+    let parentScaleF: f32 = 1.0 / u.invParentScale;
+    let warmupMarginX: f32 = f32(u.W) * parentScaleF * 0.5;
+    let warmupMarginY: f32 = f32(u.H) * parentScaleF * 0.5;
+    var ox_f: f32 = cxF;
+    var oy_f: f32 = cyF;
+    if (u.swap != 0u) { ox_f = cyF; oy_f = cxF; }
+    if (u.flipX != 0u) { ox_f = f32(u.W) - 1.0 - ox_f; }
+    if (u.flipY != 0u) { oy_f = f32(u.H) - 1.0 - oy_f; }
+    let hx_f: f32 = (ox_f + warmupMarginX) * u.invParentScale - u.parentCenterOffset;
+    let hy_f: f32 = (oy_f + warmupMarginY) * u.invParentScale - u.parentCenterOffset;
+    let hx_i: i32 = i32(floor(hx_f));
+    let hy_i: i32 = i32(floor(hy_f));
+    if (hx_i < 0 || hx_i + 1 >= hN || hy_i < 0 || hy_i + 1 >= hN) {
+      return vec2<f32>(0.0, 0.0);
+    }
+    let fx: f32 = hx_f - f32(hx_i);
+    let fy: f32 = hy_f - f32(hy_i);
+    let h: f32 =
+      (1.0 - fx) * (1.0 - fy) * horizon[hy_i * hN + hx_i] +
+      fx * (1.0 - fy) * horizon[hy_i * hN + hx_i + 1] +
+      (1.0 - fx) * fy * horizon[(hy_i + 1) * hN + hx_i] +
+      fx * fy * horizon[(hy_i + 1) * hN + hx_i + 1];
+    return vec2<f32>(h, 1.0);
+  }
 `;
 
 // LSAO-specific warmup: iterate at parent-pixel resolution along the
@@ -522,10 +557,20 @@ function buildComputeWGSL({ mode, prewarm, lsaoFalloff }) {
         if (loIn) { iLo = toOrig(cx, yi); }
         if (hiIn) { iHi = toOrig(cx, yj); }
 
+        // Ray height. When one bracketing row is outside the view,
+        // prefer the horizon ring's estimate of the terrain there over
+        // clamping to the edge row — mirrors sweep-core.js.
         var hLo: f32 = 0.0;
         var hHi: f32 = 0.0;
         if (loIn) { hLo = elev[iLo]; } else { hLo = elev[iHi]; }
         if (hiIn) { hHi = elev[iHi]; } else { hHi = hLo; }
+        if (!loIn) {
+          let hOut = sampleHorizonAt(f32(cx), f32(yi));
+          if (hOut.y != 0.0) { hLo = hOut.x; }
+        } else if (!hiIn) {
+          let hOut = sampleHorizonAt(f32(cx), f32(yj));
+          if (hOut.y != 0.0) { hHi = hOut.x; }
+        }
         let hRay = (1.0 - fy) * hLo + fy * hHi;
 
         // Per-target pxSize and its derived sweep constants, from the


### PR DESCRIPTION
## Summary

Fixes visible seam lines along tile boundaries by using bilinear samples from the horizon ring instead of clamping to edge elevations when rays straddle the tile boundary in the cross-ray axis.

## Changes

- **sweep-core.js**: Added `sampleHorizonAt()` function to perform bilinear interpolation on the horizon ring at arbitrary canonical coordinates. Modified ray height calculation to prefer horizon samples over edge clamping when one bracketing row falls outside the view.

- **webgpu-pipelines.js**: Implemented WebGPU equivalent of `sampleHorizonAt()` in WGSL, mirroring the JavaScript logic. Updated the main compute loop to use horizon samples for out-of-bounds ray heights, matching the CPU path.

- **tile-viewer.js**: Simplified `parentDZ` auto-selection logic. Changed from zoom-adaptive formula (bumping dz by 1 per zoom past z=11) to a fixed cap at dz=2 (or dz=1 just above minZoom). Updated documentation to explain the trade-off: dz is capped because coarser rings resolve near-field blockers poorly, making sun-facing seams worse at higher dz values, despite reduced reach.

## Implementation Details

The horizon ring covers all four sides of the computation tile. When a ray's interpolation straddles the tile boundary (yi = −1 or yj = viewH), the previous approach clamped to the edge row's elevation, which disagreed with neighboring tiles' views of the same ray and produced constant seam lines independent of parent resolution.

The new approach samples the horizon ring instead, which provides a consistent view across tile boundaries. The ring is indexed using the same coordinate transformations (swap, flipX, flipY) and scaling as the main computation, ensuring coherent results.

The horizon sample returns null/zero when unavailable (no ring or out of bounds), falling back to the original clamping behavior for compatibility.

https://claude.ai/code/session_01BmUMWbDA7FrbvwVMDGUruv